### PR TITLE
FLOW-002 add JSONL workflow run state

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A lightweight workflow orchestration engine.
 
 This repository is in the Phase 1 baseline stage. The current package exposes a
 minimal TypeScript scaffold plus the initial standalone workflow definition
-schema. It does not implement workflow state, runner, executor connector, or
-audit behavior yet.
+schema and append-only JSONL workflow run state helpers. It does not implement a
+runner, executor connector, or audit behavior yet.
 
 Use the same commands locally that CI runs:
 
@@ -32,3 +32,11 @@ The initial standalone workflow definition schema is documented in
 It validates versioned workflow definitions, stable workflow and step IDs,
 trigger shape, dependencies, retry policy, neutral actions, and idempotency key
 semantics without contacting Ensen-loop or external executor connectors.
+
+## Workflow Run JSONL State
+
+Workflow run state can be persisted locally with append-only JSONL records via
+`createWorkflowRun`, `appendWorkflowRunEvent`, and `readWorkflowRunState`.
+The model records trigger context, idempotency metadata, step attempts, retry
+metadata, timestamps, and explicit terminal states while remaining independent
+from Ensen-loop and external connector contracts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^25.6.0",
+        "@types/node": "^22.19.17",
         "typescript": "^5.9.3",
         "vitest": "^4.0.15"
       },
@@ -395,13 +395,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1103,9 +1103,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
+        "@types/node": "^25.6.0",
         "typescript": "^5.9.3",
         "vitest": "^4.0.15"
       },
@@ -392,6 +393,16 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
@@ -1090,6 +1101,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.10",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dist"
   ],
   "devDependencies": {
-    "@types/node": "^25.6.0",
+    "@types/node": "^22.19.17",
     "typescript": "^5.9.3",
     "vitest": "^4.0.15"
   }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dist"
   ],
   "devDependencies": {
+    "@types/node": "^25.6.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.15"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,28 @@ export const baselineInfo: BaselineInfo = {
 };
 
 export {
+  appendWorkflowRunEvent,
+  createWorkflowRun,
+  readWorkflowRunState
+} from "./workflow-run-state.js";
+
+export type {
+  AppendableWorkflowRunEvent,
+  CreateWorkflowRunInput,
+  WorkflowRunCreatedEvent,
+  WorkflowRunEvent,
+  WorkflowRunIdempotencyMetadata,
+  WorkflowRunRecord,
+  WorkflowRunRetryMetadata,
+  WorkflowRunState,
+  WorkflowRunStatus,
+  WorkflowRunTerminalState,
+  WorkflowRunTriggerContext,
+  WorkflowStepAttemptEvent,
+  WorkflowStepAttemptState
+} from "./workflow-run-state.js";
+
+export {
   validateWorkflowDefinition,
   workflowDefinitionSchemaVersion
 } from "./workflow-definition.js";

--- a/src/workflow-run-state.ts
+++ b/src/workflow-run-state.ts
@@ -1,6 +1,6 @@
 import { constants } from "node:fs";
 import { mkdir, open, readFile, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 
 const ISO_TIMESTAMP_PATTERN =
   /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
@@ -59,6 +59,7 @@ const IDEMPOTENCY_METADATA_ALLOWED_KEYS = new Set([
   "source",
   "key"
 ]);
+const statePathAppendLocks = new Map<string, Promise<void>>();
 
 export type WorkflowRunTerminalState =
   | "succeeded"
@@ -179,42 +180,40 @@ export const appendWorkflowRunEvent = async (
   validateWorkflowRunEvent(event, 1);
   await mkdir(dirname(statePath), { recursive: true });
 
-  const currentState = await readWorkflowRunState(statePath).catch((error: unknown) => {
-    if (isNodeError(error) && error.code === "ENOENT") {
-      throw new Error(
-        "appendWorkflowRunEvent requires an existing workflow run state file; call createWorkflowRun before appendWorkflowRunEvent so readWorkflowRunState can project a stream with run.created"
-      );
+  await withStatePathAppendLock(statePath, async () => {
+    const currentState = await readWorkflowRunState(statePath).catch((error: unknown) => {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        throw missingWorkflowRunStateError();
+      }
+
+      throw error;
+    });
+
+    if (currentState.run.runId !== event.runId) {
+      throw new Error("appendWorkflowRunEvent event.runId must match the existing workflow run");
     }
 
-    throw error;
+    if (currentState.run.terminalState !== undefined) {
+      throw new Error("appendWorkflowRunEvent cannot append to a completed workflow run");
+    }
+
+    let stateFile;
+    try {
+      stateFile = await open(statePath, constants.O_WRONLY | constants.O_APPEND);
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        throw missingWorkflowRunStateError();
+      }
+
+      throw error;
+    }
+
+    try {
+      await stateFile.writeFile(`${JSON.stringify(event)}\n`, "utf8");
+    } finally {
+      await stateFile.close();
+    }
   });
-
-  if (currentState.run.runId !== event.runId) {
-    throw new Error("appendWorkflowRunEvent event.runId must match the existing workflow run");
-  }
-
-  if (currentState.run.terminalState !== undefined) {
-    throw new Error("appendWorkflowRunEvent cannot append to a completed workflow run");
-  }
-
-  let stateFile;
-  try {
-    stateFile = await open(statePath, constants.O_WRONLY | constants.O_APPEND);
-  } catch (error) {
-    if (isNodeError(error) && error.code === "ENOENT") {
-      throw new Error(
-        "appendWorkflowRunEvent requires an existing workflow run state file; call createWorkflowRun before appendWorkflowRunEvent so readWorkflowRunState can project a stream with run.created"
-      );
-    }
-
-    throw error;
-  }
-
-  try {
-    await stateFile.writeFile(`${JSON.stringify(event)}\n`, "utf8");
-  } finally {
-    await stateFile.close();
-  }
 };
 
 export const readWorkflowRunState = async (
@@ -435,6 +434,10 @@ const validateTrigger = (value: unknown, lineNumber: number): void => {
     throw stateError(lineNumber, "trigger.context must be an object");
   }
 
+  if ("context" in value) {
+    validateJsonSerializableValue(value.context, lineNumber, "trigger.context");
+  }
+
   if ("idempotencyKey" in value) {
     validateIdempotencyMetadata(value.idempotencyKey, lineNumber);
   }
@@ -524,6 +527,103 @@ const stateError = (lineNumber: number, message: string): Error =>
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
+
+const withStatePathAppendLock = async <T>(
+  statePath: string,
+  operation: () => Promise<T>
+): Promise<T> => {
+  const lockKey = resolve(statePath);
+  const previousLock = statePathAppendLocks.get(lockKey) ?? Promise.resolve();
+  let releaseLock: () => void = () => undefined;
+  const currentLock = new Promise<void>((resolveLock) => {
+    releaseLock = resolveLock;
+  });
+  const nextLock = previousLock.catch(() => undefined).then(() => currentLock);
+  statePathAppendLocks.set(lockKey, nextLock);
+
+  await previousLock.catch(() => undefined);
+
+  try {
+    return await operation();
+  } finally {
+    releaseLock();
+    if (statePathAppendLocks.get(lockKey) === nextLock) {
+      statePathAppendLocks.delete(lockKey);
+    }
+  }
+};
+
+const missingWorkflowRunStateError = (): Error =>
+  new Error(
+    "appendWorkflowRunEvent requires an existing workflow run state file; call createWorkflowRun before appendWorkflowRunEvent so readWorkflowRunState can project a stream with run.created"
+  );
+
+const validateJsonSerializableValue = (
+  value: unknown,
+  lineNumber: number,
+  path: string,
+  seen: WeakSet<object> = new WeakSet()
+): void => {
+  if (value === null) {
+    return;
+  }
+
+  if (typeof value === "string" || typeof value === "boolean") {
+    return;
+  }
+
+  if (typeof value === "number") {
+    if (Number.isFinite(value)) {
+      return;
+    }
+
+    throw stateError(lineNumber, `${path} must contain only finite numbers`);
+  }
+
+  if (Array.isArray(value)) {
+    validateJsonContainer(value, lineNumber, path, seen, () => {
+      value.forEach((item, index) => {
+        validateJsonSerializableValue(item, lineNumber, `${path}[${index}]`, seen);
+      });
+    });
+    return;
+  }
+
+  if (isRecord(value) && isPlainJsonObject(value)) {
+    validateJsonContainer(value, lineNumber, path, seen, () => {
+      Object.entries(value).forEach(([key, item]) => {
+        validateJsonSerializableValue(item, lineNumber, `${path}.${key}`, seen);
+      });
+    });
+    return;
+  }
+
+  throw stateError(lineNumber, `${path} must contain only JSON-serializable values`);
+};
+
+const validateJsonContainer = (
+  value: object,
+  lineNumber: number,
+  path: string,
+  seen: WeakSet<object>,
+  validateChildren: () => void
+): void => {
+  if (seen.has(value)) {
+    throw stateError(lineNumber, `${path} must not contain circular references`);
+  }
+
+  seen.add(value);
+  try {
+    validateChildren();
+  } finally {
+    seen.delete(value);
+  }
+};
+
+const isPlainJsonObject = (value: Record<string, unknown>): boolean => {
+  const prototype = Object.getPrototypeOf(value) as unknown;
+  return prototype === Object.prototype || prototype === null;
+};
 
 const isStrictIsoTimestamp = (value: string): boolean => {
   const match = ISO_TIMESTAMP_PATTERN.exec(value);

--- a/src/workflow-run-state.ts
+++ b/src/workflow-run-state.ts
@@ -1,0 +1,456 @@
+import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+const TERMINAL_STATES = new Set([
+  "succeeded",
+  "failed",
+  "canceled",
+  "retryable-failed"
+]);
+const EVENT_TYPES = new Set([
+  "run.created",
+  "step.attempt.started",
+  "step.attempt.completed",
+  "step.attempt.failed",
+  "run.completed"
+]);
+const RUN_CREATED_ALLOWED_KEYS = new Set([
+  "type",
+  "runId",
+  "workflowId",
+  "workflowVersion",
+  "trigger",
+  "occurredAt"
+]);
+const STEP_ATTEMPT_ALLOWED_KEYS = new Set([
+  "type",
+  "runId",
+  "stepId",
+  "attempt",
+  "occurredAt",
+  "retry"
+]);
+const RUN_COMPLETED_ALLOWED_KEYS = new Set([
+  "type",
+  "runId",
+  "terminalState",
+  "occurredAt"
+]);
+const RETRY_METADATA_ALLOWED_KEYS = new Set([
+  "retryable",
+  "nextAttemptAt",
+  "reason"
+]);
+const TRIGGER_ALLOWED_KEYS = new Set([
+  "type",
+  "receivedAt",
+  "context",
+  "idempotencyKey"
+]);
+const IDEMPOTENCY_METADATA_ALLOWED_KEYS = new Set([
+  "source",
+  "key"
+]);
+
+export type WorkflowRunTerminalState =
+  | "succeeded"
+  | "failed"
+  | "canceled"
+  | "retryable-failed";
+
+export type WorkflowRunStatus = "created" | "running" | WorkflowRunTerminalState;
+
+export interface WorkflowRunTriggerContext {
+  type: string;
+  receivedAt: string;
+  context?: Record<string, unknown>;
+  idempotencyKey?: WorkflowRunIdempotencyMetadata;
+}
+
+export interface WorkflowRunIdempotencyMetadata {
+  source: "input" | "workflow" | "static";
+  key: string;
+}
+
+export interface WorkflowRunRetryMetadata {
+  retryable: boolean;
+  nextAttemptAt?: string;
+  reason?: string;
+}
+
+export interface CreateWorkflowRunInput {
+  runId: string;
+  workflowId: string;
+  workflowVersion: string;
+  trigger: WorkflowRunTriggerContext;
+  createdAt: string;
+}
+
+export interface WorkflowRunCreatedEvent {
+  type: "run.created";
+  runId: string;
+  workflowId: string;
+  workflowVersion: string;
+  trigger: WorkflowRunTriggerContext;
+  occurredAt: string;
+}
+
+export interface WorkflowStepAttemptEvent {
+  type: "step.attempt.started" | "step.attempt.completed" | "step.attempt.failed";
+  runId: string;
+  stepId: string;
+  attempt: number;
+  occurredAt: string;
+  retry?: WorkflowRunRetryMetadata;
+}
+
+export interface WorkflowRunCompletedEvent {
+  type: "run.completed";
+  runId: string;
+  terminalState: WorkflowRunTerminalState;
+  occurredAt: string;
+}
+
+export type WorkflowRunEvent =
+  | WorkflowRunCreatedEvent
+  | WorkflowStepAttemptEvent
+  | WorkflowRunCompletedEvent;
+
+export type AppendableWorkflowRunEvent =
+  | WorkflowStepAttemptEvent
+  | WorkflowRunCompletedEvent;
+
+export interface WorkflowRunRecord {
+  runId: string;
+  workflowId: string;
+  workflowVersion: string;
+  trigger: WorkflowRunTriggerContext;
+  createdAt: string;
+  updatedAt: string;
+  status: WorkflowRunStatus;
+  terminalState?: WorkflowRunTerminalState;
+}
+
+export interface WorkflowStepAttemptState {
+  attempt: number;
+  startedAt?: string;
+  completedAt?: string;
+  failedAt?: string;
+  retry?: WorkflowRunRetryMetadata;
+  status: "running" | "succeeded" | "failed" | "retryable-failed";
+}
+
+export interface WorkflowRunState {
+  run: WorkflowRunRecord;
+  events: WorkflowRunEvent[];
+  stepAttempts: Record<string, WorkflowStepAttemptState[]>;
+}
+
+export const createWorkflowRun = async (
+  statePath: string,
+  input: CreateWorkflowRunInput
+): Promise<void> => {
+  const event: WorkflowRunCreatedEvent = {
+    type: "run.created",
+    runId: input.runId,
+    workflowId: input.workflowId,
+    workflowVersion: input.workflowVersion,
+    trigger: input.trigger,
+    occurredAt: input.createdAt
+  };
+
+  validateWorkflowRunEvent(event, 1);
+  await mkdir(dirname(statePath), { recursive: true });
+  await writeFile(statePath, `${JSON.stringify(event)}\n`, { encoding: "utf8", flag: "wx" });
+};
+
+export const appendWorkflowRunEvent = async (
+  statePath: string,
+  event: AppendableWorkflowRunEvent
+): Promise<void> => {
+  validateWorkflowRunEvent(event, 1);
+  await mkdir(dirname(statePath), { recursive: true });
+  await appendFile(statePath, `${JSON.stringify(event)}\n`, "utf8");
+};
+
+export const readWorkflowRunState = async (
+  statePath: string
+): Promise<WorkflowRunState> => {
+  const contents = await readFile(statePath, "utf8");
+  const events = parseWorkflowRunEvents(contents);
+
+  if (events.length === 0) {
+    throw new Error("workflow run state must contain a run.created record");
+  }
+
+  const [createdEvent] = events;
+  if (createdEvent.type !== "run.created") {
+    throw new Error("workflow run state line 1: first record must be run.created");
+  }
+
+  const stepAttempts: Record<string, WorkflowStepAttemptState[]> = {};
+  const run: WorkflowRunRecord = {
+    runId: createdEvent.runId,
+    workflowId: createdEvent.workflowId,
+    workflowVersion: createdEvent.workflowVersion,
+    trigger: createdEvent.trigger,
+    createdAt: createdEvent.occurredAt,
+    updatedAt: createdEvent.occurredAt,
+    status: "created"
+  };
+
+  events.slice(1).forEach((event, index) => {
+    const lineNumber = index + 2;
+    if (event.type === "run.created") {
+      throw new Error(`workflow run state line ${lineNumber}: run.created must only appear once`);
+    }
+
+    if (event.runId !== run.runId) {
+      throw new Error(`workflow run state line ${lineNumber}: runId must match run.created`);
+    }
+
+    run.updatedAt = event.occurredAt;
+
+    if (event.type === "run.completed") {
+      run.status = event.terminalState;
+      run.terminalState = event.terminalState;
+      return;
+    }
+
+    run.status = run.terminalState ?? "running";
+    applyStepAttemptEvent(stepAttempts, event);
+  });
+
+  return {
+    run,
+    events,
+    stepAttempts
+  };
+};
+
+const parseWorkflowRunEvents = (contents: string): WorkflowRunEvent[] => {
+  const lines = contents.split("\n");
+  if (lines.at(-1) === "") {
+    lines.pop();
+  }
+
+  return lines.map((line, index) => {
+    const lineNumber = index + 1;
+    if (line.trim() === "") {
+      throw new Error(`workflow run state line ${lineNumber}: record must not be blank`);
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line) as unknown;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "invalid JSON";
+      throw new Error(`workflow run state line ${lineNumber}: invalid JSON: ${message}`);
+    }
+
+    return validateWorkflowRunEvent(parsed, lineNumber);
+  });
+};
+
+const applyStepAttemptEvent = (
+  stepAttempts: Record<string, WorkflowStepAttemptState[]>,
+  event: WorkflowStepAttemptEvent
+): void => {
+  const attempts = (stepAttempts[event.stepId] ??= []);
+  let attempt = attempts.find((candidate) => candidate.attempt === event.attempt);
+
+  if (event.type === "step.attempt.started") {
+    if (attempt !== undefined) {
+      attempt.startedAt = event.occurredAt;
+      attempt.status = "running";
+      attempt.retry = event.retry;
+      return;
+    }
+
+    attempts.push({
+      attempt: event.attempt,
+      startedAt: event.occurredAt,
+      retry: event.retry,
+      status: "running"
+    });
+    attempts.sort((left, right) => left.attempt - right.attempt);
+    return;
+  }
+
+  if (attempt === undefined) {
+    attempt = {
+      attempt: event.attempt,
+      retry: event.retry,
+      status: "running"
+    };
+    attempts.push(attempt);
+    attempts.sort((left, right) => left.attempt - right.attempt);
+  }
+
+  if (event.type === "step.attempt.completed") {
+    attempt.completedAt = event.occurredAt;
+    attempt.status = "succeeded";
+    attempt.retry = event.retry;
+  } else {
+    attempt.failedAt = event.occurredAt;
+    attempt.status = event.retry?.retryable === true ? "retryable-failed" : "failed";
+    attempt.retry = event.retry;
+  }
+};
+
+const validateWorkflowRunEvent = (
+  value: unknown,
+  lineNumber: number
+): WorkflowRunEvent => {
+  if (!isRecord(value)) {
+    throw stateError(lineNumber, "record must be an object");
+  }
+
+  const eventType = value.type;
+  if (typeof eventType !== "string" || !EVENT_TYPES.has(eventType)) {
+    throw stateError(
+      lineNumber,
+      "type must be run.created, step.attempt.started, step.attempt.completed, step.attempt.failed, or run.completed"
+    );
+  }
+
+  if (eventType === "run.created") {
+    rejectUnknownKeys(value, RUN_CREATED_ALLOWED_KEYS, lineNumber);
+    requireNonEmptyString(value, "runId", lineNumber);
+    requireNonEmptyString(value, "workflowId", lineNumber);
+    requireNonEmptyString(value, "workflowVersion", lineNumber);
+    requireTimestamp(value, "occurredAt", lineNumber);
+    validateTrigger(value.trigger, lineNumber);
+    return value as unknown as WorkflowRunCreatedEvent;
+  }
+
+  if (eventType === "run.completed") {
+    rejectUnknownKeys(value, RUN_COMPLETED_ALLOWED_KEYS, lineNumber);
+    requireNonEmptyString(value, "runId", lineNumber);
+    requireTimestamp(value, "occurredAt", lineNumber);
+
+    if (typeof value.terminalState !== "string" || !TERMINAL_STATES.has(value.terminalState)) {
+      throw stateError(
+        lineNumber,
+        "terminalState must be succeeded, failed, canceled, or retryable-failed"
+      );
+    }
+
+    return value as unknown as WorkflowRunCompletedEvent;
+  }
+
+  rejectUnknownKeys(value, STEP_ATTEMPT_ALLOWED_KEYS, lineNumber);
+  requireNonEmptyString(value, "runId", lineNumber);
+  requireNonEmptyString(value, "stepId", lineNumber);
+  requirePositiveInteger(value, "attempt", lineNumber);
+  requireTimestamp(value, "occurredAt", lineNumber);
+
+  if ("retry" in value) {
+    validateRetryMetadata(value.retry, lineNumber);
+  }
+
+  return value as unknown as WorkflowStepAttemptEvent;
+};
+
+const validateTrigger = (value: unknown, lineNumber: number): void => {
+  if (!isRecord(value)) {
+    throw stateError(lineNumber, "trigger must be an object");
+  }
+
+  rejectUnknownKeys(value, TRIGGER_ALLOWED_KEYS, lineNumber);
+  requireNonEmptyString(value, "type", lineNumber);
+  requireTimestamp(value, "receivedAt", lineNumber);
+
+  if ("context" in value && !isRecord(value.context)) {
+    throw stateError(lineNumber, "trigger.context must be an object");
+  }
+
+  if ("idempotencyKey" in value) {
+    validateIdempotencyMetadata(value.idempotencyKey, lineNumber);
+  }
+};
+
+const validateIdempotencyMetadata = (value: unknown, lineNumber: number): void => {
+  if (!isRecord(value)) {
+    throw stateError(lineNumber, "trigger.idempotencyKey must be an object");
+  }
+
+  rejectUnknownKeys(value, IDEMPOTENCY_METADATA_ALLOWED_KEYS, lineNumber);
+  if (
+    value.source !== "input" &&
+    value.source !== "workflow" &&
+    value.source !== "static"
+  ) {
+    throw stateError(lineNumber, "idempotencyKey.source must be input, workflow, or static");
+  }
+
+  requireNonEmptyString(value, "key", lineNumber);
+};
+
+const validateRetryMetadata = (value: unknown, lineNumber: number): void => {
+  if (!isRecord(value)) {
+    throw stateError(lineNumber, "retry must be an object");
+  }
+
+  rejectUnknownKeys(value, RETRY_METADATA_ALLOWED_KEYS, lineNumber);
+
+  if (typeof value.retryable !== "boolean") {
+    throw stateError(lineNumber, "retry.retryable must be boolean");
+  }
+
+  if ("nextAttemptAt" in value) {
+    requireTimestamp(value, "nextAttemptAt", lineNumber);
+  }
+
+  if ("reason" in value && (typeof value.reason !== "string" || value.reason.trim() === "")) {
+    throw stateError(lineNumber, "retry.reason must be a non-empty string");
+  }
+};
+
+const rejectUnknownKeys = (
+  value: Record<string, unknown>,
+  allowedKeys: Set<string>,
+  lineNumber: number
+): void => {
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) {
+      throw stateError(lineNumber, `${key} is outside the workflow run state schema boundary`);
+    }
+  }
+};
+
+const requireNonEmptyString = (
+  value: Record<string, unknown>,
+  key: string,
+  lineNumber: number
+): void => {
+  if (typeof value[key] !== "string" || value[key].trim() === "") {
+    throw stateError(lineNumber, `${key} must be a non-empty string`);
+  }
+};
+
+const requireTimestamp = (
+  value: Record<string, unknown>,
+  key: string,
+  lineNumber: number
+): void => {
+  if (typeof value[key] !== "string" || Number.isNaN(Date.parse(value[key]))) {
+    throw stateError(lineNumber, `${key} must be an ISO timestamp string`);
+  }
+};
+
+const requirePositiveInteger = (
+  value: Record<string, unknown>,
+  key: string,
+  lineNumber: number
+): void => {
+  if (typeof value[key] !== "number" || !Number.isInteger(value[key]) || value[key] < 1) {
+    throw stateError(lineNumber, `${key} must be a positive integer`);
+  }
+};
+
+const stateError = (lineNumber: number, message: string): Error =>
+  new Error(`workflow run state line ${lineNumber}: ${message}`);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);

--- a/src/workflow-run-state.ts
+++ b/src/workflow-run-state.ts
@@ -179,6 +179,24 @@ export const appendWorkflowRunEvent = async (
   validateWorkflowRunEvent(event, 1);
   await mkdir(dirname(statePath), { recursive: true });
 
+  const currentState = await readWorkflowRunState(statePath).catch((error: unknown) => {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      throw new Error(
+        "appendWorkflowRunEvent requires an existing workflow run state file; call createWorkflowRun before appendWorkflowRunEvent so readWorkflowRunState can project a stream with run.created"
+      );
+    }
+
+    throw error;
+  });
+
+  if (currentState.run.runId !== event.runId) {
+    throw new Error("appendWorkflowRunEvent event.runId must match the existing workflow run");
+  }
+
+  if (currentState.run.terminalState !== undefined) {
+    throw new Error("appendWorkflowRunEvent cannot append to a completed workflow run");
+  }
+
   let stateFile;
   try {
     stateFile = await open(statePath, constants.O_WRONLY | constants.O_APPEND);
@@ -295,6 +313,23 @@ const applyStepAttemptEvent = (
       throw stateError(
         lineNumber,
         `workflow step attempt ${event.stepId}#${event.attempt}: step.attempt.started cannot follow ${attempt.status}`
+      );
+    }
+
+    const runningAttempt = attempts.find((candidate) => candidate.status === "running");
+    if (runningAttempt !== undefined) {
+      throw stateError(
+        lineNumber,
+        `workflow step attempt ${event.stepId}#${event.attempt}: step.attempt.started cannot follow running attempt ${event.stepId}#${runningAttempt.attempt}`
+      );
+    }
+
+    const latestAttempt = attempts.at(-1);
+    const expectedAttempt = latestAttempt === undefined ? 1 : latestAttempt.attempt + 1;
+    if (event.attempt !== expectedAttempt) {
+      throw stateError(
+        lineNumber,
+        `workflow step attempt ${event.stepId}#${event.attempt}: attempt numbers must increase by 1`
       );
     }
 

--- a/src/workflow-run-state.ts
+++ b/src/workflow-run-state.ts
@@ -1,10 +1,18 @@
-import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { mkdir, open, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
+const ISO_TIMESTAMP_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
 const TERMINAL_STATES = new Set([
   "succeeded",
   "failed",
   "canceled",
+  "retryable-failed"
+]);
+const STEP_ATTEMPT_TERMINAL_STATUSES = new Set([
+  "succeeded",
+  "failed",
   "retryable-failed"
 ]);
 const EVENT_TYPES = new Set([
@@ -170,7 +178,25 @@ export const appendWorkflowRunEvent = async (
 ): Promise<void> => {
   validateWorkflowRunEvent(event, 1);
   await mkdir(dirname(statePath), { recursive: true });
-  await appendFile(statePath, `${JSON.stringify(event)}\n`, "utf8");
+
+  let stateFile;
+  try {
+    stateFile = await open(statePath, constants.O_WRONLY | constants.O_APPEND);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      throw new Error(
+        "appendWorkflowRunEvent requires an existing workflow run state file; call createWorkflowRun before appendWorkflowRunEvent so readWorkflowRunState can project a stream with run.created"
+      );
+    }
+
+    throw error;
+  }
+
+  try {
+    await stateFile.writeFile(`${JSON.stringify(event)}\n`, "utf8");
+  } finally {
+    await stateFile.close();
+  }
 };
 
 export const readWorkflowRunState = async (
@@ -201,6 +227,10 @@ export const readWorkflowRunState = async (
 
   events.slice(1).forEach((event, index) => {
     const lineNumber = index + 2;
+    if (run.terminalState !== undefined) {
+      throw new Error(`workflow run state line ${lineNumber}: no records are allowed after run.completed`);
+    }
+
     if (event.type === "run.created") {
       throw new Error(`workflow run state line ${lineNumber}: run.created must only appear once`);
     }
@@ -218,7 +248,7 @@ export const readWorkflowRunState = async (
     }
 
     run.status = run.terminalState ?? "running";
-    applyStepAttemptEvent(stepAttempts, event);
+    applyStepAttemptEvent(stepAttempts, event, lineNumber);
   });
 
   return {
@@ -254,17 +284,18 @@ const parseWorkflowRunEvents = (contents: string): WorkflowRunEvent[] => {
 
 const applyStepAttemptEvent = (
   stepAttempts: Record<string, WorkflowStepAttemptState[]>,
-  event: WorkflowStepAttemptEvent
+  event: WorkflowStepAttemptEvent,
+  lineNumber: number
 ): void => {
   const attempts = (stepAttempts[event.stepId] ??= []);
   let attempt = attempts.find((candidate) => candidate.attempt === event.attempt);
 
   if (event.type === "step.attempt.started") {
     if (attempt !== undefined) {
-      attempt.startedAt = event.occurredAt;
-      attempt.status = "running";
-      attempt.retry = event.retry;
-      return;
+      throw stateError(
+        lineNumber,
+        `workflow step attempt ${event.stepId}#${event.attempt}: step.attempt.started cannot follow ${attempt.status}`
+      );
     }
 
     attempts.push({
@@ -278,13 +309,17 @@ const applyStepAttemptEvent = (
   }
 
   if (attempt === undefined) {
-    attempt = {
-      attempt: event.attempt,
-      retry: event.retry,
-      status: "running"
-    };
-    attempts.push(attempt);
-    attempts.sort((left, right) => left.attempt - right.attempt);
+    throw stateError(
+      lineNumber,
+      `workflow step attempt ${event.stepId}#${event.attempt}: ${event.type} requires step.attempt.started first`
+    );
+  }
+
+  if (STEP_ATTEMPT_TERMINAL_STATUSES.has(attempt.status)) {
+    throw stateError(
+      lineNumber,
+      `workflow step attempt ${event.stepId}#${event.attempt}: ${event.type} cannot follow ${attempt.status}`
+    );
   }
 
   if (event.type === "step.attempt.completed") {
@@ -434,7 +469,7 @@ const requireTimestamp = (
   key: string,
   lineNumber: number
 ): void => {
-  if (typeof value[key] !== "string" || Number.isNaN(Date.parse(value[key]))) {
+  if (typeof value[key] !== "string" || !isStrictIsoTimestamp(value[key])) {
     throw stateError(lineNumber, `${key} must be an ISO timestamp string`);
   }
 };
@@ -454,3 +489,31 @@ const stateError = (lineNumber: number, message: string): Error =>
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isStrictIsoTimestamp = (value: string): boolean => {
+  const match = ISO_TIMESTAMP_PATTERN.exec(value);
+  if (match === null || Number.isNaN(Date.parse(value))) {
+    return false;
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  if (
+    month < 1 ||
+    month > 12 ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59
+  ) {
+    return false;
+  }
+
+  return day >= 1 && day <= new Date(Date.UTC(year, month, 0)).getUTCDate();
+};
+
+const isNodeError = (error: unknown): error is NodeJS.ErrnoException =>
+  error instanceof Error && "code" in error;

--- a/src/workflow-run-state.ts
+++ b/src/workflow-run-state.ts
@@ -197,6 +197,8 @@ export const appendWorkflowRunEvent = async (
       throw new Error("appendWorkflowRunEvent cannot append to a completed workflow run");
     }
 
+    projectWorkflowRunEvents([...currentState.events, event]);
+
     let stateFile;
     try {
       stateFile = await open(statePath, constants.O_WRONLY | constants.O_APPEND);
@@ -222,6 +224,10 @@ export const readWorkflowRunState = async (
   const contents = await readFile(statePath, "utf8");
   const events = parseWorkflowRunEvents(contents);
 
+  return projectWorkflowRunEvents(events);
+};
+
+const projectWorkflowRunEvents = (events: WorkflowRunEvent[]): WorkflowRunState => {
   if (events.length === 0) {
     throw new Error("workflow run state must contain a run.created record");
   }
@@ -329,6 +335,13 @@ const applyStepAttemptEvent = (
       throw stateError(
         lineNumber,
         `workflow step attempt ${event.stepId}#${event.attempt}: attempt numbers must increase by 1`
+      );
+    }
+
+    if (latestAttempt !== undefined && latestAttempt.status !== "retryable-failed") {
+      throw stateError(
+        lineNumber,
+        `workflow step attempt ${event.stepId}#${event.attempt}: step.attempt.started cannot follow ${latestAttempt.status}`
       );
     }
 

--- a/test/workflow-run-state.test.ts
+++ b/test/workflow-run-state.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -238,6 +238,81 @@ describe("workflow run JSONL state", () => {
     );
   });
 
+  it("rejects appending events for a different run without modifying state", async () => {
+    const statePath = await createTempStatePath();
+
+    await createWorkflowRun(statePath, {
+      runId: "run-001",
+      workflowId: "operator-review",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z"
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+
+    const contentsBeforeAppend = await readFile(statePath, "utf8");
+
+    await expect(
+      appendWorkflowRunEvent(statePath, {
+        type: "step.attempt.started",
+        runId: "run-002",
+        stepId: "collect-input",
+        attempt: 1,
+        occurredAt: "2026-04-29T00:00:02.000Z"
+      })
+    ).rejects.toThrow("appendWorkflowRunEvent event.runId must match the existing workflow run");
+
+    await expect(readFile(statePath, "utf8")).resolves.toBe(contentsBeforeAppend);
+    await expect(readWorkflowRunState(statePath)).resolves.toMatchObject({
+      events: [{ runId: "run-001", type: "run.created" }]
+    });
+  });
+
+  it("rejects appending events after run completion without modifying state", async () => {
+    const statePath = await createTempStatePath();
+
+    await createWorkflowRun(statePath, {
+      runId: "run-001",
+      workflowId: "operator-review",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z"
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+
+    await appendWorkflowRunEvent(statePath, {
+      type: "run.completed",
+      runId: "run-001",
+      terminalState: "succeeded",
+      occurredAt: "2026-04-29T00:00:02.000Z"
+    });
+
+    const contentsBeforeAppend = await readFile(statePath, "utf8");
+
+    await expect(
+      appendWorkflowRunEvent(statePath, {
+        type: "step.attempt.started",
+        runId: "run-001",
+        stepId: "collect-input",
+        attempt: 1,
+        occurredAt: "2026-04-29T00:00:03.000Z"
+      })
+    ).rejects.toThrow("appendWorkflowRunEvent cannot append to a completed workflow run");
+
+    await expect(readFile(statePath, "utf8")).resolves.toBe(contentsBeforeAppend);
+    await expect(readWorkflowRunState(statePath)).resolves.toMatchObject({
+      run: {
+        runId: "run-001",
+        status: "succeeded",
+        terminalState: "succeeded"
+      }
+    });
+  });
+
   it("fails closed when records appear after run completion", async () => {
     const statePath = await createTempStatePath();
     await writeFile(
@@ -342,6 +417,89 @@ describe("workflow run JSONL state", () => {
 
     await expect(readWorkflowRunState(statePath)).rejects.toThrow(
       "workflow run state line 4: workflow step attempt collect-input#1: step.attempt.failed cannot follow succeeded"
+    );
+  });
+
+  it("fails closed when starting a new attempt before the active attempt finishes", async () => {
+    const statePath = await createTempStatePath();
+    await writeFile(
+      statePath,
+      [
+        JSON.stringify({
+          type: "run.created",
+          runId: "run-001",
+          workflowId: "operator-review",
+          workflowVersion: "flow.workflow.v1",
+          trigger: { type: "manual", receivedAt: "2026-04-29T00:00:00.000Z" },
+          occurredAt: "2026-04-29T00:00:01.000Z"
+        }),
+        JSON.stringify({
+          type: "step.attempt.started",
+          runId: "run-001",
+          stepId: "collect-input",
+          attempt: 1,
+          occurredAt: "2026-04-29T00:00:02.000Z"
+        }),
+        JSON.stringify({
+          type: "step.attempt.started",
+          runId: "run-001",
+          stepId: "collect-input",
+          attempt: 2,
+          occurredAt: "2026-04-29T00:00:03.000Z"
+        })
+      ].join("\n"),
+      "utf8"
+    );
+
+    await expect(readWorkflowRunState(statePath)).rejects.toThrow(
+      "workflow run state line 3: workflow step attempt collect-input#2: step.attempt.started cannot follow running attempt collect-input#1"
+    );
+  });
+
+  it("fails closed when step attempt numbers skip ahead", async () => {
+    const statePath = await createTempStatePath();
+    await writeFile(
+      statePath,
+      [
+        JSON.stringify({
+          type: "run.created",
+          runId: "run-001",
+          workflowId: "operator-review",
+          workflowVersion: "flow.workflow.v1",
+          trigger: { type: "manual", receivedAt: "2026-04-29T00:00:00.000Z" },
+          occurredAt: "2026-04-29T00:00:01.000Z"
+        }),
+        JSON.stringify({
+          type: "step.attempt.started",
+          runId: "run-001",
+          stepId: "collect-input",
+          attempt: 1,
+          occurredAt: "2026-04-29T00:00:02.000Z"
+        }),
+        JSON.stringify({
+          type: "step.attempt.failed",
+          runId: "run-001",
+          stepId: "collect-input",
+          attempt: 1,
+          occurredAt: "2026-04-29T00:00:03.000Z",
+          retry: {
+            retryable: true,
+            nextAttemptAt: "2026-04-29T00:00:13.000Z"
+          }
+        }),
+        JSON.stringify({
+          type: "step.attempt.started",
+          runId: "run-001",
+          stepId: "collect-input",
+          attempt: 3,
+          occurredAt: "2026-04-29T00:00:14.000Z"
+        })
+      ].join("\n"),
+      "utf8"
+    );
+
+    await expect(readWorkflowRunState(statePath)).rejects.toThrow(
+      "workflow run state line 4: workflow step attempt collect-input#3: attempt numbers must increase by 1"
     );
   });
 

--- a/test/workflow-run-state.test.ts
+++ b/test/workflow-run-state.test.ts
@@ -1,0 +1,215 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  appendWorkflowRunEvent,
+  createWorkflowRun,
+  readWorkflowRunState
+} from "../src/index.js";
+
+const tempRoots: string[] = [];
+
+const createTempStatePath = async () => {
+  const root = await mkdtemp(join(tmpdir(), "ensen-flow-run-state-"));
+  tempRoots.push(root);
+  const statePath = join(root, "runs", "manual-run.jsonl");
+  await mkdir(join(root, "runs"), { recursive: true });
+  return statePath;
+};
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
+  );
+});
+
+describe("workflow run JSONL state", () => {
+  it("persists and reads workflow run events in append order", async () => {
+    const statePath = await createTempStatePath();
+
+    await createWorkflowRun(statePath, {
+      runId: "run-001",
+      workflowId: "operator-review",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z",
+        context: {
+          operator: "local-test",
+          source: "unit-test"
+        },
+        idempotencyKey: {
+          source: "input",
+          key: "ticket-123"
+        }
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "run-001",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:02.000Z"
+    });
+
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.completed",
+      runId: "run-001",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:03.000Z"
+    });
+
+    await appendWorkflowRunEvent(statePath, {
+      type: "run.completed",
+      runId: "run-001",
+      terminalState: "succeeded",
+      occurredAt: "2026-04-29T00:00:04.000Z"
+    });
+
+    const state = await readWorkflowRunState(statePath);
+
+    expect(state.run).toMatchObject({
+      runId: "run-001",
+      workflowId: "operator-review",
+      workflowVersion: "flow.workflow.v1",
+      status: "succeeded",
+      terminalState: "succeeded"
+    });
+    expect(state.run.trigger).toEqual({
+      type: "manual",
+      receivedAt: "2026-04-29T00:00:00.000Z",
+      context: {
+        operator: "local-test",
+        source: "unit-test"
+      },
+      idempotencyKey: {
+        source: "input",
+        key: "ticket-123"
+      }
+    });
+    expect(state.events.map((event) => event.type)).toEqual([
+      "run.created",
+      "step.attempt.started",
+      "step.attempt.completed",
+      "run.completed"
+    ]);
+    expect(state.stepAttempts).toEqual({
+      "collect-input": [
+        {
+          attempt: 1,
+          startedAt: "2026-04-29T00:00:02.000Z",
+          completedAt: "2026-04-29T00:00:03.000Z",
+          retry: undefined,
+          status: "succeeded"
+        }
+      ]
+    });
+  });
+
+  it("fails closed on malformed JSONL records", async () => {
+    const statePath = await createTempStatePath();
+    await writeFile(
+      statePath,
+      [
+        JSON.stringify({
+          type: "run.created",
+          runId: "run-001",
+          workflowId: "operator-review",
+          workflowVersion: "flow.workflow.v1",
+          trigger: { type: "manual", receivedAt: "2026-04-29T00:00:00.000Z" },
+          occurredAt: "2026-04-29T00:00:01.000Z"
+        }),
+        JSON.stringify({
+          type: "run.completed",
+          runId: "run-001",
+          terminalState: "unknown",
+          occurredAt: "2026-04-29T00:00:02.000Z"
+        })
+      ].join("\n"),
+      "utf8"
+    );
+
+    await expect(readWorkflowRunState(statePath)).rejects.toThrow(
+      "workflow run state line 2: terminalState must be succeeded, failed, canceled, or retryable-failed"
+    );
+  });
+
+  it.each(["succeeded", "failed", "canceled", "retryable-failed"] as const)(
+    "represents %s as a distinct terminal state",
+    async (terminalState) => {
+      const statePath = await createTempStatePath();
+
+      await createWorkflowRun(statePath, {
+        runId: `run-${terminalState}`,
+        workflowId: "operator-review",
+        workflowVersion: "flow.workflow.v1",
+        trigger: {
+          type: "manual",
+          receivedAt: "2026-04-29T00:00:00.000Z"
+        },
+        createdAt: "2026-04-29T00:00:01.000Z"
+      });
+
+      await appendWorkflowRunEvent(statePath, {
+        type: "run.completed",
+        runId: `run-${terminalState}`,
+        terminalState,
+        occurredAt: "2026-04-29T00:00:02.000Z"
+      });
+
+      const state = await readWorkflowRunState(statePath);
+
+      expect(state.run.status).toBe(terminalState);
+      expect(state.run.terminalState).toBe(terminalState);
+    }
+  );
+
+  it("retains retry metadata on failed step attempts", async () => {
+    const statePath = await createTempStatePath();
+
+    await createWorkflowRun(statePath, {
+      runId: "run-retry-001",
+      workflowId: "operator-review",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z"
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.failed",
+      runId: "run-retry-001",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:02.000Z",
+      retry: {
+        retryable: true,
+        nextAttemptAt: "2026-04-29T00:00:12.000Z",
+        reason: "temporary unavailable dependency"
+      }
+    });
+
+    const state = await readWorkflowRunState(statePath);
+
+    expect(state.stepAttempts["collect-input"]).toEqual([
+      {
+        attempt: 1,
+        failedAt: "2026-04-29T00:00:02.000Z",
+        retry: {
+          retryable: true,
+          nextAttemptAt: "2026-04-29T00:00:12.000Z",
+          reason: "temporary unavailable dependency"
+        },
+        status: "retryable-failed"
+      }
+    ]);
+  });
+});

--- a/test/workflow-run-state.test.ts
+++ b/test/workflow-run-state.test.ts
@@ -39,7 +39,11 @@ describe("workflow run JSONL state", () => {
         receivedAt: "2026-04-29T00:00:00.000Z",
         context: {
           operator: "local-test",
-          source: "unit-test"
+          source: "unit-test",
+          payload: {
+            retryable: true,
+            labels: ["review", null, 2]
+          }
         },
         idempotencyKey: {
           source: "input",
@@ -86,7 +90,11 @@ describe("workflow run JSONL state", () => {
       receivedAt: "2026-04-29T00:00:00.000Z",
       context: {
         operator: "local-test",
-        source: "unit-test"
+        source: "unit-test",
+        payload: {
+          retryable: true,
+          labels: ["review", null, 2]
+        }
       },
       idempotencyKey: {
         source: "input",
@@ -138,6 +146,57 @@ describe("workflow run JSONL state", () => {
     await expect(readWorkflowRunState(statePath)).rejects.toThrow(
       "workflow run state line 2: terminalState must be succeeded, failed, canceled, or retryable-failed"
     );
+  });
+
+  it.each([
+    { context: { dropped: undefined }, message: "trigger.context.dropped must contain only JSON-serializable values" },
+    { context: { fn: () => undefined }, message: "trigger.context.fn must contain only JSON-serializable values" },
+    { context: { marker: Symbol("bad") }, message: "trigger.context.marker must contain only JSON-serializable values" },
+    { context: { count: 1n }, message: "trigger.context.count must contain only JSON-serializable values" },
+    { context: { value: Number.NaN }, message: "trigger.context.value must contain only finite numbers" },
+    { context: { received: new Date("2026-04-29T00:00:00.000Z") }, message: "trigger.context.received must contain only JSON-serializable values" }
+  ])("rejects non-JSON trigger context values before writing %#", async ({ context, message }) => {
+    const statePath = await createTempStatePath();
+
+    await expect(
+      createWorkflowRun(statePath, {
+        runId: "run-001",
+        workflowId: "operator-review",
+        workflowVersion: "flow.workflow.v1",
+        trigger: {
+          type: "manual",
+          receivedAt: "2026-04-29T00:00:00.000Z",
+          context
+        },
+        createdAt: "2026-04-29T00:00:01.000Z"
+      })
+    ).rejects.toThrow(`workflow run state line 1: ${message}`);
+
+    await expect(readFile(statePath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects circular trigger context values before writing", async () => {
+    const statePath = await createTempStatePath();
+    const context: Record<string, unknown> = {};
+    context.self = context;
+
+    await expect(
+      createWorkflowRun(statePath, {
+        runId: "run-001",
+        workflowId: "operator-review",
+        workflowVersion: "flow.workflow.v1",
+        trigger: {
+          type: "manual",
+          receivedAt: "2026-04-29T00:00:00.000Z",
+          context
+        },
+        createdAt: "2026-04-29T00:00:01.000Z"
+      })
+    ).rejects.toThrow(
+      "workflow run state line 1: trigger.context.self must not contain circular references"
+    );
+
+    await expect(readFile(statePath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it.each(["succeeded", "failed", "canceled", "retryable-failed"] as const)(
@@ -311,6 +370,52 @@ describe("workflow run JSONL state", () => {
         terminalState: "succeeded"
       }
     });
+  });
+
+  it("serializes concurrent terminal appends for the same state file", async () => {
+    const statePath = await createTempStatePath();
+
+    await createWorkflowRun(statePath, {
+      runId: "run-001",
+      workflowId: "operator-review",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z"
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+
+    const results = await Promise.allSettled([
+      appendWorkflowRunEvent(statePath, {
+        type: "run.completed",
+        runId: "run-001",
+        terminalState: "succeeded",
+        occurredAt: "2026-04-29T00:00:02.000Z"
+      }),
+      appendWorkflowRunEvent(statePath, {
+        type: "run.completed",
+        runId: "run-001",
+        terminalState: "failed",
+        occurredAt: "2026-04-29T00:00:03.000Z"
+      })
+    ]);
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const rejected = results.filter((result) => result.status === "rejected");
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]).toMatchObject({
+      reason: expect.objectContaining({
+        message: "appendWorkflowRunEvent cannot append to a completed workflow run"
+      })
+    });
+
+    const lines = (await readFile(statePath, "utf8")).trimEnd().split("\n");
+    expect(lines).toHaveLength(2);
+
+    const state = await readWorkflowRunState(statePath);
+    expect(["succeeded", "failed"]).toContain(state.run.terminalState);
+    expect(state.events.map((event) => event.type)).toEqual(["run.created", "run.completed"]);
   });
 
   it("fails closed when records appear after run completion", async () => {

--- a/test/workflow-run-state.test.ts
+++ b/test/workflow-run-state.test.ts
@@ -281,6 +281,120 @@ describe("workflow run JSONL state", () => {
     ]);
   });
 
+  it("allows the next attempt after a retryable failed attempt", async () => {
+    const statePath = await createTempStatePath();
+
+    await createWorkflowRun(statePath, {
+      runId: "run-retry-002",
+      workflowId: "operator-review",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z"
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "run-retry-002",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:01.500Z"
+    });
+
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.failed",
+      runId: "run-retry-002",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:02.000Z",
+      retry: {
+        retryable: true,
+        nextAttemptAt: "2026-04-29T00:00:12.000Z"
+      }
+    });
+
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "run-retry-002",
+      stepId: "collect-input",
+      attempt: 2,
+      occurredAt: "2026-04-29T00:00:12.000Z"
+    });
+
+    const state = await readWorkflowRunState(statePath);
+
+    expect(state.stepAttempts["collect-input"]).toMatchObject([
+      { attempt: 1, status: "retryable-failed" },
+      { attempt: 2, status: "running" }
+    ]);
+  });
+
+  it.each([
+    {
+      event: {
+        type: "step.attempt.completed" as const,
+        occurredAt: "2026-04-29T00:00:02.000Z"
+      },
+      expectedStatus: "succeeded"
+    },
+    {
+      event: {
+        type: "step.attempt.failed" as const,
+        occurredAt: "2026-04-29T00:00:02.000Z",
+        retry: { retryable: false }
+      },
+      expectedStatus: "failed"
+    }
+  ])(
+    "fails closed when a new attempt follows a $expectedStatus attempt",
+    async ({ event, expectedStatus }) => {
+      const statePath = await createTempStatePath();
+
+      await createWorkflowRun(statePath, {
+        runId: "run-retry-003",
+        workflowId: "operator-review",
+        workflowVersion: "flow.workflow.v1",
+        trigger: {
+          type: "manual",
+          receivedAt: "2026-04-29T00:00:00.000Z"
+        },
+        createdAt: "2026-04-29T00:00:01.000Z"
+      });
+
+      await appendWorkflowRunEvent(statePath, {
+        type: "step.attempt.started",
+        runId: "run-retry-003",
+        stepId: "collect-input",
+        attempt: 1,
+        occurredAt: "2026-04-29T00:00:01.500Z"
+      });
+
+      await appendWorkflowRunEvent(statePath, {
+        ...event,
+        runId: "run-retry-003",
+        stepId: "collect-input",
+        attempt: 1
+      });
+
+      const contentsBeforeRejectedAppend = await readFile(statePath, "utf8");
+
+      await expect(
+        appendWorkflowRunEvent(statePath, {
+          type: "step.attempt.started",
+          runId: "run-retry-003",
+          stepId: "collect-input",
+          attempt: 2,
+          occurredAt: "2026-04-29T00:00:03.000Z"
+        })
+      ).rejects.toThrow(
+        `workflow run state line 4: workflow step attempt collect-input#2: step.attempt.started cannot follow ${expectedStatus}`
+      );
+      await expect(readFile(statePath, "utf8")).resolves.toBe(contentsBeforeRejectedAppend);
+    }
+  );
+
   it("rejects appending events before the run is created", async () => {
     const statePath = await createTempStatePath();
 

--- a/test/workflow-run-state.test.ts
+++ b/test/workflow-run-state.test.ts
@@ -185,6 +185,14 @@ describe("workflow run JSONL state", () => {
     });
 
     await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "run-retry-001",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:01.500Z"
+    });
+
+    await appendWorkflowRunEvent(statePath, {
       type: "step.attempt.failed",
       runId: "run-retry-001",
       stepId: "collect-input",
@@ -202,6 +210,7 @@ describe("workflow run JSONL state", () => {
     expect(state.stepAttempts["collect-input"]).toEqual([
       {
         attempt: 1,
+        startedAt: "2026-04-29T00:00:01.500Z",
         failedAt: "2026-04-29T00:00:02.000Z",
         retry: {
           retryable: true,
@@ -211,5 +220,148 @@ describe("workflow run JSONL state", () => {
         status: "retryable-failed"
       }
     ]);
+  });
+
+  it("rejects appending events before the run is created", async () => {
+    const statePath = await createTempStatePath();
+
+    await expect(
+      appendWorkflowRunEvent(statePath, {
+        type: "step.attempt.started",
+        runId: "run-001",
+        stepId: "collect-input",
+        attempt: 1,
+        occurredAt: "2026-04-29T00:00:02.000Z"
+      })
+    ).rejects.toThrow(
+      "appendWorkflowRunEvent requires an existing workflow run state file; call createWorkflowRun before appendWorkflowRunEvent"
+    );
+  });
+
+  it("fails closed when records appear after run completion", async () => {
+    const statePath = await createTempStatePath();
+    await writeFile(
+      statePath,
+      [
+        JSON.stringify({
+          type: "run.created",
+          runId: "run-001",
+          workflowId: "operator-review",
+          workflowVersion: "flow.workflow.v1",
+          trigger: { type: "manual", receivedAt: "2026-04-29T00:00:00.000Z" },
+          occurredAt: "2026-04-29T00:00:01.000Z"
+        }),
+        JSON.stringify({
+          type: "run.completed",
+          runId: "run-001",
+          terminalState: "succeeded",
+          occurredAt: "2026-04-29T00:00:02.000Z"
+        }),
+        JSON.stringify({
+          type: "step.attempt.started",
+          runId: "run-001",
+          stepId: "collect-input",
+          attempt: 1,
+          occurredAt: "2026-04-29T00:00:03.000Z"
+        })
+      ].join("\n"),
+      "utf8"
+    );
+
+    await expect(readWorkflowRunState(statePath)).rejects.toThrow(
+      "workflow run state line 3: no records are allowed after run.completed"
+    );
+  });
+
+  it("fails closed on out-of-order step attempt transitions", async () => {
+    const statePath = await createTempStatePath();
+    await writeFile(
+      statePath,
+      [
+        JSON.stringify({
+          type: "run.created",
+          runId: "run-001",
+          workflowId: "operator-review",
+          workflowVersion: "flow.workflow.v1",
+          trigger: { type: "manual", receivedAt: "2026-04-29T00:00:00.000Z" },
+          occurredAt: "2026-04-29T00:00:01.000Z"
+        }),
+        JSON.stringify({
+          type: "step.attempt.completed",
+          runId: "run-001",
+          stepId: "collect-input",
+          attempt: 1,
+          occurredAt: "2026-04-29T00:00:02.000Z"
+        })
+      ].join("\n"),
+      "utf8"
+    );
+
+    await expect(readWorkflowRunState(statePath)).rejects.toThrow(
+      "workflow run state line 2: workflow step attempt collect-input#1: step.attempt.completed requires step.attempt.started first"
+    );
+  });
+
+  it("fails closed on duplicate terminal step attempt transitions", async () => {
+    const statePath = await createTempStatePath();
+    await writeFile(
+      statePath,
+      [
+        JSON.stringify({
+          type: "run.created",
+          runId: "run-001",
+          workflowId: "operator-review",
+          workflowVersion: "flow.workflow.v1",
+          trigger: { type: "manual", receivedAt: "2026-04-29T00:00:00.000Z" },
+          occurredAt: "2026-04-29T00:00:01.000Z"
+        }),
+        JSON.stringify({
+          type: "step.attempt.started",
+          runId: "run-001",
+          stepId: "collect-input",
+          attempt: 1,
+          occurredAt: "2026-04-29T00:00:02.000Z"
+        }),
+        JSON.stringify({
+          type: "step.attempt.completed",
+          runId: "run-001",
+          stepId: "collect-input",
+          attempt: 1,
+          occurredAt: "2026-04-29T00:00:03.000Z"
+        }),
+        JSON.stringify({
+          type: "step.attempt.failed",
+          runId: "run-001",
+          stepId: "collect-input",
+          attempt: 1,
+          occurredAt: "2026-04-29T00:00:04.000Z"
+        })
+      ].join("\n"),
+      "utf8"
+    );
+
+    await expect(readWorkflowRunState(statePath)).rejects.toThrow(
+      "workflow run state line 4: workflow step attempt collect-input#1: step.attempt.failed cannot follow succeeded"
+    );
+  });
+
+  it("rejects non-ISO timestamp strings", async () => {
+    const statePath = await createTempStatePath();
+    await writeFile(
+      statePath,
+      JSON.stringify({
+        type: "run.created",
+        runId: "run-001",
+        workflowId: "operator-review",
+        workflowVersion: "flow.workflow.v1",
+        trigger: { type: "manual", receivedAt: "Jan 15, 2024" },
+        occurredAt: "2026-04-29T00:00:01.000Z"
+      }),
+      "utf8"
+    );
+
+    await expect(readWorkflowRunState(statePath)).rejects.toThrow(
+      "workflow run state line 1: receivedAt must be an ISO timestamp string"
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add executor-neutral JSONL workflow run state events and read projection
- retain trigger context, idempotency metadata, retry metadata, step attempts, and terminal states
- fail closed on malformed JSONL records with line-scoped errors

## Verification
- npm run build
- npm test

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Append-only workflow run state: create runs, record events, and read reconstructed run state with per-step attempt history, timestamps, retry/idempotency metadata, and terminal statuses.

* **Documentation**
  * README adds a “Workflow Run JSONL State” section documenting public helper APIs and stored run model.

* **Tests**
  * New test suite validating lifecycle flows, sequencing rules, strict validation, error cases, and concurrent terminal append behavior.

* **Chores**
  * Development tooling type dependency updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->