### PR TITLE
Fix optional trigger idempotency run creation

### DIFF
--- a/src/workflow-runner.ts
+++ b/src/workflow-runner.ts
@@ -94,7 +94,7 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
       type: input.definition.trigger.type,
       receivedAt: triggerReceivedAt,
       context: triggerContext,
-      idempotencyKey: triggerIdempotencyKey
+      ...(triggerIdempotencyKey === undefined ? {} : { idempotencyKey: triggerIdempotencyKey })
     },
     createdAt
   });

--- a/test/workflow-runner.test.ts
+++ b/test/workflow-runner.test.ts
@@ -136,6 +136,39 @@ describe("sequential workflow runner", () => {
     ]);
   });
 
+  it("runs a valid manual workflow without trigger idempotency metadata", async () => {
+    const definition = readWorkflowFixture("simple-manual.valid.json");
+    delete definition.trigger.idempotencyKey;
+    const statePath = await createTempStatePath();
+
+    const result = await runWorkflow({
+      definition,
+      statePath,
+      now: (() => {
+        let index = 0;
+        const timestamps = [
+          "2026-04-29T00:04:00.000Z",
+          "2026-04-29T00:04:01.000Z",
+          "2026-04-29T00:04:02.000Z",
+          "2026-04-29T00:04:03.000Z",
+          "2026-04-29T00:04:04.000Z",
+          "2026-04-29T00:04:05.000Z"
+        ];
+        return () => timestamps[index++] ?? "2026-04-29T00:04:06.000Z";
+      })()
+    });
+
+    expect(result.run.status).toBe("succeeded");
+    expect(result.run.trigger).toEqual({
+      type: "manual",
+      receivedAt: "2026-04-29T00:04:00.000Z",
+      context: {}
+    });
+
+    const persisted = await readWorkflowRunState(statePath);
+    expect(persisted.run.trigger).toEqual(result.run.trigger);
+  });
+
   it("records retryable failures and retries according to the step policy", async () => {
     const definition = readWorkflowFixture("simple-manual.valid.json");
     const statePath = await createTempStatePath();


### PR DESCRIPTION
## Summary
- omit trigger idempotency metadata from run.created when no trigger idempotency key resolves
- add a runner regression for a schema-valid manual workflow without trigger.idempotencyKey
- keep existing repeated-run idempotency guard coverage in the focused verification set

## Verification
- npm test -- --run test/workflow-runner.test.ts -t "without trigger idempotency|repeated execution changes|existing terminal run"
- npm run build
- npm test

Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Workflow run idempotency key handling has been refined. Keys are now conditionally omitted from the persisted payload when undefined, rather than written with empty values. This affects how workflow state is recorded and retrieved.

* **Tests**
  * Added test case for manual workflow execution without idempotency keys to validate successful operation and proper trigger state persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->