### PR TITLE
FLOW-FU-002: Reject cyclic dependencies before state writes

### DIFF
--- a/src/workflow-runner.ts
+++ b/src/workflow-runner.ts
@@ -51,6 +51,7 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
     throw new Error(`workflow definition is invalid: ${details}`);
   }
 
+  const orderedSteps = orderSteps(input.definition.steps);
   const now = input.now ?? (() => new Date().toISOString());
   const triggerContext = input.triggerContext ?? {};
   const triggerIdempotencyKey = resolveIdempotencyKey(
@@ -102,8 +103,6 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
     type: "workflow.started",
     occurredAt: createdAt
   });
-
-  const orderedSteps = orderSteps(input.definition.steps);
 
   for (const step of orderedSteps) {
     const retryPolicy = step.retry ?? { maxAttempts: 1, backoff: { strategy: "none" as const } };

--- a/test/workflow-runner.test.ts
+++ b/test/workflow-runner.test.ts
@@ -136,6 +136,28 @@ describe("sequential workflow runner", () => {
     ]);
   });
 
+  it("rejects cyclic dependencies before writing state or audit records", async () => {
+    const definition = readWorkflowFixture("simple-manual.valid.json");
+    definition.steps[0].dependsOn = ["notify-operator"];
+    definition.steps[1].dependsOn = ["collect-input"];
+    const statePath = await createTempStatePath();
+    const auditPath = await createTempAuditPath();
+
+    await expect(
+      runWorkflow({
+        definition,
+        statePath,
+        auditPath,
+        triggerContext: {
+          requestId: "manual-cycle"
+        }
+      })
+    ).rejects.toThrow("workflow definition dependencies cannot be ordered");
+
+    await expect(readFile(statePath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(auditPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("runs a valid manual workflow without trigger idempotency metadata", async () => {
     const definition = readWorkflowFixture("simple-manual.valid.json");
     delete definition.trigger.idempotencyKey;


### PR DESCRIPTION
## Summary
- reject cyclic workflow dependencies before local runner state or audit JSONL files are written
- add a regression covering a two-step dependency cycle and asserting no state/audit files are created
- preserve existing acyclic dependency ordering by reusing the same ordered step list for execution

## Verification
- npm test -- test/workflow-runner.test.ts
- npm run build
- npm test

Closes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow validation to detect and reject cyclic step dependencies, ensuring workflows are properly ordered before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->