### PR TITLE
FLOW-003: Implement sequential workflow runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,17 @@ Workflow run state can be persisted locally with append-only JSONL records via
 The model records trigger context, idempotency metadata, step attempts, retry
 metadata, timestamps, and explicit terminal states while remaining independent
 from Ensen-loop and external connector contracts.
+
+## Local Sequential Runner
+
+The Phase 1 local runner can execute a validated workflow definition through a
+neutral in-process step handler and persist progress to the JSONL state layer.
+It is intentionally independent from Ensen-loop and external executor
+connectors.
+
+Programmatic callers can use `runWorkflow`. The built CLI can run the canonical
+manual fixture after `npm run build`:
+
+```sh
+node dist/cli.js run fixtures/workflow-definitions/simple-manual.valid.json <state-jsonl-path> '{"requestId":"manual-001"}'
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@tommykammy/ensen-flow",
       "version": "0.0.0",
       "license": "MIT",
+      "bin": {
+        "ensen-flow": "dist/cli.js"
+      },
       "devDependencies": {
         "@types/node": "^22.19.17",
         "typescript": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "private": true,
   "license": "MIT",
+  "bin": {
+    "ensen-flow": "./dist/cli.js"
+  },
   "engines": {
     "node": ">=22"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+import { fileURLToPath } from "node:url";
+
+import { loadWorkflowDefinitionFile, runWorkflow } from "./index.js";
+
+const printUsage = (): void => {
+  console.error(
+    "Usage: node dist/cli.js run <workflow-definition.json> <state.jsonl> [trigger-context-json]"
+  );
+};
+
+export const runCli = async (argv: string[]): Promise<number> => {
+  const [command, definitionPath, statePath, triggerContextJson] = argv;
+
+  if (command !== "run" || definitionPath === undefined || statePath === undefined) {
+    printUsage();
+    return 2;
+  }
+
+  const triggerContext = parseTriggerContext(triggerContextJson);
+  const definition = await loadWorkflowDefinitionFile(definitionPath);
+  const state = await runWorkflow({
+    definition,
+    statePath,
+    triggerContext
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        runId: state.run.runId,
+        workflowId: state.run.workflowId,
+        status: state.run.status,
+        terminalState: state.run.terminalState,
+        statePath
+      },
+      null,
+      2
+    )
+  );
+
+  return 0;
+};
+
+const parseTriggerContext = (
+  triggerContextJson: string | undefined
+): Record<string, unknown> => {
+  if (triggerContextJson === undefined) {
+    return {};
+  }
+
+  const parsed = JSON.parse(triggerContextJson) as unknown;
+  if (!isRecord(parsed)) {
+    throw new Error("trigger context JSON must be an object");
+  }
+
+  return parsed;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  runCli(process.argv.slice(2))
+    .then((exitCode) => {
+      process.exitCode = exitCode;
+    })
+    .catch((error: unknown) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,11 @@ export {
   workflowDefinitionSchemaVersion
 } from "./workflow-definition.js";
 
+export {
+  loadWorkflowDefinitionFile,
+  runWorkflow
+} from "./workflow-runner.js";
+
 export type {
   IdempotencyKeyDefinition,
   RetryBackoffPolicy,
@@ -49,3 +54,9 @@ export type {
   WorkflowStep,
   WorkflowTrigger
 } from "./workflow-definition.js";
+
+export type {
+  RunWorkflowInput,
+  WorkflowStepHandler,
+  WorkflowStepHandlerInput
+} from "./workflow-runner.js";

--- a/src/workflow-runner.ts
+++ b/src/workflow-runner.ts
@@ -1,0 +1,322 @@
+import { readFile } from "node:fs/promises";
+
+import {
+  appendWorkflowRunEvent,
+  createWorkflowRun,
+  readWorkflowRunState
+} from "./workflow-run-state.js";
+import type {
+  WorkflowRunIdempotencyMetadata,
+  WorkflowRunState
+} from "./workflow-run-state.js";
+import {
+  validateWorkflowDefinition,
+  workflowDefinitionSchemaVersion
+} from "./workflow-definition.js";
+import type {
+  IdempotencyKeyDefinition,
+  RetryPolicy,
+  WorkflowDefinition,
+  WorkflowStep
+} from "./workflow-definition.js";
+
+export interface RunWorkflowInput {
+  definition: WorkflowDefinition;
+  statePath: string;
+  runId?: string;
+  triggerContext?: Record<string, unknown>;
+  now?: () => string;
+  stepHandler?: WorkflowStepHandler;
+}
+
+export interface WorkflowStepHandlerInput {
+  definition: WorkflowDefinition;
+  step: WorkflowStep;
+  attempt: number;
+  triggerContext: Record<string, unknown>;
+  runState: WorkflowRunState;
+}
+
+export type WorkflowStepHandler = (input: WorkflowStepHandlerInput) => Promise<void> | void;
+
+export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunState> => {
+  const validation = validateWorkflowDefinition(input.definition);
+  if (!validation.valid) {
+    const details = validation.errors
+      .map((error) => `${error.path}: ${error.message}`)
+      .join("; ");
+    throw new Error(`workflow definition is invalid: ${details}`);
+  }
+
+  const now = input.now ?? (() => new Date().toISOString());
+  const triggerContext = input.triggerContext ?? {};
+  const triggerIdempotencyKey = resolveIdempotencyKey(
+    input.definition.trigger.idempotencyKey,
+    input.definition,
+    undefined,
+    triggerContext
+  );
+  const runId =
+    input.runId ??
+    `${input.definition.id}-${triggerIdempotencyKey?.key ?? "local-run"}`;
+  const stepHandler = input.stepHandler ?? defaultWorkflowStepHandler;
+
+  const existingState = await readExistingRunState(input.statePath);
+  if (existingState !== undefined) {
+    assertExistingRunMatches(existingState, input.definition, runId, triggerIdempotencyKey);
+    if (existingState.run.terminalState !== undefined) {
+      return existingState;
+    }
+    throw new Error("workflow run state already exists but is not terminal; resume is out of scope");
+  }
+
+  await createWorkflowRun(input.statePath, {
+    runId,
+    workflowId: input.definition.id,
+    workflowVersion: workflowDefinitionSchemaVersion,
+    trigger: {
+      type: input.definition.trigger.type,
+      receivedAt: now(),
+      context: triggerContext,
+      idempotencyKey: triggerIdempotencyKey
+    },
+    createdAt: now()
+  });
+
+  const orderedSteps = orderSteps(input.definition.steps);
+
+  for (const step of orderedSteps) {
+    const retryPolicy = step.retry ?? { maxAttempts: 1, backoff: { strategy: "none" as const } };
+
+    for (let attempt = 1; attempt <= retryPolicy.maxAttempts; attempt += 1) {
+      await appendWorkflowRunEvent(input.statePath, {
+        type: "step.attempt.started",
+        runId,
+        stepId: step.id,
+        attempt,
+        occurredAt: now()
+      });
+
+      try {
+        await stepHandler({
+          definition: input.definition,
+          step,
+          attempt,
+          triggerContext,
+          runState: await readWorkflowRunState(input.statePath)
+        });
+
+        await appendWorkflowRunEvent(input.statePath, {
+          type: "step.attempt.completed",
+          runId,
+          stepId: step.id,
+          attempt,
+          occurredAt: now()
+        });
+        break;
+      } catch (error) {
+        const retryable = attempt < retryPolicy.maxAttempts;
+        const failedAt = now();
+        const nextAttemptAt = retryable
+          ? calculateNextAttemptAt(failedAt, retryPolicy, attempt)
+          : undefined;
+        await appendWorkflowRunEvent(input.statePath, {
+          type: "step.attempt.failed",
+          runId,
+          stepId: step.id,
+          attempt,
+          occurredAt: failedAt,
+          retry: {
+            retryable,
+            ...(nextAttemptAt === undefined ? {} : { nextAttemptAt }),
+            reason: errorReason(error)
+          }
+        });
+
+        if (!retryable) {
+          await appendWorkflowRunEvent(input.statePath, {
+            type: "run.completed",
+            runId,
+            terminalState: "failed",
+            occurredAt: now()
+          });
+          return readWorkflowRunState(input.statePath);
+        }
+      }
+    }
+  }
+
+  await appendWorkflowRunEvent(input.statePath, {
+    type: "run.completed",
+    runId,
+    terminalState: "succeeded",
+    occurredAt: now()
+  });
+
+  return readWorkflowRunState(input.statePath);
+};
+
+export const loadWorkflowDefinitionFile = async (
+  definitionPath: string
+): Promise<WorkflowDefinition> => {
+  const parsed = JSON.parse(await readFile(definitionPath, "utf8")) as unknown;
+  const validation = validateWorkflowDefinition(parsed);
+  if (!validation.valid) {
+    const details = validation.errors
+      .map((error) => `${error.path}: ${error.message}`)
+      .join("; ");
+    throw new Error(`workflow definition is invalid: ${details}`);
+  }
+
+  return parsed as WorkflowDefinition;
+};
+
+const defaultWorkflowStepHandler: WorkflowStepHandler = ({ step }) => {
+  if (step.action.name.trim() === "") {
+    throw new Error("step action name must be configured");
+  }
+};
+
+const readExistingRunState = async (statePath: string): Promise<WorkflowRunState | undefined> => {
+  try {
+    return await readWorkflowRunState(statePath);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  }
+};
+
+const assertExistingRunMatches = (
+  existingState: WorkflowRunState,
+  definition: WorkflowDefinition,
+  runId: string,
+  triggerIdempotencyKey: WorkflowRunIdempotencyMetadata | undefined
+): void => {
+  if (existingState.run.workflowId !== definition.id) {
+    throw new Error("existing workflow run state has a different workflowId");
+  }
+
+  const existingKey = existingState.run.trigger.idempotencyKey;
+  if (JSON.stringify(existingKey) !== JSON.stringify(triggerIdempotencyKey)) {
+    throw new Error("existing workflow run state has a different idempotency key");
+  }
+
+  if (existingState.run.runId !== runId) {
+    throw new Error("existing workflow run state has a different runId");
+  }
+};
+
+const orderSteps = (steps: WorkflowStep[]): WorkflowStep[] => {
+  const remaining = new Map(steps.map((step) => [step.id, step]));
+  const ordered: WorkflowStep[] = [];
+
+  while (remaining.size > 0) {
+    const ready = [...remaining.values()].find((step) =>
+      (step.dependsOn ?? []).every((dependency) =>
+        ordered.some((orderedStep) => orderedStep.id === dependency)
+      )
+    );
+
+    if (ready === undefined) {
+      throw new Error("workflow definition dependencies cannot be ordered");
+    }
+
+    ordered.push(ready);
+    remaining.delete(ready.id);
+  }
+
+  return ordered;
+};
+
+const resolveIdempotencyKey = (
+  definition: IdempotencyKeyDefinition | undefined,
+  workflow: WorkflowDefinition,
+  step: WorkflowStep | undefined,
+  triggerContext: Record<string, unknown>
+): WorkflowRunIdempotencyMetadata | undefined => {
+  if (definition === undefined) {
+    return undefined;
+  }
+
+  if (definition.source === "static") {
+    return { source: "static", key: definition.value };
+  }
+
+  if (definition.source === "input") {
+    const value = triggerContext[definition.field];
+    if (value === undefined || value === null || value === "") {
+      if (definition.required !== false) {
+        throw new Error(`required idempotency input ${definition.field} is missing`);
+      }
+      return undefined;
+    }
+
+    if (typeof value !== "string" && typeof value !== "number" && typeof value !== "boolean") {
+      throw new Error(`idempotency input ${definition.field} must be a scalar value`);
+    }
+
+    return { source: "input", key: String(value) };
+  }
+
+  return {
+    source: "workflow",
+    key: definition.template
+      .replaceAll("{workflow.id}", workflow.id)
+      .replaceAll("{step.id}", step?.id ?? "")
+      .replaceAll("{trigger.type}", workflow.trigger.type)
+      .replaceAll("{trigger.idempotencyKey}", resolveTriggerKey(triggerContext))
+  };
+};
+
+const resolveTriggerKey = (triggerContext: Record<string, unknown>): string => {
+  const requestId = triggerContext.requestId;
+  if (typeof requestId === "string" || typeof requestId === "number") {
+    return String(requestId);
+  }
+
+  return "";
+};
+
+const calculateNextAttemptAt = (
+  failedAt: string,
+  retryPolicy: RetryPolicy,
+  attempt: number
+): string | undefined => {
+  const failedAtTime = Date.parse(failedAt);
+  if (!Number.isFinite(failedAtTime)) {
+    return undefined;
+  }
+
+  const backoff = retryPolicy.backoff;
+  if (backoff.strategy === "none") {
+    return failedAt;
+  }
+
+  if (backoff.strategy === "fixed") {
+    return new Date(failedAtTime + backoff.delayMs).toISOString();
+  }
+
+  const delay = Math.min(
+    backoff.initialDelayMs * 2 ** Math.max(0, attempt - 1),
+    backoff.maxDelayMs
+  );
+  return new Date(failedAtTime + delay).toISOString();
+};
+
+const errorReason = (error: unknown): string => {
+  if (error instanceof Error && error.message.trim() !== "") {
+    return error.message;
+  }
+
+  if (typeof error === "string" && error.trim() !== "") {
+    return error;
+  }
+
+  return "step handler failed";
+};
+
+const isNodeError = (error: unknown): error is NodeJS.ErrnoException =>
+  error instanceof Error && "code" in error;

--- a/test/workflow-runner.test.ts
+++ b/test/workflow-runner.test.ts
@@ -1,0 +1,225 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readWorkflowRunState, runWorkflow } from "../src/index.js";
+import type { WorkflowDefinition } from "../src/index.js";
+
+const tempRoots: string[] = [];
+
+const readWorkflowFixture = (name: string): WorkflowDefinition =>
+  JSON.parse(
+    readFileSync(join(process.cwd(), "fixtures", "workflow-definitions", name), "utf8")
+  ) as WorkflowDefinition;
+
+const createTempStatePath = async () => {
+  const root = await mkdtemp(join(tmpdir(), "ensen-flow-runner-"));
+  tempRoots.push(root);
+  return join(root, "runs", "manual-run.jsonl");
+};
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
+  );
+});
+
+describe("sequential workflow runner", () => {
+  it("runs the simple manual workflow fixture to completion", async () => {
+    const definition = readWorkflowFixture("simple-manual.valid.json");
+    const statePath = await createTempStatePath();
+
+    const result = await runWorkflow({
+      definition,
+      statePath,
+      triggerContext: {
+        requestId: "manual-001"
+      },
+      now: (() => {
+        let index = 0;
+        const timestamps = [
+          "2026-04-29T00:00:00.000Z",
+          "2026-04-29T00:00:01.000Z",
+          "2026-04-29T00:00:02.000Z",
+          "2026-04-29T00:00:03.000Z",
+          "2026-04-29T00:00:04.000Z",
+          "2026-04-29T00:00:05.000Z"
+        ];
+        return () => timestamps[index++] ?? "2026-04-29T00:00:06.000Z";
+      })()
+    });
+
+    expect(result.run.status).toBe("succeeded");
+    expect(result.run.trigger.idempotencyKey).toEqual({
+      source: "input",
+      key: "manual-001"
+    });
+
+    const persisted = await readWorkflowRunState(statePath);
+    expect(persisted.events.map((event) => event.type)).toEqual([
+      "run.created",
+      "step.attempt.started",
+      "step.attempt.completed",
+      "step.attempt.started",
+      "step.attempt.completed",
+      "run.completed"
+    ]);
+    expect(Object.keys(persisted.stepAttempts)).toEqual([
+      "collect-input",
+      "notify-operator"
+    ]);
+  });
+
+  it("records retryable failures and retries according to the step policy", async () => {
+    const definition = readWorkflowFixture("simple-manual.valid.json");
+    const statePath = await createTempStatePath();
+    let calls = 0;
+
+    const result = await runWorkflow({
+      definition,
+      statePath,
+      triggerContext: {
+        requestId: "manual-retry"
+      },
+      now: (() => {
+        let index = 0;
+        const timestamps = [
+          "2026-04-29T00:01:00.000Z",
+          "2026-04-29T00:01:01.000Z",
+          "2026-04-29T00:01:02.000Z",
+          "2026-04-29T00:01:03.000Z",
+          "2026-04-29T00:01:04.000Z",
+          "2026-04-29T00:01:05.000Z",
+          "2026-04-29T00:01:06.000Z",
+          "2026-04-29T00:01:07.000Z",
+          "2026-04-29T00:01:08.000Z"
+        ];
+        return () => timestamps[index++] ?? "2026-04-29T00:01:09.000Z";
+      })(),
+      stepHandler: ({ step }) => {
+        if (step.id === "notify-operator" && calls === 0) {
+          calls += 1;
+          throw new Error("operator notice transport unavailable");
+        }
+      }
+    });
+
+    expect(result.run.status).toBe("succeeded");
+    expect(result.stepAttempts["notify-operator"]).toEqual([
+      {
+        attempt: 1,
+        startedAt: "2026-04-29T00:01:04.000Z",
+        failedAt: "2026-04-29T00:01:05.000Z",
+        retry: {
+          retryable: true,
+          nextAttemptAt: "2026-04-29T00:01:06.000Z",
+          reason: "operator notice transport unavailable"
+        },
+        status: "retryable-failed"
+      },
+      {
+        attempt: 2,
+        startedAt: "2026-04-29T00:01:06.000Z",
+        completedAt: "2026-04-29T00:01:07.000Z",
+        retry: undefined,
+        status: "succeeded"
+      }
+    ]);
+  });
+
+  it("records failed steps with diagnostic retry metadata", async () => {
+    const definition = readWorkflowFixture("simple-manual.valid.json");
+    const statePath = await createTempStatePath();
+
+    const result = await runWorkflow({
+      definition,
+      statePath,
+      triggerContext: {
+        requestId: "manual-failed"
+      },
+      now: (() => {
+        let index = 0;
+        const timestamps = [
+          "2026-04-29T00:02:00.000Z",
+          "2026-04-29T00:02:01.000Z",
+          "2026-04-29T00:02:02.000Z",
+          "2026-04-29T00:02:03.000Z",
+          "2026-04-29T00:02:04.000Z"
+        ];
+        return () => timestamps[index++] ?? "2026-04-29T00:02:05.000Z";
+      })(),
+      stepHandler: ({ step }) => {
+        if (step.id === "collect-input") {
+          throw new Error("manual input was incomplete");
+        }
+      }
+    });
+
+    expect(result.run.status).toBe("failed");
+    expect(result.stepAttempts["collect-input"]).toEqual([
+      {
+        attempt: 1,
+        startedAt: "2026-04-29T00:02:02.000Z",
+        failedAt: "2026-04-29T00:02:03.000Z",
+        retry: {
+          retryable: false,
+          nextAttemptAt: undefined,
+          reason: "manual input was incomplete"
+        },
+        status: "failed"
+      }
+    ]);
+  });
+
+  it("returns the existing terminal run when the idempotency key matches", async () => {
+    const definition = readWorkflowFixture("simple-manual.valid.json");
+    const statePath = await createTempStatePath();
+
+    const first = await runWorkflow({
+      definition,
+      statePath,
+      triggerContext: {
+        requestId: "manual-idempotent"
+      }
+    });
+    const second = await runWorkflow({
+      definition,
+      statePath,
+      triggerContext: {
+        requestId: "manual-idempotent"
+      }
+    });
+
+    expect(second).toEqual(first);
+    expect(second.run.trigger.idempotencyKey).toEqual({
+      source: "input",
+      key: "manual-idempotent"
+    });
+  });
+
+  it("fails closed when repeated execution changes the idempotency key", async () => {
+    const definition = readWorkflowFixture("simple-manual.valid.json");
+    const statePath = await createTempStatePath();
+
+    await runWorkflow({
+      definition,
+      statePath,
+      triggerContext: {
+        requestId: "manual-original"
+      }
+    });
+
+    await expect(
+      runWorkflow({
+        definition,
+        statePath,
+        triggerContext: {
+          requestId: "manual-drifted"
+        }
+      })
+    ).rejects.toThrow("existing workflow run state has a different idempotency key");
+  });
+});


### PR DESCRIPTION
## Summary
- add a Phase 1 sequential workflow runner that validates definitions and persists JSONL run/step progress
- add retry, failure diagnostic, and idempotent repeated-run behavior through focused tests
- expose a small built CLI entry point for local fixture verification

## Verification
- npm run build
- npm test
- node dist/cli.js run fixtures/workflow-definitions/simple-manual.valid.json .codex-supervisor/tmp/issue-5-cli-run.jsonl '{"requestId":"cli-manual-001"}'

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI executable (`ensen-flow`) for running workflows from the command line with trigger context support.
  * Introduced programmatic workflow execution API with state persistence and resumption capabilities.
  * Added configurable retry policies for workflow steps.

* **Documentation**
  * Updated README with Local Sequential Runner guidance and practical CLI usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->