### PR TITLE
FLOW-004 add neutral audit event writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ The model records trigger context, idempotency metadata, step attempts, retry
 metadata, timestamps, and explicit terminal states while remaining independent
 from Ensen-loop and external connector contracts.
 
+## Neutral Audit JSONL Events
+
+The local runner can also write append-only JSONL audit events when callers pass
+an `auditPath` to `runWorkflow`. These records use an internal neutral event
+shape for workflow start, step start, step completion, step failure, retry
+scheduling, and workflow completion or failure. Each record includes a stable
+event ID, timestamp, actor and source context, workflow and run references, and
+step references where applicable.
+
+This internal shape is intended to support a later mapping to EIP AuditEvent,
+but it does not claim EIP conformance and does not import Ensen-protocol runtime
+packages. Formal protocol mapping belongs to a later protocol or connector
+integration phase.
+
 ## Local Sequential Runner
 
 The Phase 1 local runner can execute a validated workflow definition through a

--- a/docs/workflow-definition.md
+++ b/docs/workflow-definition.md
@@ -26,6 +26,12 @@ persistence behavior, executor connector configuration, or real Slack, Teams,
 ERPNext, GitHub, or other connector behavior. Those concerns are deferred to
 later Phase 1 issues.
 
+Runner audit output is intentionally separate from the workflow definition
+schema. The Phase 1 runner writes an internal neutral JSONL audit shape for
+local lifecycle activity only; a formal mapping to EIP AuditEvent is deferred to
+a later protocol or connector integration phase and does not depend on
+Ensen-protocol runtime packages here.
+
 Approval and notification are represented only as neutral action concepts. A
 definition can name that a step requires an approval or notification action, but
 the schema does not bind that action to a provider, credential, channel, or

--- a/src/audit-event-writer.ts
+++ b/src/audit-event-writer.ts
@@ -78,6 +78,8 @@ export interface CreateLocalAuditEventWriterInput {
 }
 
 const DEFAULT_RUNNER_CONTEXT = "ensen-flow.local-runner";
+const NEUTRAL_AUDIT_ACTOR_TYPE = "system";
+const NEUTRAL_AUDIT_SOURCE_TYPE = "runner";
 const NEUTRAL_AUDIT_EVENT_TYPES = new Set<string>([
   "workflow.started",
   "step.started",
@@ -86,6 +88,12 @@ const NEUTRAL_AUDIT_EVENT_TYPES = new Set<string>([
   "step.retry.scheduled",
   "workflow.completed",
   "workflow.failed"
+]);
+const NEUTRAL_AUDIT_OUTCOME_STATUSES = new Set<string>([
+  "succeeded",
+  "failed",
+  "canceled",
+  "retryable-failed"
 ]);
 const ISO_UTC_MILLIS_TIMESTAMP_PATTERN =
   /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})\.\d{3}Z$/;
@@ -156,7 +164,13 @@ const validateNeutralAuditEvent = (event: NeutralAuditEvent): void => {
 
   requireNonEmptyString(event.id, "audit event id");
   requireIsoTimestamp(event.occurredAt, "audit event occurredAt");
+  if (event.actor.type !== NEUTRAL_AUDIT_ACTOR_TYPE) {
+    throw new Error("audit event actor.type must be system");
+  }
   requireNonEmptyString(event.actor.id, "audit event actor.id");
+  if (event.source.type !== NEUTRAL_AUDIT_SOURCE_TYPE) {
+    throw new Error("audit event source.type must be runner");
+  }
   requireNonEmptyString(event.source.id, "audit event source.id");
   requireNonEmptyString(event.workflow.id, "audit event workflow.id");
   requireNonEmptyString(event.workflow.version, "audit event workflow.version");
@@ -174,6 +188,12 @@ const validateNeutralAuditEvent = (event: NeutralAuditEvent): void => {
     if (event.retry.nextAttemptAt !== undefined) {
       requireIsoTimestamp(event.retry.nextAttemptAt, "audit event retry.nextAttemptAt");
     }
+  }
+
+  if (event.outcome !== undefined && !NEUTRAL_AUDIT_OUTCOME_STATUSES.has(event.outcome.status)) {
+    throw new Error(
+      "audit event outcome.status must be succeeded, failed, canceled, or retryable-failed"
+    );
   }
 
   if (event.outcome?.reason !== undefined) {
@@ -195,7 +215,7 @@ const requireIsoTimestamp = (value: string, label: string): void => {
 
 const isStrictUtcMillisTimestamp = (value: string): boolean => {
   const match = ISO_UTC_MILLIS_TIMESTAMP_PATTERN.exec(value);
-  if (match === null || Number.isNaN(Date.parse(value))) {
+  if (match === null) {
     return false;
   }
 
@@ -209,5 +229,21 @@ const isStrictUtcMillisTimestamp = (value: string): boolean => {
     return false;
   }
 
-  return day >= 1 && day <= new Date(Date.UTC(year, month, 0)).getUTCDate();
+  const isLeapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [
+    31,
+    isLeapYear ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31
+  ];
+
+  return day >= 1 && day <= daysInMonth[month - 1];
 };

--- a/src/audit-event-writer.ts
+++ b/src/audit-event-writer.ts
@@ -91,11 +91,15 @@ export const createLocalAuditEventWriter = (
       sequence += 1;
       const event: NeutralAuditEvent = {
         id: createAuditEventId(input.run.id, sequence),
+        type: eventInput.type,
+        occurredAt: eventInput.occurredAt,
         actor,
         source,
         workflow: input.workflow,
         run: input.run,
-        ...eventInput
+        ...(eventInput.step === undefined ? {} : { step: eventInput.step }),
+        ...(eventInput.retry === undefined ? {} : { retry: eventInput.retry }),
+        ...(eventInput.outcome === undefined ? {} : { outcome: eventInput.outcome })
       };
 
       validateNeutralAuditEvent(event);

--- a/src/audit-event-writer.ts
+++ b/src/audit-event-writer.ts
@@ -1,0 +1,158 @@
+import { mkdir, open } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import type { WorkflowRunTerminalState } from "./workflow-run-state.js";
+
+export type NeutralAuditEventType =
+  | "workflow.started"
+  | "step.started"
+  | "step.completed"
+  | "step.failed"
+  | "step.retry.scheduled"
+  | "workflow.completed"
+  | "workflow.failed";
+
+export interface NeutralAuditActorContext {
+  type: "system";
+  id: string;
+}
+
+export interface NeutralAuditSourceContext {
+  type: "runner";
+  id: string;
+}
+
+export interface NeutralAuditWorkflowReference {
+  id: string;
+  version: string;
+}
+
+export interface NeutralAuditRunReference {
+  id: string;
+}
+
+export interface NeutralAuditStepReference {
+  id: string;
+  attempt: number;
+}
+
+export interface NeutralAuditRetryContext {
+  retryable: boolean;
+  reason: string;
+  nextAttemptAt?: string;
+}
+
+export interface NeutralAuditOutcomeContext {
+  status: WorkflowRunTerminalState | "succeeded" | "failed";
+  reason?: string;
+}
+
+export interface NeutralAuditEvent {
+  id: string;
+  type: NeutralAuditEventType;
+  occurredAt: string;
+  actor: NeutralAuditActorContext;
+  source: NeutralAuditSourceContext;
+  workflow: NeutralAuditWorkflowReference;
+  run: NeutralAuditRunReference;
+  step?: NeutralAuditStepReference;
+  retry?: NeutralAuditRetryContext;
+  outcome?: NeutralAuditOutcomeContext;
+}
+
+export interface NeutralAuditEventWriter {
+  write(event: CreateNeutralAuditEventInput): Promise<void>;
+}
+
+export type CreateNeutralAuditEventInput = Omit<
+  NeutralAuditEvent,
+  "id" | "actor" | "source" | "workflow" | "run"
+>;
+
+export interface CreateLocalAuditEventWriterInput {
+  auditPath: string;
+  workflow: NeutralAuditWorkflowReference;
+  run: NeutralAuditRunReference;
+  actor?: NeutralAuditActorContext;
+  source?: NeutralAuditSourceContext;
+}
+
+const DEFAULT_RUNNER_CONTEXT = "ensen-flow.local-runner";
+
+export const createLocalAuditEventWriter = (
+  input: CreateLocalAuditEventWriterInput
+): NeutralAuditEventWriter => {
+  let sequence = 0;
+  const actor = input.actor ?? { type: "system" as const, id: DEFAULT_RUNNER_CONTEXT };
+  const source = input.source ?? { type: "runner" as const, id: DEFAULT_RUNNER_CONTEXT };
+
+  return {
+    async write(eventInput) {
+      sequence += 1;
+      const event: NeutralAuditEvent = {
+        id: createAuditEventId(input.run.id, sequence),
+        actor,
+        source,
+        workflow: input.workflow,
+        run: input.run,
+        ...eventInput
+      };
+
+      validateNeutralAuditEvent(event);
+      await appendAuditEvent(input.auditPath, event);
+    }
+  };
+};
+
+const createAuditEventId = (runId: string, sequence: number): string =>
+  `audit.${runId}.${String(sequence).padStart(6, "0")}`;
+
+const appendAuditEvent = async (auditPath: string, event: NeutralAuditEvent): Promise<void> => {
+  await mkdir(dirname(auditPath), { recursive: true });
+  const auditFile = await open(auditPath, "a");
+  try {
+    await auditFile.writeFile(`${JSON.stringify(event)}\n`, "utf8");
+  } finally {
+    await auditFile.close();
+  }
+};
+
+const validateNeutralAuditEvent = (event: NeutralAuditEvent): void => {
+  requireNonEmptyString(event.id, "audit event id");
+  requireIsoTimestamp(event.occurredAt, "audit event occurredAt");
+  requireNonEmptyString(event.actor.id, "audit event actor.id");
+  requireNonEmptyString(event.source.id, "audit event source.id");
+  requireNonEmptyString(event.workflow.id, "audit event workflow.id");
+  requireNonEmptyString(event.workflow.version, "audit event workflow.version");
+  requireNonEmptyString(event.run.id, "audit event run.id");
+
+  if (event.step !== undefined) {
+    requireNonEmptyString(event.step.id, "audit event step.id");
+    if (!Number.isInteger(event.step.attempt) || event.step.attempt < 1) {
+      throw new Error("audit event step.attempt must be a positive integer");
+    }
+  }
+
+  if (event.retry !== undefined) {
+    requireNonEmptyString(event.retry.reason, "audit event retry.reason");
+    if (event.retry.nextAttemptAt !== undefined) {
+      requireIsoTimestamp(event.retry.nextAttemptAt, "audit event retry.nextAttemptAt");
+    }
+  }
+
+  if (event.outcome?.reason !== undefined) {
+    requireNonEmptyString(event.outcome.reason, "audit event outcome.reason");
+  }
+};
+
+const requireNonEmptyString = (value: string, label: string): void => {
+  if (value.trim() === "") {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+};
+
+const requireIsoTimestamp = (value: string, label: string): void => {
+  if (Number.isNaN(Date.parse(value))) {
+    throw new Error(`${label} must be an ISO timestamp string`);
+  }
+};

--- a/src/audit-event-writer.ts
+++ b/src/audit-event-writer.ts
@@ -78,32 +78,60 @@ export interface CreateLocalAuditEventWriterInput {
 }
 
 const DEFAULT_RUNNER_CONTEXT = "ensen-flow.local-runner";
+const NEUTRAL_AUDIT_EVENT_TYPES = new Set<string>([
+  "workflow.started",
+  "step.started",
+  "step.completed",
+  "step.failed",
+  "step.retry.scheduled",
+  "workflow.completed",
+  "workflow.failed"
+]);
+const ISO_UTC_MILLIS_TIMESTAMP_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})\.\d{3}Z$/;
 
 export const createLocalAuditEventWriter = (
   input: CreateLocalAuditEventWriterInput
 ): NeutralAuditEventWriter => {
   let sequence = 0;
-  const actor = input.actor ?? { type: "system" as const, id: DEFAULT_RUNNER_CONTEXT };
-  const source = input.source ?? { type: "runner" as const, id: DEFAULT_RUNNER_CONTEXT };
+  const auditPath = input.auditPath;
+  const actor = Object.freeze(
+    input.actor === undefined
+      ? { type: "system" as const, id: DEFAULT_RUNNER_CONTEXT }
+      : { ...input.actor }
+  );
+  const source = Object.freeze(
+    input.source === undefined
+      ? { type: "runner" as const, id: DEFAULT_RUNNER_CONTEXT }
+      : { ...input.source }
+  );
+  const workflow = Object.freeze({ ...input.workflow });
+  const run = Object.freeze({ ...input.run });
 
   return {
     async write(eventInput) {
       sequence += 1;
+      const step =
+        eventInput.step === undefined ? undefined : Object.freeze({ ...eventInput.step });
+      const retry =
+        eventInput.retry === undefined ? undefined : Object.freeze({ ...eventInput.retry });
+      const outcome =
+        eventInput.outcome === undefined ? undefined : Object.freeze({ ...eventInput.outcome });
       const event: NeutralAuditEvent = {
-        id: createAuditEventId(input.run.id, sequence),
+        id: createAuditEventId(run.id, sequence),
         type: eventInput.type,
         occurredAt: eventInput.occurredAt,
         actor,
         source,
-        workflow: input.workflow,
-        run: input.run,
-        ...(eventInput.step === undefined ? {} : { step: eventInput.step }),
-        ...(eventInput.retry === undefined ? {} : { retry: eventInput.retry }),
-        ...(eventInput.outcome === undefined ? {} : { outcome: eventInput.outcome })
+        workflow,
+        run,
+        ...(step === undefined ? {} : { step }),
+        ...(retry === undefined ? {} : { retry }),
+        ...(outcome === undefined ? {} : { outcome })
       };
 
       validateNeutralAuditEvent(event);
-      await appendAuditEvent(input.auditPath, event);
+      await appendAuditEvent(auditPath, event);
     }
   };
 };
@@ -122,6 +150,10 @@ const appendAuditEvent = async (auditPath: string, event: NeutralAuditEvent): Pr
 };
 
 const validateNeutralAuditEvent = (event: NeutralAuditEvent): void => {
+  if (!NEUTRAL_AUDIT_EVENT_TYPES.has(event.type)) {
+    throw new Error("audit event type is invalid");
+  }
+
   requireNonEmptyString(event.id, "audit event id");
   requireIsoTimestamp(event.occurredAt, "audit event occurredAt");
   requireNonEmptyString(event.actor.id, "audit event actor.id");
@@ -156,7 +188,26 @@ const requireNonEmptyString = (value: string, label: string): void => {
 };
 
 const requireIsoTimestamp = (value: string, label: string): void => {
-  if (Number.isNaN(Date.parse(value))) {
+  if (!isStrictUtcMillisTimestamp(value)) {
     throw new Error(`${label} must be an ISO timestamp string`);
   }
+};
+
+const isStrictUtcMillisTimestamp = (value: string): boolean => {
+  const match = ISO_UTC_MILLIS_TIMESTAMP_PATTERN.exec(value);
+  if (match === null || Number.isNaN(Date.parse(value))) {
+    return false;
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  if (month < 1 || month > 12 || hour > 23 || minute > 59 || second > 59) {
+    return false;
+  }
+
+  return day >= 1 && day <= new Date(Date.UTC(year, month, 0)).getUTCDate();
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ export {
   readWorkflowRunState
 } from "./workflow-run-state.js";
 
+export { createLocalAuditEventWriter } from "./audit-event-writer.js";
+
 export type {
   AppendableWorkflowRunEvent,
   CreateWorkflowRunInput,
@@ -60,3 +62,18 @@ export type {
   WorkflowStepHandler,
   WorkflowStepHandlerInput
 } from "./workflow-runner.js";
+
+export type {
+  CreateLocalAuditEventWriterInput,
+  CreateNeutralAuditEventInput,
+  NeutralAuditActorContext,
+  NeutralAuditEvent,
+  NeutralAuditEventType,
+  NeutralAuditEventWriter,
+  NeutralAuditOutcomeContext,
+  NeutralAuditRetryContext,
+  NeutralAuditRunReference,
+  NeutralAuditSourceContext,
+  NeutralAuditStepReference,
+  NeutralAuditWorkflowReference
+} from "./audit-event-writer.js";

--- a/src/workflow-runner.ts
+++ b/src/workflow-runner.ts
@@ -5,6 +5,8 @@ import {
   createWorkflowRun,
   readWorkflowRunState
 } from "./workflow-run-state.js";
+import { createLocalAuditEventWriter } from "./audit-event-writer.js";
+import type { NeutralAuditEventWriter } from "./audit-event-writer.js";
 import type {
   WorkflowRunIdempotencyMetadata,
   WorkflowRunState
@@ -23,6 +25,7 @@ import type {
 export interface RunWorkflowInput {
   definition: WorkflowDefinition;
   statePath: string;
+  auditPath?: string;
   runId?: string;
   triggerContext?: Record<string, unknown>;
   now?: () => string;
@@ -60,6 +63,17 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
     input.runId ??
     `${input.definition.id}-${triggerIdempotencyKey?.key ?? "local-run"}`;
   const stepHandler = input.stepHandler ?? defaultWorkflowStepHandler;
+  const auditWriter =
+    input.auditPath === undefined
+      ? undefined
+      : createLocalAuditEventWriter({
+          auditPath: input.auditPath,
+          workflow: {
+            id: input.definition.id,
+            version: workflowDefinitionSchemaVersion
+          },
+          run: { id: runId }
+        });
 
   const existingState = await readExistingRunState(input.statePath);
   if (existingState !== undefined) {
@@ -70,17 +84,23 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
     throw new Error("workflow run state already exists but is not terminal; resume is out of scope");
   }
 
+  const triggerReceivedAt = now();
+  const createdAt = now();
   await createWorkflowRun(input.statePath, {
     runId,
     workflowId: input.definition.id,
     workflowVersion: workflowDefinitionSchemaVersion,
     trigger: {
       type: input.definition.trigger.type,
-      receivedAt: now(),
+      receivedAt: triggerReceivedAt,
       context: triggerContext,
       idempotencyKey: triggerIdempotencyKey
     },
-    createdAt: now()
+    createdAt
+  });
+  await auditWriter?.write({
+    type: "workflow.started",
+    occurredAt: createdAt
   });
 
   const orderedSteps = orderSteps(input.definition.steps);
@@ -89,12 +109,19 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
     const retryPolicy = step.retry ?? { maxAttempts: 1, backoff: { strategy: "none" as const } };
 
     for (let attempt = 1; attempt <= retryPolicy.maxAttempts; attempt += 1) {
+      const startedAt = now();
       await appendWorkflowRunEvent(input.statePath, {
         type: "step.attempt.started",
         runId,
         stepId: step.id,
         attempt,
-        occurredAt: now()
+        occurredAt: startedAt
+      });
+      await writeStepAuditEvent(auditWriter, {
+        type: "step.started",
+        occurredAt: startedAt,
+        stepId: step.id,
+        attempt
       });
 
       try {
@@ -106,12 +133,20 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
           runState: await readWorkflowRunState(input.statePath)
         });
 
+        const completedAt = now();
         await appendWorkflowRunEvent(input.statePath, {
           type: "step.attempt.completed",
           runId,
           stepId: step.id,
           attempt,
-          occurredAt: now()
+          occurredAt: completedAt
+        });
+        await writeStepAuditEvent(auditWriter, {
+          type: "step.completed",
+          occurredAt: completedAt,
+          stepId: step.id,
+          attempt,
+          outcome: { status: "succeeded" }
         });
         break;
       } catch (error) {
@@ -132,25 +167,61 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
             reason: errorReason(error)
           }
         });
+        await writeStepAuditEvent(auditWriter, {
+          type: "step.failed",
+          occurredAt: failedAt,
+          stepId: step.id,
+          attempt,
+          retry: {
+            retryable,
+            ...(nextAttemptAt === undefined ? {} : { nextAttemptAt }),
+            reason: errorReason(error)
+          },
+          outcome: { status: "failed", reason: errorReason(error) }
+        });
 
         if (!retryable) {
+          const completedAt = now();
           await appendWorkflowRunEvent(input.statePath, {
             type: "run.completed",
             runId,
             terminalState: "failed",
-            occurredAt: now()
+            occurredAt: completedAt
+          });
+          await auditWriter?.write({
+            type: "workflow.failed",
+            occurredAt: completedAt,
+            outcome: { status: "failed", reason: errorReason(error) }
           });
           return readWorkflowRunState(input.statePath);
         }
+
+        await writeStepAuditEvent(auditWriter, {
+          type: "step.retry.scheduled",
+          occurredAt: failedAt,
+          stepId: step.id,
+          attempt,
+          retry: {
+            retryable,
+            ...(nextAttemptAt === undefined ? {} : { nextAttemptAt }),
+            reason: errorReason(error)
+          }
+        });
       }
     }
   }
 
+  const completedAt = now();
   await appendWorkflowRunEvent(input.statePath, {
     type: "run.completed",
     runId,
     terminalState: "succeeded",
-    occurredAt: now()
+    occurredAt: completedAt
+  });
+  await auditWriter?.write({
+    type: "workflow.completed",
+    occurredAt: completedAt,
+    outcome: { status: "succeeded" }
   });
 
   return readWorkflowRunState(input.statePath);
@@ -316,6 +387,38 @@ const errorReason = (error: unknown): string => {
   }
 
   return "step handler failed";
+};
+
+interface StepAuditInput {
+  type: "step.started" | "step.completed" | "step.failed" | "step.retry.scheduled";
+  occurredAt: string;
+  stepId: string;
+  attempt: number;
+  retry?: {
+    retryable: boolean;
+    reason: string;
+    nextAttemptAt?: string;
+  };
+  outcome?: {
+    status: "succeeded" | "failed";
+    reason?: string;
+  };
+}
+
+const writeStepAuditEvent = async (
+  auditWriter: NeutralAuditEventWriter | undefined,
+  input: StepAuditInput
+): Promise<void> => {
+  await auditWriter?.write({
+    type: input.type,
+    occurredAt: input.occurredAt,
+    step: {
+      id: input.stepId,
+      attempt: input.attempt
+    },
+    ...(input.retry === undefined ? {} : { retry: input.retry }),
+    ...(input.outcome === undefined ? {} : { outcome: input.outcome })
+  });
 };
 
 const isNodeError = (error: unknown): error is NodeJS.ErrnoException =>

--- a/test/audit-event-writer.test.ts
+++ b/test/audit-event-writer.test.ts
@@ -1,0 +1,61 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createLocalAuditEventWriter } from "../src/index.js";
+import type { CreateNeutralAuditEventInput } from "../src/index.js";
+
+const tempRoots: string[] = [];
+
+const createTempAuditPath = async () => {
+  const root = await mkdtemp(join(tmpdir(), "ensen-flow-audit-writer-"));
+  tempRoots.push(root);
+  return join(root, "audit", "manual-run.audit.jsonl");
+};
+
+const readAuditEvent = async (auditPath: string): Promise<Record<string, unknown>> => {
+  const [line] = (await readFile(auditPath, "utf8")).trimEnd().split("\n");
+  return JSON.parse(line) as Record<string, unknown>;
+};
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
+  );
+});
+
+describe("neutral audit event writer", () => {
+  it("does not let runtime event input override trusted audit fields", async () => {
+    const auditPath = await createTempAuditPath();
+    const writer = createLocalAuditEventWriter({
+      auditPath,
+      workflow: { id: "trusted-workflow", version: "flow.workflow.v1" },
+      run: { id: "trusted-run" },
+      actor: { type: "system", id: "trusted-actor" },
+      source: { type: "runner", id: "trusted-source" }
+    });
+    const untrustedPayload = {
+      id: "attacker-id",
+      type: "workflow.started",
+      occurredAt: "2026-04-29T00:00:00.000Z",
+      actor: { type: "system", id: "attacker-actor" },
+      source: { type: "runner", id: "attacker-source" },
+      workflow: { id: "attacker-workflow", version: "flow.workflow.v0" },
+      run: { id: "attacker-run" }
+    } as unknown as CreateNeutralAuditEventInput;
+
+    await writer.write(untrustedPayload);
+
+    await expect(readAuditEvent(auditPath)).resolves.toMatchObject({
+      id: "audit.trusted-run.000001",
+      type: "workflow.started",
+      occurredAt: "2026-04-29T00:00:00.000Z",
+      actor: { type: "system", id: "trusted-actor" },
+      source: { type: "runner", id: "trusted-source" },
+      workflow: { id: "trusted-workflow", version: "flow.workflow.v1" },
+      run: { id: "trusted-run" }
+    });
+  });
+});

--- a/test/audit-event-writer.test.ts
+++ b/test/audit-event-writer.test.ts
@@ -27,6 +27,40 @@ afterEach(async () => {
 });
 
 describe("neutral audit event writer", () => {
+  it("freezes constructor context snapshots before later caller mutation", async () => {
+    const auditPath = await createTempAuditPath();
+    const workflow = { id: "trusted-workflow", version: "flow.workflow.v1" };
+    const run = { id: "trusted-run" };
+    const actor = { type: "system" as const, id: "trusted-actor" };
+    const source = { type: "runner" as const, id: "trusted-source" };
+    const writer = createLocalAuditEventWriter({
+      auditPath,
+      workflow,
+      run,
+      actor,
+      source
+    });
+
+    workflow.id = "mutated-workflow";
+    workflow.version = "flow.workflow.mutated";
+    run.id = "mutated-run";
+    actor.id = "mutated-actor";
+    source.id = "mutated-source";
+
+    await writer.write({
+      type: "workflow.started",
+      occurredAt: "2026-04-29T00:00:00.000Z"
+    });
+
+    await expect(readAuditEvent(auditPath)).resolves.toMatchObject({
+      id: "audit.trusted-run.000001",
+      actor: { type: "system", id: "trusted-actor" },
+      source: { type: "runner", id: "trusted-source" },
+      workflow: { id: "trusted-workflow", version: "flow.workflow.v1" },
+      run: { id: "trusted-run" }
+    });
+  });
+
   it("does not let runtime event input override trusted audit fields", async () => {
     const auditPath = await createTempAuditPath();
     const writer = createLocalAuditEventWriter({
@@ -57,5 +91,49 @@ describe("neutral audit event writer", () => {
       workflow: { id: "trusted-workflow", version: "flow.workflow.v1" },
       run: { id: "trusted-run" }
     });
+  });
+
+  it("rejects runtime event types outside the neutral audit union", async () => {
+    const auditPath = await createTempAuditPath();
+    const writer = createLocalAuditEventWriter({
+      auditPath,
+      workflow: { id: "trusted-workflow", version: "flow.workflow.v1" },
+      run: { id: "trusted-run" }
+    });
+
+    await expect(
+      writer.write({
+        type: "workflow.deleted",
+        occurredAt: "2026-04-29T00:00:00.000Z"
+      } as unknown as CreateNeutralAuditEventInput)
+    ).rejects.toThrow("audit event type is invalid");
+  });
+
+  it("rejects non-UTC or locale timestamp strings", async () => {
+    const auditPath = await createTempAuditPath();
+    const writer = createLocalAuditEventWriter({
+      auditPath,
+      workflow: { id: "trusted-workflow", version: "flow.workflow.v1" },
+      run: { id: "trusted-run" }
+    });
+
+    await expect(
+      writer.write({
+        type: "workflow.started",
+        occurredAt: "04/29/2026"
+      })
+    ).rejects.toThrow("audit event occurredAt must be an ISO timestamp string");
+    await expect(
+      writer.write({
+        type: "step.retry.scheduled",
+        occurredAt: "2026-04-29T00:00:00+09:00",
+        step: { id: "approval", attempt: 1 },
+        retry: {
+          retryable: true,
+          reason: "temporary failure",
+          nextAttemptAt: "2026-04-29T00:01:00+09:00"
+        }
+      })
+    ).rejects.toThrow("audit event occurredAt must be an ISO timestamp string");
   });
 });

--- a/test/audit-event-writer.test.ts
+++ b/test/audit-event-writer.test.ts
@@ -109,6 +109,59 @@ describe("neutral audit event writer", () => {
     ).rejects.toThrow("audit event type is invalid");
   });
 
+  it("rejects runtime actor and source types outside the neutral audit schema", async () => {
+    const invalidActorWriter = createLocalAuditEventWriter({
+      auditPath: await createTempAuditPath(),
+      workflow: { id: "trusted-workflow", version: "flow.workflow.v1" },
+      run: { id: "trusted-run" },
+      actor: { type: "operator", id: "trusted-actor" } as unknown as {
+        type: "system";
+        id: string;
+      }
+    });
+    const invalidSourceWriter = createLocalAuditEventWriter({
+      auditPath: await createTempAuditPath(),
+      workflow: { id: "trusted-workflow", version: "flow.workflow.v1" },
+      run: { id: "trusted-run" },
+      source: { type: "connector", id: "trusted-source" } as unknown as {
+        type: "runner";
+        id: string;
+      }
+    });
+
+    await expect(
+      invalidActorWriter.write({
+        type: "workflow.started",
+        occurredAt: "2026-04-29T00:00:00.000Z"
+      })
+    ).rejects.toThrow("audit event actor.type must be system");
+    await expect(
+      invalidSourceWriter.write({
+        type: "workflow.started",
+        occurredAt: "2026-04-29T00:00:00.000Z"
+      })
+    ).rejects.toThrow("audit event source.type must be runner");
+  });
+
+  it("rejects runtime outcome statuses outside the neutral audit schema", async () => {
+    const auditPath = await createTempAuditPath();
+    const writer = createLocalAuditEventWriter({
+      auditPath,
+      workflow: { id: "trusted-workflow", version: "flow.workflow.v1" },
+      run: { id: "trusted-run" }
+    });
+
+    await expect(
+      writer.write({
+        type: "workflow.completed",
+        occurredAt: "2026-04-29T00:00:00.000Z",
+        outcome: { status: "complete" }
+      } as unknown as CreateNeutralAuditEventInput)
+    ).rejects.toThrow(
+      "audit event outcome.status must be succeeded, failed, canceled, or retryable-failed"
+    );
+  });
+
   it("rejects non-UTC or locale timestamp strings", async () => {
     const auditPath = await createTempAuditPath();
     const writer = createLocalAuditEventWriter({
@@ -133,6 +186,28 @@ describe("neutral audit event writer", () => {
           reason: "temporary failure",
           nextAttemptAt: "2026-04-29T00:01:00+09:00"
         }
+      })
+    ).rejects.toThrow("audit event occurredAt must be an ISO timestamp string");
+  });
+
+  it("rejects invalid calendar days without relying on Date normalization", async () => {
+    const auditPath = await createTempAuditPath();
+    const writer = createLocalAuditEventWriter({
+      auditPath,
+      workflow: { id: "trusted-workflow", version: "flow.workflow.v1" },
+      run: { id: "trusted-run" }
+    });
+
+    await expect(
+      writer.write({
+        type: "workflow.started",
+        occurredAt: "2024-02-30T00:00:00.000Z"
+      })
+    ).rejects.toThrow("audit event occurredAt must be an ISO timestamp string");
+    await expect(
+      writer.write({
+        type: "workflow.started",
+        occurredAt: "0001-02-29T00:00:00.000Z"
       })
     ).rejects.toThrow("audit event occurredAt must be an ISO timestamp string");
   });

--- a/test/workflow-runner.test.ts
+++ b/test/workflow-runner.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -21,6 +21,18 @@ const createTempStatePath = async () => {
   return join(root, "runs", "manual-run.jsonl");
 };
 
+const createTempAuditPath = async () => {
+  const root = await mkdtemp(join(tmpdir(), "ensen-flow-audit-"));
+  tempRoots.push(root);
+  return join(root, "audit", "manual-run.audit.jsonl");
+};
+
+const readAuditEvents = async (auditPath: string): Promise<Array<Record<string, unknown>>> =>
+  (await readFile(auditPath, "utf8"))
+    .trimEnd()
+    .split("\n")
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+
 afterEach(async () => {
   await Promise.all(
     tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
@@ -28,6 +40,57 @@ afterEach(async () => {
 });
 
 describe("sequential workflow runner", () => {
+  it("emits deterministic neutral audit events for a successful run", async () => {
+    const definition = readWorkflowFixture("simple-manual.valid.json");
+    const statePath = await createTempStatePath();
+    const auditPath = await createTempAuditPath();
+
+    await runWorkflow({
+      definition,
+      statePath,
+      auditPath,
+      triggerContext: {
+        requestId: "manual-audit"
+      },
+      now: (() => {
+        let index = 0;
+        const timestamps = [
+          "2026-04-29T00:03:00.000Z",
+          "2026-04-29T00:03:01.000Z",
+          "2026-04-29T00:03:02.000Z",
+          "2026-04-29T00:03:03.000Z",
+          "2026-04-29T00:03:04.000Z",
+          "2026-04-29T00:03:05.000Z"
+        ];
+        return () => timestamps[index++] ?? "2026-04-29T00:03:06.000Z";
+      })()
+    });
+
+    const auditEvents = await readAuditEvents(auditPath);
+
+    expect(auditEvents.map((event) => event.type)).toEqual([
+      "workflow.started",
+      "step.started",
+      "step.completed",
+      "step.started",
+      "step.completed",
+      "workflow.completed"
+    ]);
+    expect(auditEvents[0]).toMatchObject({
+      id: "audit.local-manual-demo-manual-audit.000001",
+      occurredAt: "2026-04-29T00:03:01.000Z",
+      actor: { type: "system", id: "ensen-flow.local-runner" },
+      source: { type: "runner", id: "ensen-flow.local-runner" },
+      workflow: { id: "local-manual-demo", version: "flow.workflow.v1" },
+      run: { id: "local-manual-demo-manual-audit" }
+    });
+    expect(auditEvents[1]).toMatchObject({
+      id: "audit.local-manual-demo-manual-audit.000002",
+      occurredAt: "2026-04-29T00:03:02.000Z",
+      step: { id: "collect-input", attempt: 1 }
+    });
+  });
+
   it("runs the simple manual workflow fixture to completion", async () => {
     const definition = readWorkflowFixture("simple-manual.valid.json");
     const statePath = await createTempStatePath();
@@ -76,11 +139,13 @@ describe("sequential workflow runner", () => {
   it("records retryable failures and retries according to the step policy", async () => {
     const definition = readWorkflowFixture("simple-manual.valid.json");
     const statePath = await createTempStatePath();
+    const auditPath = await createTempAuditPath();
     let calls = 0;
 
     const result = await runWorkflow({
       definition,
       statePath,
+      auditPath,
       triggerContext: {
         requestId: "manual-retry"
       },
@@ -128,15 +193,40 @@ describe("sequential workflow runner", () => {
         status: "succeeded"
       }
     ]);
+
+    const auditEvents = await readAuditEvents(auditPath);
+    expect(auditEvents.map((event) => event.type)).toEqual([
+      "workflow.started",
+      "step.started",
+      "step.completed",
+      "step.started",
+      "step.failed",
+      "step.retry.scheduled",
+      "step.started",
+      "step.completed",
+      "workflow.completed"
+    ]);
+    expect(auditEvents[5]).toMatchObject({
+      type: "step.retry.scheduled",
+      occurredAt: "2026-04-29T00:01:05.000Z",
+      step: { id: "notify-operator", attempt: 1 },
+      retry: {
+        retryable: true,
+        nextAttemptAt: "2026-04-29T00:01:06.000Z",
+        reason: "operator notice transport unavailable"
+      }
+    });
   });
 
   it("records failed steps with diagnostic retry metadata", async () => {
     const definition = readWorkflowFixture("simple-manual.valid.json");
     const statePath = await createTempStatePath();
+    const auditPath = await createTempAuditPath();
 
     const result = await runWorkflow({
       definition,
       statePath,
+      auditPath,
       triggerContext: {
         requestId: "manual-failed"
       },
@@ -172,6 +262,22 @@ describe("sequential workflow runner", () => {
         status: "failed"
       }
     ]);
+
+    const auditEvents = await readAuditEvents(auditPath);
+    expect(auditEvents.map((event) => event.type)).toEqual([
+      "workflow.started",
+      "step.started",
+      "step.failed",
+      "workflow.failed"
+    ]);
+    expect(auditEvents[3]).toMatchObject({
+      type: "workflow.failed",
+      occurredAt: "2026-04-29T00:02:04.000Z",
+      outcome: {
+        status: "failed",
+        reason: "manual input was incomplete"
+      }
+    });
   });
 
   it("returns the existing terminal run when the idempotency key matches", async () => {


### PR DESCRIPTION
## Summary
- add an opt-in neutral JSONL audit writer for local runner lifecycle events
- emit deterministic audit records for workflow, step, retry, and terminal lifecycle activity
- document that EIP AuditEvent mapping is deferred to a later protocol or connector integration phase

## Verification
- npm run build
- npx vitest run test/workflow-runner.test.ts
- npm test

Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runner can emit append-only JSONL audit events when an audit path is provided, recording workflow and step lifecycle events with stable IDs and precise timestamps.

* **Documentation**
  * Added docs describing the neutral JSONL audit schema and clarifying it is decoupled from the workflow definition and protocol mapping is deferred.

* **Tests**
  * Added tests validating emitted audit event ordering, IDs, timestamp formats, and schema validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->