### PR TITLE
FLOW-001: Define workflow definition schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ CI runs on pull requests and pushes to `main`, installing dependencies with
 
 This baseline is intentionally independent from Ensen-loop. Runtime workflow
 features and Ensen-loop integration points belong to later Phase 1 issues.
+
+## Workflow Definition Schema
+
+The initial standalone workflow definition schema is documented in
+`docs/workflow-definition.md`. It validates versioned workflow definitions,
+stable workflow and step IDs, trigger shape, dependencies, retry policy, neutral
+actions, and idempotency key semantics without contacting Ensen-loop or external
+executor connectors.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ A lightweight workflow orchestration engine.
 ## Development Baseline
 
 This repository is in the Phase 1 baseline stage. The current package exposes a
-minimal TypeScript scaffold for future workflow-core implementation work, but it
-does not implement workflow schema, state, runner, or audit behavior yet.
+minimal TypeScript scaffold plus the initial standalone workflow definition
+schema. It does not implement workflow state, runner, executor connector, or
+audit behavior yet.
 
 Use the same commands locally that CI runs:
 
@@ -27,7 +28,7 @@ features and Ensen-loop integration points belong to later Phase 1 issues.
 ## Workflow Definition Schema
 
 The initial standalone workflow definition schema is documented in
-`docs/workflow-definition.md`. It validates versioned workflow definitions,
-stable workflow and step IDs, trigger shape, dependencies, retry policy, neutral
-actions, and idempotency key semantics without contacting Ensen-loop or external
-executor connectors.
+`docs/workflow-definition.md` under the "Workflow Definition Schema" section.
+It validates versioned workflow definitions, stable workflow and step IDs,
+trigger shape, dependencies, retry policy, neutral actions, and idempotency key
+semantics without contacting Ensen-loop or external executor connectors.

--- a/docs/workflow-definition.md
+++ b/docs/workflow-definition.md
@@ -17,6 +17,10 @@ The schema includes:
 - idempotency key semantics for `input`, `workflow`, and `static` sources
 - free-form workflow and step metadata
 
+Schema-owned objects reject unknown fields so typos and connector-specific drift
+fail validation. Use `metadata` for workflow or step annotations and action
+`with` values for neutral action inputs; both remain free-form at this boundary.
+
 The schema does not include Ensen-loop-specific fields, run state transitions,
 persistence behavior, executor connector configuration, or real Slack, Teams,
 ERPNext, GitHub, or other connector behavior. Those concerns are deferred to

--- a/docs/workflow-definition.md
+++ b/docs/workflow-definition.md
@@ -1,0 +1,85 @@
+# Workflow Definition Schema
+
+Ensen-flow workflow definitions use the `flow.workflow.v1` schema version. The
+schema describes standalone workflow orchestration metadata that the local runner
+can validate without contacting Ensen-loop, executor connectors, or external
+services.
+
+## Boundary
+
+The schema includes:
+
+- stable workflow and step IDs using kebab-case identifiers
+- one trigger per workflow
+- ordered step definitions with explicit `dependsOn` dependencies
+- neutral action declarations for `local`, `approval`, and `notification`
+- retry policies with `none`, `fixed`, or `exponential` backoff
+- idempotency key semantics for `input`, `workflow`, and `static` sources
+- free-form workflow and step metadata
+
+The schema does not include Ensen-loop-specific fields, run state transitions,
+persistence behavior, executor connector configuration, or real Slack, Teams,
+ERPNext, GitHub, or other connector behavior. Those concerns are deferred to
+later Phase 1 issues.
+
+Approval and notification are represented only as neutral action concepts. A
+definition can name that a step requires an approval or notification action, but
+the schema does not bind that action to a provider, credential, channel, or
+runtime dispatch implementation.
+
+## Shape
+
+```json
+{
+  "schemaVersion": "flow.workflow.v1",
+  "id": "local-manual-demo",
+  "name": "Local manual demo",
+  "metadata": {
+    "owner": "workflow-core"
+  },
+  "trigger": {
+    "type": "manual",
+    "idempotencyKey": {
+      "source": "input",
+      "field": "requestId",
+      "required": true
+    }
+  },
+  "steps": [
+    {
+      "id": "collect-input",
+      "action": {
+        "type": "local",
+        "name": "collect_input",
+        "with": {
+          "mode": "dry-run"
+        }
+      },
+      "retry": {
+        "maxAttempts": 1,
+        "backoff": {
+          "strategy": "none"
+        }
+      }
+    }
+  ]
+}
+```
+
+The canonical fixture set lives in `fixtures/workflow-definitions/`. Tests load
+those fixtures and validate them through `validateWorkflowDefinition`.
+
+## Validation
+
+Use the normal repository checks:
+
+```sh
+npm run build
+npm test
+```
+
+For focused schema work, run:
+
+```sh
+npm run validate:workflow-fixtures
+```

--- a/fixtures/workflow-definitions/invalid-dependency.invalid.json
+++ b/fixtures/workflow-definitions/invalid-dependency.invalid.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": "flow.workflow.v1",
+  "id": "invalid-dependency-demo",
+  "trigger": {
+    "type": "manual"
+  },
+  "steps": [
+    {
+      "id": "first",
+      "action": {
+        "type": "local",
+        "name": "first"
+      }
+    },
+    {
+      "id": "second",
+      "dependsOn": ["missing-step"],
+      "action": {
+        "type": "local",
+        "name": "second"
+      }
+    }
+  ]
+}

--- a/fixtures/workflow-definitions/malformed-idempotency.invalid.json
+++ b/fixtures/workflow-definitions/malformed-idempotency.invalid.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "flow.workflow.v1",
+  "id": "bad-idempotency-demo",
+  "trigger": {
+    "type": "manual"
+  },
+  "steps": [
+    {
+      "id": "only-step",
+      "action": {
+        "type": "local",
+        "name": "noop"
+      },
+      "idempotencyKey": {
+        "source": "workflow"
+      }
+    }
+  ]
+}

--- a/fixtures/workflow-definitions/malformed-retry-policy.invalid.json
+++ b/fixtures/workflow-definitions/malformed-retry-policy.invalid.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "flow.workflow.v1",
+  "id": "bad-retry-demo",
+  "trigger": {
+    "type": "manual"
+  },
+  "steps": [
+    {
+      "id": "only-step",
+      "action": {
+        "type": "local",
+        "name": "noop"
+      },
+      "retry": {
+        "maxAttempts": 0,
+        "backoff": {
+          "strategy": "fixed",
+          "delayMs": 500
+        }
+      }
+    }
+  ]
+}

--- a/fixtures/workflow-definitions/missing-id.invalid.json
+++ b/fixtures/workflow-definitions/missing-id.invalid.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "flow.workflow.v1",
+  "trigger": {
+    "type": "manual"
+  },
+  "steps": [
+    {
+      "id": "only-step",
+      "action": {
+        "type": "local",
+        "name": "noop"
+      }
+    }
+  ]
+}

--- a/fixtures/workflow-definitions/simple-manual.valid.json
+++ b/fixtures/workflow-definitions/simple-manual.valid.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": "flow.workflow.v1",
+  "id": "local-manual-demo",
+  "name": "Local manual demo",
+  "description": "A simple local workflow that can be validated without external executors.",
+  "metadata": {
+    "owner": "workflow-core",
+    "phase": "phase-1"
+  },
+  "trigger": {
+    "type": "manual",
+    "idempotencyKey": {
+      "source": "input",
+      "field": "requestId",
+      "required": true
+    }
+  },
+  "steps": [
+    {
+      "id": "collect-input",
+      "name": "Collect input",
+      "action": {
+        "type": "local",
+        "name": "collect_input",
+        "with": {
+          "mode": "dry-run"
+        }
+      },
+      "retry": {
+        "maxAttempts": 1,
+        "backoff": {
+          "strategy": "none"
+        }
+      },
+      "idempotencyKey": {
+        "source": "workflow",
+        "template": "{workflow.id}:{step.id}:{trigger.idempotencyKey}"
+      }
+    },
+    {
+      "id": "notify-operator",
+      "name": "Notify operator",
+      "dependsOn": ["collect-input"],
+      "action": {
+        "type": "notification",
+        "name": "operator_notice",
+        "with": {
+          "channel": "operator"
+        }
+      },
+      "retry": {
+        "maxAttempts": 2,
+        "backoff": {
+          "strategy": "fixed",
+          "delayMs": 1000
+        }
+      }
+    }
+  ]
+}

--- a/fixtures/workflow-definitions/unsupported-trigger.invalid.json
+++ b/fixtures/workflow-definitions/unsupported-trigger.invalid.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "flow.workflow.v1",
+  "id": "unsupported-trigger-demo",
+  "trigger": {
+    "type": "ensen-loop",
+    "queue": "loop-specific"
+  },
+  "steps": [
+    {
+      "id": "only-step",
+      "action": {
+        "type": "local",
+        "name": "noop"
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "vitest run"
+    "test": "vitest run",
+    "validate:workflow-fixtures": "vitest run test/workflow-definition.test.ts"
   },
   "files": [
     "dist"

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,21 @@ export const baselineInfo: BaselineInfo = {
   phase: "phase-1-baseline",
   runtimeFeaturesEnabled: false
 };
+
+export {
+  validateWorkflowDefinition,
+  workflowDefinitionSchemaVersion
+} from "./workflow-definition.js";
+
+export type {
+  IdempotencyKeyDefinition,
+  RetryBackoffPolicy,
+  RetryPolicy,
+  WorkflowAction,
+  WorkflowDefinition,
+  WorkflowDefinitionValidationError,
+  WorkflowDefinitionValidationResult,
+  WorkflowSchemaVersion,
+  WorkflowStep,
+  WorkflowTrigger
+} from "./workflow-definition.js";

--- a/src/workflow-definition.ts
+++ b/src/workflow-definition.ts
@@ -353,7 +353,7 @@ const validateIdempotencyKey = (
   }
 
   if (value.source === "workflow") {
-    requireNonEmptyString(value, "template", path, errors);
+    requireNonEmptyString(value, "template", `${path}.template`, errors);
   }
 
   if (value.source === "static") {

--- a/src/workflow-definition.ts
+++ b/src/workflow-definition.ts
@@ -5,6 +5,35 @@ const ACTION_TYPES = new Set(["local", "approval", "notification"]);
 const IDEMPOTENCY_KEY_SOURCES = new Set(["input", "workflow", "static"]);
 const BACKOFF_STRATEGIES = new Set(["none", "fixed", "exponential"]);
 const STABLE_ID_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+const TRIGGER_ALLOWED_KEYS = new Set(["type", "cron", "path", "idempotencyKey"]);
+const MANUAL_TRIGGER_ALLOWED_KEYS = new Set(["type", "idempotencyKey"]);
+const SCHEDULE_TRIGGER_ALLOWED_KEYS = new Set(["type", "cron", "idempotencyKey"]);
+const WEBHOOK_TRIGGER_ALLOWED_KEYS = new Set(["type", "path", "idempotencyKey"]);
+const ACTION_ALLOWED_KEYS = new Set(["type", "name", "with"]);
+const RETRY_POLICY_ALLOWED_KEYS = new Set(["maxAttempts", "backoff"]);
+const RETRY_BACKOFF_ALLOWED_KEYS = new Set([
+  "strategy",
+  "delayMs",
+  "initialDelayMs",
+  "maxDelayMs"
+]);
+const RETRY_BACKOFF_NONE_ALLOWED_KEYS = new Set(["strategy"]);
+const RETRY_BACKOFF_FIXED_ALLOWED_KEYS = new Set(["strategy", "delayMs"]);
+const RETRY_BACKOFF_EXPONENTIAL_ALLOWED_KEYS = new Set([
+  "strategy",
+  "initialDelayMs",
+  "maxDelayMs"
+]);
+const IDEMPOTENCY_KEY_ALLOWED_KEYS = new Set([
+  "source",
+  "field",
+  "required",
+  "template",
+  "value"
+]);
+const INPUT_IDEMPOTENCY_KEY_ALLOWED_KEYS = new Set(["source", "field", "required"]);
+const WORKFLOW_IDEMPOTENCY_KEY_ALLOWED_KEYS = new Set(["source", "template"]);
+const STATIC_IDEMPOTENCY_KEY_ALLOWED_KEYS = new Set(["source", "value"]);
 
 export type WorkflowSchemaVersion = typeof WORKFLOW_SCHEMA_VERSION;
 
@@ -132,8 +161,18 @@ const validateTrigger = (
   }
 
   rejectEnsenLoopSpecificFields(value, "trigger", errors);
+  const triggerType = value.type;
+  if (triggerType === "manual") {
+    rejectUnknownKeys(value, MANUAL_TRIGGER_ALLOWED_KEYS, "trigger", errors);
+  } else if (triggerType === "schedule") {
+    rejectUnknownKeys(value, SCHEDULE_TRIGGER_ALLOWED_KEYS, "trigger", errors);
+  } else if (triggerType === "webhook") {
+    rejectUnknownKeys(value, WEBHOOK_TRIGGER_ALLOWED_KEYS, "trigger", errors);
+  } else {
+    rejectUnknownKeys(value, TRIGGER_ALLOWED_KEYS, "trigger", errors);
+  }
 
-  if (typeof value.type !== "string" || !TRIGGER_TYPES.has(value.type)) {
+  if (typeof triggerType !== "string" || !TRIGGER_TYPES.has(triggerType)) {
     errors.push({
       path: "trigger.type",
       message: "trigger.type must be manual, schedule, or webhook"
@@ -141,11 +180,11 @@ const validateTrigger = (
     return;
   }
 
-  if (value.type === "schedule") {
+  if (triggerType === "schedule") {
     requireNonEmptyString(value, "cron", "trigger.cron", errors);
   }
 
-  if (value.type === "webhook") {
+  if (triggerType === "webhook") {
     requireNonEmptyString(value, "path", "trigger.path", errors);
   }
 
@@ -252,6 +291,8 @@ const validateAction = (
     return;
   }
 
+  rejectUnknownKeys(value, ACTION_ALLOWED_KEYS, path, errors);
+
   if (typeof value.type !== "string" || !ACTION_TYPES.has(value.type)) {
     errors.push({
       path: `${path}.type`,
@@ -276,6 +317,8 @@ const validateRetryPolicy = (
     return;
   }
 
+  rejectUnknownKeys(value, RETRY_POLICY_ALLOWED_KEYS, path, errors);
+
   if (!isPositiveInteger(value.maxAttempts)) {
     errors.push({
       path: `${path}.maxAttempts`,
@@ -289,6 +332,21 @@ const validateRetryPolicy = (
   }
 
   const { strategy } = value.backoff;
+  if (strategy === "none") {
+    rejectUnknownKeys(value.backoff, RETRY_BACKOFF_NONE_ALLOWED_KEYS, `${path}.backoff`, errors);
+  } else if (strategy === "fixed") {
+    rejectUnknownKeys(value.backoff, RETRY_BACKOFF_FIXED_ALLOWED_KEYS, `${path}.backoff`, errors);
+  } else if (strategy === "exponential") {
+    rejectUnknownKeys(
+      value.backoff,
+      RETRY_BACKOFF_EXPONENTIAL_ALLOWED_KEYS,
+      `${path}.backoff`,
+      errors
+    );
+  } else {
+    rejectUnknownKeys(value.backoff, RETRY_BACKOFF_ALLOWED_KEYS, `${path}.backoff`, errors);
+  }
+
   if (typeof strategy !== "string" || !BACKOFF_STRATEGIES.has(strategy)) {
     errors.push({
       path: `${path}.backoff.strategy`,
@@ -331,9 +389,20 @@ const validateIdempotencyKey = (
     return;
   }
 
+  const idempotencyKeySource = value.source;
+  if (idempotencyKeySource === "input") {
+    rejectUnknownKeys(value, INPUT_IDEMPOTENCY_KEY_ALLOWED_KEYS, path, errors);
+  } else if (idempotencyKeySource === "workflow") {
+    rejectUnknownKeys(value, WORKFLOW_IDEMPOTENCY_KEY_ALLOWED_KEYS, path, errors);
+  } else if (idempotencyKeySource === "static") {
+    rejectUnknownKeys(value, STATIC_IDEMPOTENCY_KEY_ALLOWED_KEYS, path, errors);
+  } else {
+    rejectUnknownKeys(value, IDEMPOTENCY_KEY_ALLOWED_KEYS, path, errors);
+  }
+
   if (
-    typeof value.source !== "string" ||
-    !IDEMPOTENCY_KEY_SOURCES.has(value.source)
+    typeof idempotencyKeySource !== "string" ||
+    !IDEMPOTENCY_KEY_SOURCES.has(idempotencyKeySource)
   ) {
     errors.push({
       path: `${path}.source`,
@@ -342,7 +411,7 @@ const validateIdempotencyKey = (
     return;
   }
 
-  if (value.source === "input") {
+  if (idempotencyKeySource === "input") {
     requireNonEmptyString(value, "field", `${path}.field`, errors);
     if ("required" in value && typeof value.required !== "boolean") {
       errors.push({
@@ -352,11 +421,11 @@ const validateIdempotencyKey = (
     }
   }
 
-  if (value.source === "workflow") {
+  if (idempotencyKeySource === "workflow") {
     requireNonEmptyString(value, "template", `${path}.template`, errors);
   }
 
-  if (value.source === "static") {
+  if (idempotencyKeySource === "static") {
     requireNonEmptyString(value, "value", `${path}.value`, errors);
   }
 };
@@ -429,6 +498,22 @@ const rejectEnsenLoopSpecificFields = (
 ): void => {
   for (const key of ["ensenLoop", "ensenLoopField", "loopQueue", "executorConnector"]) {
     if (key in value) {
+      errors.push({
+        path: path ? `${path}.${key}` : `workflow.${key}`,
+        message: `${key} is outside the workflow definition schema boundary`
+      });
+    }
+  }
+};
+
+const rejectUnknownKeys = (
+  value: Record<string, unknown>,
+  allowedKeys: Set<string>,
+  path: string,
+  errors: WorkflowDefinitionValidationError[]
+): void => {
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
       errors.push({
         path: path ? `${path}.${key}` : `workflow.${key}`,
         message: `${key} is outside the workflow definition schema boundary`

--- a/src/workflow-definition.ts
+++ b/src/workflow-definition.ts
@@ -34,6 +34,24 @@ const IDEMPOTENCY_KEY_ALLOWED_KEYS = new Set([
 const INPUT_IDEMPOTENCY_KEY_ALLOWED_KEYS = new Set(["source", "field", "required"]);
 const WORKFLOW_IDEMPOTENCY_KEY_ALLOWED_KEYS = new Set(["source", "template"]);
 const STATIC_IDEMPOTENCY_KEY_ALLOWED_KEYS = new Set(["source", "value"]);
+const WORKFLOW_ALLOWED_KEYS = new Set([
+  "schemaVersion",
+  "id",
+  "name",
+  "description",
+  "metadata",
+  "trigger",
+  "steps"
+]);
+const STEP_ALLOWED_KEYS = new Set([
+  "id",
+  "name",
+  "dependsOn",
+  "action",
+  "retry",
+  "idempotencyKey",
+  "metadata"
+]);
 
 export type WorkflowSchemaVersion = typeof WORKFLOW_SCHEMA_VERSION;
 
@@ -135,6 +153,7 @@ export const validateWorkflowDefinition = (
   }
 
   rejectEnsenLoopSpecificFields(value, "", errors);
+  rejectUnknownKeys(value, WORKFLOW_ALLOWED_KEYS, "", errors);
   requireLiteral(value, "schemaVersion", WORKFLOW_SCHEMA_VERSION, errors);
   requireStableId(value, "id", "workflow.id", errors);
   optionalString(value, "name", "workflow.name", errors);
@@ -216,6 +235,7 @@ const validateSteps = (
     }
 
     rejectEnsenLoopSpecificFields(step, path, errors);
+    rejectUnknownKeys(step, STEP_ALLOWED_KEYS, path, errors);
     requireStableId(step, "id", `${path}.id`, errors);
 
     if (typeof step.id === "string" && STABLE_ID_PATTERN.test(step.id)) {
@@ -234,7 +254,7 @@ const validateSteps = (
     const path = `steps[${index}]`;
     optionalString(step, "name", `${path}.name`, errors);
     optionalRecord(step, "metadata", `${path}.metadata`, errors);
-    validateDependencies(step.dependsOn, stepIds, `${path}.dependsOn`, errors);
+    validateDependencies(step.dependsOn, stepIds, step.id, `${path}.dependsOn`, errors);
     validateAction(step.action, `${path}.action`, errors);
 
     if ("retry" in step) {
@@ -250,6 +270,7 @@ const validateSteps = (
 const validateDependencies = (
   value: unknown,
   stepIds: Set<string>,
+  currentStepId: unknown,
   path: string,
   errors: WorkflowDefinitionValidationError[]
 ): void => {
@@ -268,6 +289,14 @@ const validateDependencies = (
       errors.push({
         path: dependencyPath,
         message: "dependsOn entries must be stable step IDs"
+      });
+      return;
+    }
+
+    if (typeof currentStepId === "string" && dependency === currentStepId) {
+      errors.push({
+        path: dependencyPath,
+        message: "dependsOn entries cannot reference the current step"
       });
       return;
     }

--- a/src/workflow-definition.ts
+++ b/src/workflow-definition.ts
@@ -1,0 +1,447 @@
+const WORKFLOW_SCHEMA_VERSION = "flow.workflow.v1";
+
+const TRIGGER_TYPES = new Set(["manual", "schedule", "webhook"]);
+const ACTION_TYPES = new Set(["local", "approval", "notification"]);
+const IDEMPOTENCY_KEY_SOURCES = new Set(["input", "workflow", "static"]);
+const BACKOFF_STRATEGIES = new Set(["none", "fixed", "exponential"]);
+const STABLE_ID_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+
+export type WorkflowSchemaVersion = typeof WORKFLOW_SCHEMA_VERSION;
+
+export interface WorkflowDefinition {
+  schemaVersion: WorkflowSchemaVersion;
+  id: string;
+  name?: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+  trigger: WorkflowTrigger;
+  steps: WorkflowStep[];
+}
+
+export type WorkflowTrigger =
+  | ManualWorkflowTrigger
+  | ScheduleWorkflowTrigger
+  | WebhookWorkflowTrigger;
+
+interface WorkflowTriggerBase {
+  type: string;
+  idempotencyKey?: IdempotencyKeyDefinition;
+}
+
+export interface ManualWorkflowTrigger extends WorkflowTriggerBase {
+  type: "manual";
+}
+
+export interface ScheduleWorkflowTrigger extends WorkflowTriggerBase {
+  type: "schedule";
+  cron: string;
+}
+
+export interface WebhookWorkflowTrigger extends WorkflowTriggerBase {
+  type: "webhook";
+  path: string;
+}
+
+export interface WorkflowStep {
+  id: string;
+  name?: string;
+  dependsOn?: string[];
+  action: WorkflowAction;
+  retry?: RetryPolicy;
+  idempotencyKey?: IdempotencyKeyDefinition;
+  metadata?: Record<string, unknown>;
+}
+
+export interface WorkflowAction {
+  type: "local" | "approval" | "notification";
+  name: string;
+  with?: Record<string, unknown>;
+}
+
+export interface RetryPolicy {
+  maxAttempts: number;
+  backoff: RetryBackoffPolicy;
+}
+
+export type RetryBackoffPolicy =
+  | { strategy: "none" }
+  | { strategy: "fixed"; delayMs: number }
+  | { strategy: "exponential"; initialDelayMs: number; maxDelayMs: number };
+
+export type IdempotencyKeyDefinition =
+  | {
+      source: "input";
+      field: string;
+      required?: boolean;
+    }
+  | {
+      source: "workflow";
+      template: string;
+    }
+  | {
+      source: "static";
+      value: string;
+    };
+
+export interface WorkflowDefinitionValidationError {
+  path: string;
+  message: string;
+}
+
+export interface WorkflowDefinitionValidationResult {
+  valid: boolean;
+  errors: WorkflowDefinitionValidationError[];
+}
+
+export const workflowDefinitionSchemaVersion: WorkflowSchemaVersion =
+  WORKFLOW_SCHEMA_VERSION;
+
+export const validateWorkflowDefinition = (
+  value: unknown
+): WorkflowDefinitionValidationResult => {
+  const errors: WorkflowDefinitionValidationError[] = [];
+
+  if (!isRecord(value)) {
+    return invalid("workflow definition must be an object");
+  }
+
+  rejectEnsenLoopSpecificFields(value, "", errors);
+  requireLiteral(value, "schemaVersion", WORKFLOW_SCHEMA_VERSION, errors);
+  requireStableId(value, "id", "workflow.id", errors);
+  optionalString(value, "name", "workflow.name", errors);
+  optionalString(value, "description", "workflow.description", errors);
+  optionalRecord(value, "metadata", "workflow.metadata", errors);
+  validateTrigger(value.trigger, errors);
+  validateSteps(value.steps, errors);
+
+  return { valid: errors.length === 0, errors };
+};
+
+const invalid = (message: string): WorkflowDefinitionValidationResult => ({
+  valid: false,
+  errors: [{ path: "workflow", message }]
+});
+
+const validateTrigger = (
+  value: unknown,
+  errors: WorkflowDefinitionValidationError[]
+): void => {
+  if (!isRecord(value)) {
+    errors.push({ path: "trigger", message: "trigger must be an object" });
+    return;
+  }
+
+  rejectEnsenLoopSpecificFields(value, "trigger", errors);
+
+  if (typeof value.type !== "string" || !TRIGGER_TYPES.has(value.type)) {
+    errors.push({
+      path: "trigger.type",
+      message: "trigger.type must be manual, schedule, or webhook"
+    });
+    return;
+  }
+
+  if (value.type === "schedule") {
+    requireNonEmptyString(value, "cron", "trigger.cron", errors);
+  }
+
+  if (value.type === "webhook") {
+    requireNonEmptyString(value, "path", "trigger.path", errors);
+  }
+
+  if ("idempotencyKey" in value) {
+    validateIdempotencyKey(value.idempotencyKey, "trigger.idempotencyKey", errors);
+  }
+};
+
+const validateSteps = (
+  value: unknown,
+  errors: WorkflowDefinitionValidationError[]
+): void => {
+  if (!Array.isArray(value) || value.length === 0) {
+    errors.push({
+      path: "steps",
+      message: "steps must contain at least one workflow step"
+    });
+    return;
+  }
+
+  const stepIds = new Set<string>();
+
+  value.forEach((step, index) => {
+    const path = `steps[${index}]`;
+
+    if (!isRecord(step)) {
+      errors.push({ path, message: "step must be an object" });
+      return;
+    }
+
+    rejectEnsenLoopSpecificFields(step, path, errors);
+    requireStableId(step, "id", `${path}.id`, errors);
+
+    if (typeof step.id === "string" && STABLE_ID_PATTERN.test(step.id)) {
+      if (stepIds.has(step.id)) {
+        errors.push({ path: `${path}.id`, message: "step.id must be unique" });
+      }
+      stepIds.add(step.id);
+    }
+  });
+
+  value.forEach((step, index) => {
+    if (!isRecord(step)) {
+      return;
+    }
+
+    const path = `steps[${index}]`;
+    optionalString(step, "name", `${path}.name`, errors);
+    optionalRecord(step, "metadata", `${path}.metadata`, errors);
+    validateDependencies(step.dependsOn, stepIds, `${path}.dependsOn`, errors);
+    validateAction(step.action, `${path}.action`, errors);
+
+    if ("retry" in step) {
+      validateRetryPolicy(step.retry, `${path}.retry`, errors);
+    }
+
+    if ("idempotencyKey" in step) {
+      validateIdempotencyKey(step.idempotencyKey, `${path}.idempotencyKey`, errors);
+    }
+  });
+};
+
+const validateDependencies = (
+  value: unknown,
+  stepIds: Set<string>,
+  path: string,
+  errors: WorkflowDefinitionValidationError[]
+): void => {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!Array.isArray(value)) {
+    errors.push({ path, message: "dependsOn must be an array of step IDs" });
+    return;
+  }
+
+  value.forEach((dependency, index) => {
+    const dependencyPath = `${path}[${index}]`;
+    if (typeof dependency !== "string" || !STABLE_ID_PATTERN.test(dependency)) {
+      errors.push({
+        path: dependencyPath,
+        message: "dependsOn entries must be stable step IDs"
+      });
+      return;
+    }
+
+    if (!stepIds.has(dependency)) {
+      errors.push({
+        path: dependencyPath,
+        message: "dependsOn entries must reference an existing step"
+      });
+    }
+  });
+};
+
+const validateAction = (
+  value: unknown,
+  path: string,
+  errors: WorkflowDefinitionValidationError[]
+): void => {
+  if (!isRecord(value)) {
+    errors.push({ path, message: "action must be an object" });
+    return;
+  }
+
+  if (typeof value.type !== "string" || !ACTION_TYPES.has(value.type)) {
+    errors.push({
+      path: `${path}.type`,
+      message: "action.type must be local, approval, or notification"
+    });
+  }
+
+  requireNonEmptyString(value, "name", `${path}.name`, errors);
+
+  if ("with" in value && !isRecord(value.with)) {
+    errors.push({ path: `${path}.with`, message: "action.with must be an object" });
+  }
+};
+
+const validateRetryPolicy = (
+  value: unknown,
+  path: string,
+  errors: WorkflowDefinitionValidationError[]
+): void => {
+  if (!isRecord(value)) {
+    errors.push({ path, message: "retry must be an object" });
+    return;
+  }
+
+  if (!isPositiveInteger(value.maxAttempts)) {
+    errors.push({
+      path: `${path}.maxAttempts`,
+      message: "retry.maxAttempts must be a positive integer"
+    });
+  }
+
+  if (!isRecord(value.backoff)) {
+    errors.push({ path: `${path}.backoff`, message: "retry.backoff must be an object" });
+    return;
+  }
+
+  const { strategy } = value.backoff;
+  if (typeof strategy !== "string" || !BACKOFF_STRATEGIES.has(strategy)) {
+    errors.push({
+      path: `${path}.backoff.strategy`,
+      message: "retry.backoff.strategy must be none, fixed, or exponential"
+    });
+    return;
+  }
+
+  if (strategy === "fixed" && !isNonNegativeInteger(value.backoff.delayMs)) {
+    errors.push({
+      path: `${path}.backoff.delayMs`,
+      message: "fixed retry backoff requires a non-negative delayMs"
+    });
+  }
+
+  if (strategy === "exponential") {
+    if (!isNonNegativeInteger(value.backoff.initialDelayMs)) {
+      errors.push({
+        path: `${path}.backoff.initialDelayMs`,
+        message: "exponential retry backoff requires a non-negative initialDelayMs"
+      });
+    }
+
+    if (!isNonNegativeInteger(value.backoff.maxDelayMs)) {
+      errors.push({
+        path: `${path}.backoff.maxDelayMs`,
+        message: "exponential retry backoff requires a non-negative maxDelayMs"
+      });
+    }
+  }
+};
+
+const validateIdempotencyKey = (
+  value: unknown,
+  path: string,
+  errors: WorkflowDefinitionValidationError[]
+): void => {
+  if (!isRecord(value)) {
+    errors.push({ path, message: "idempotencyKey must be an object" });
+    return;
+  }
+
+  if (
+    typeof value.source !== "string" ||
+    !IDEMPOTENCY_KEY_SOURCES.has(value.source)
+  ) {
+    errors.push({
+      path: `${path}.source`,
+      message: "idempotencyKey.source must be input, workflow, or static"
+    });
+    return;
+  }
+
+  if (value.source === "input") {
+    requireNonEmptyString(value, "field", `${path}.field`, errors);
+    if ("required" in value && typeof value.required !== "boolean") {
+      errors.push({
+        path: `${path}.required`,
+        message: "input idempotency required flag must be boolean"
+      });
+    }
+  }
+
+  if (value.source === "workflow") {
+    requireNonEmptyString(value, "template", path, errors);
+  }
+
+  if (value.source === "static") {
+    requireNonEmptyString(value, "value", `${path}.value`, errors);
+  }
+};
+
+const requireLiteral = (
+  value: Record<string, unknown>,
+  key: string,
+  expected: string,
+  errors: WorkflowDefinitionValidationError[]
+): void => {
+  if (value[key] !== expected) {
+    errors.push({
+      path: `workflow.${key}`,
+      message: `${key} must be ${expected}`
+    });
+  }
+};
+
+const requireStableId = (
+  value: Record<string, unknown>,
+  key: string,
+  path: string,
+  errors: WorkflowDefinitionValidationError[]
+): void => {
+  if (typeof value[key] !== "string" || !STABLE_ID_PATTERN.test(value[key])) {
+    errors.push({
+      path,
+      message: `${key} must be a stable kebab-case identifier`
+    });
+  }
+};
+
+const requireNonEmptyString = (
+  value: Record<string, unknown>,
+  key: string,
+  path: string,
+  errors: WorkflowDefinitionValidationError[]
+): void => {
+  if (typeof value[key] !== "string" || value[key].trim() === "") {
+    errors.push({ path, message: `${key} must be a non-empty string` });
+  }
+};
+
+const optionalString = (
+  value: Record<string, unknown>,
+  key: string,
+  path: string,
+  errors: WorkflowDefinitionValidationError[]
+): void => {
+  if (key in value && typeof value[key] !== "string") {
+    errors.push({ path, message: `${key} must be a string when provided` });
+  }
+};
+
+const optionalRecord = (
+  value: Record<string, unknown>,
+  key: string,
+  path: string,
+  errors: WorkflowDefinitionValidationError[]
+): void => {
+  if (key in value && !isRecord(value[key])) {
+    errors.push({ path, message: `${key} must be an object when provided` });
+  }
+};
+
+const rejectEnsenLoopSpecificFields = (
+  value: Record<string, unknown>,
+  path: string,
+  errors: WorkflowDefinitionValidationError[]
+): void => {
+  for (const key of ["ensenLoop", "ensenLoopField", "loopQueue", "executorConnector"]) {
+    if (key in value) {
+      errors.push({
+        path: path ? `${path}.${key}` : `workflow.${key}`,
+        message: `${key} is outside the workflow definition schema boundary`
+      });
+    }
+  }
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isPositiveInteger = (value: unknown): value is number =>
+  typeof value === "number" && Number.isInteger(value) && value > 0;
+
+const isNonNegativeInteger = (value: unknown): value is number =>
+  typeof value === "number" && Number.isInteger(value) && value >= 0;

--- a/test/workflow-definition.test.ts
+++ b/test/workflow-definition.test.ts
@@ -27,7 +27,7 @@ describe("workflow definition schema", () => {
     [
       "malformed idempotency semantics",
       "malformed-idempotency.invalid.json",
-      "steps[0].idempotencyKey"
+      "steps[0].idempotencyKey.template"
     ]
   ])("rejects %s", (_name, fixture, path) => {
     const result = validateWorkflowDefinition(readFixture(fixture));

--- a/test/workflow-definition.test.ts
+++ b/test/workflow-definition.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { validateWorkflowDefinition } from "../src/index.js";
+
+const fixturePath = (...parts: string[]) =>
+  join(process.cwd(), "fixtures", "workflow-definitions", ...parts);
+
+const readFixture = (name: string): unknown =>
+  JSON.parse(readFileSync(fixturePath(name), "utf8")) as unknown;
+
+describe("workflow definition schema", () => {
+  it("accepts a simple local manual workflow fixture", () => {
+    const result = validateWorkflowDefinition(readFixture("simple-manual.valid.json"));
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it.each([
+    ["missing workflow id", "missing-id.invalid.json", "workflow.id"],
+    ["invalid dependency", "invalid-dependency.invalid.json", "steps[1].dependsOn[0]"],
+    ["unsupported trigger shape", "unsupported-trigger.invalid.json", "trigger.type"],
+    ["malformed retry policy", "malformed-retry-policy.invalid.json", "steps[0].retry.maxAttempts"],
+    [
+      "malformed idempotency semantics",
+      "malformed-idempotency.invalid.json",
+      "steps[0].idempotencyKey"
+    ]
+  ])("rejects %s", (_name, fixture, path) => {
+    const result = validateWorkflowDefinition(readFixture(fixture));
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([expect.objectContaining({ path })])
+    );
+  });
+});

--- a/test/workflow-definition.test.ts
+++ b/test/workflow-definition.test.ts
@@ -14,12 +14,13 @@ const readFixture = (name: string): unknown =>
 
 type MutableWorkflowFixture = {
   trigger: Record<string, unknown>;
-  steps: Array<{
+  steps: Array<Record<string, unknown> & {
     action: Record<string, unknown>;
+    dependsOn?: string[];
     retry?: Record<string, unknown> & { backoff?: Record<string, unknown> };
     idempotencyKey?: Record<string, unknown>;
   }>;
-};
+} & Record<string, unknown>;
 
 const readMutableWorkflowFixture = (): MutableWorkflowFixture =>
   readFixture("simple-manual.valid.json") as MutableWorkflowFixture;
@@ -99,6 +100,20 @@ describe("workflow definition schema", () => {
 
   it.each([
     [
+      "workflow",
+      "workflow.extra",
+      (workflow: MutableWorkflowFixture) => {
+        workflow.extra = true;
+      }
+    ],
+    [
+      "step",
+      "steps[0].extra",
+      (workflow: MutableWorkflowFixture) => {
+        workflow.steps[0].extra = true;
+      }
+    ],
+    [
       "trigger",
       "trigger.extra",
       (workflow: MutableWorkflowFixture) => {
@@ -146,6 +161,39 @@ describe("workflow definition schema", () => {
         {
           path,
           message: "extra is outside the workflow definition schema boundary"
+        }
+      ]);
+    }
+  );
+
+  it.each([
+    [
+      "single self-reference",
+      (workflow: MutableWorkflowFixture) => {
+        workflow.steps[0].dependsOn = ["collect-input"];
+      },
+      "steps[0].dependsOn[0]"
+    ],
+    [
+      "list containing the current step",
+      (workflow: MutableWorkflowFixture) => {
+        workflow.steps[1].dependsOn = ["collect-input", "notify-operator"];
+      },
+      "steps[1].dependsOn[1]"
+    ]
+  ] satisfies Array<[string, (workflow: MutableWorkflowFixture) => void, string]>)(
+    "rejects dependsOn %s",
+    (_name, mutate, path) => {
+      const workflow = readMutableWorkflowFixture();
+      mutate(workflow);
+
+      const result = validateWorkflowDefinition(workflow);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toEqual([
+        {
+          path,
+          message: "dependsOn entries cannot reference the current step"
         }
       ]);
     }

--- a/test/workflow-definition.test.ts
+++ b/test/workflow-definition.test.ts
@@ -4,12 +4,25 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { validateWorkflowDefinition } from "../src/index.js";
+import type { WorkflowDefinitionValidationError } from "../src/index.js";
 
 const fixturePath = (...parts: string[]) =>
   join(process.cwd(), "fixtures", "workflow-definitions", ...parts);
 
 const readFixture = (name: string): unknown =>
   JSON.parse(readFileSync(fixturePath(name), "utf8")) as unknown;
+
+type MutableWorkflowFixture = {
+  trigger: Record<string, unknown>;
+  steps: Array<{
+    action: Record<string, unknown>;
+    retry?: Record<string, unknown> & { backoff?: Record<string, unknown> };
+    idempotencyKey?: Record<string, unknown>;
+  }>;
+};
+
+const readMutableWorkflowFixture = (): MutableWorkflowFixture =>
+  readFixture("simple-manual.valid.json") as MutableWorkflowFixture;
 
 describe("workflow definition schema", () => {
   it("accepts a simple local manual workflow fixture", () => {
@@ -20,21 +33,136 @@ describe("workflow definition schema", () => {
   });
 
   it.each([
-    ["missing workflow id", "missing-id.invalid.json", "workflow.id"],
-    ["invalid dependency", "invalid-dependency.invalid.json", "steps[1].dependsOn[0]"],
-    ["unsupported trigger shape", "unsupported-trigger.invalid.json", "trigger.type"],
-    ["malformed retry policy", "malformed-retry-policy.invalid.json", "steps[0].retry.maxAttempts"],
+    [
+      "missing workflow id",
+      "missing-id.invalid.json",
+      [
+        {
+          path: "workflow.id",
+          message: "id must be a stable kebab-case identifier"
+        }
+      ]
+    ],
+    [
+      "invalid dependency",
+      "invalid-dependency.invalid.json",
+      [
+        {
+          path: "steps[1].dependsOn[0]",
+          message: "dependsOn entries must reference an existing step"
+        }
+      ]
+    ],
+    [
+      "unsupported trigger shape",
+      "unsupported-trigger.invalid.json",
+      [
+        {
+          path: "trigger.queue",
+          message: "queue is outside the workflow definition schema boundary"
+        },
+        {
+          path: "trigger.type",
+          message: "trigger.type must be manual, schedule, or webhook"
+        }
+      ]
+    ],
+    [
+      "malformed retry policy",
+      "malformed-retry-policy.invalid.json",
+      [
+        {
+          path: "steps[0].retry.maxAttempts",
+          message: "retry.maxAttempts must be a positive integer"
+        }
+      ]
+    ],
     [
       "malformed idempotency semantics",
       "malformed-idempotency.invalid.json",
-      "steps[0].idempotencyKey.template"
+      [
+        {
+          path: "steps[0].idempotencyKey.template",
+          message: "template must be a non-empty string"
+        }
+      ]
     ]
-  ])("rejects %s", (_name, fixture, path) => {
-    const result = validateWorkflowDefinition(readFixture(fixture));
+  ] satisfies Array<[string, string, WorkflowDefinitionValidationError[]]>)(
+    "rejects %s",
+    (_name, fixture, expectedErrors) => {
+      const result = validateWorkflowDefinition(readFixture(fixture));
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toEqual(expectedErrors);
+    }
+  );
+
+  it.each([
+    [
+      "trigger",
+      "trigger.extra",
+      (workflow: MutableWorkflowFixture) => {
+        workflow.trigger.extra = true;
+      }
+    ],
+    [
+      "action",
+      "steps[0].action.extra",
+      (workflow: MutableWorkflowFixture) => {
+        workflow.steps[0].action.extra = true;
+      }
+    ],
+    [
+      "retry policy",
+      "steps[0].retry.extra",
+      (workflow: MutableWorkflowFixture) => {
+        workflow.steps[0].retry!.extra = true;
+      }
+    ],
+    [
+      "retry backoff",
+      "steps[0].retry.backoff.extra",
+      (workflow: MutableWorkflowFixture) => {
+        workflow.steps[0].retry!.backoff!.extra = true;
+      }
+    ],
+    [
+      "idempotency key",
+      "steps[0].idempotencyKey.extra",
+      (workflow: MutableWorkflowFixture) => {
+        workflow.steps[0].idempotencyKey!.extra = true;
+      }
+    ]
+  ] satisfies Array<[string, string, (workflow: MutableWorkflowFixture) => void]>)(
+    "rejects unknown %s fields",
+    (_name, path, mutate) => {
+      const workflow = readMutableWorkflowFixture();
+      mutate(workflow);
+
+      const result = validateWorkflowDefinition(workflow);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors).toEqual([
+        {
+          path,
+          message: "extra is outside the workflow definition schema boundary"
+        }
+      ]);
+    }
+  );
+
+  it("rejects fields from the wrong trigger variant", () => {
+    const workflow = readMutableWorkflowFixture();
+    workflow.trigger.path = "/manual-should-not-have-path";
+
+    const result = validateWorkflowDefinition(workflow);
 
     expect(result.valid).toBe(false);
-    expect(result.errors).toEqual(
-      expect.arrayContaining([expect.objectContaining({ path })])
-    );
+    expect(result.errors).toEqual([
+      {
+        path: "trigger.path",
+        message: "path is outside the workflow definition schema boundary"
+      }
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- add the versioned flow.workflow.v1 workflow definition validator and exported TypeScript schema types
- add valid and invalid workflow definition fixtures plus focused validation tests
- document the standalone schema boundary and deferred connector/execution behavior

## Verification
- npm run build
- npm test
- npm run validate:workflow-fixtures

Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded README and added dedicated workflow-definition docs with schema rules, canonical example, exclusions, and validation guidance.

* **New Features**
  * Public workflow-definition validation API that returns structured validation results and error locations.

* **Tests**
  * Added fixture-driven validation tests and multiple invalid/mutation scenarios with new workflow fixtures.

* **Chores**
  * Added a focused npm script to run the workflow-definition validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->