### PR TITLE
FLOW-010: Vendor Ensen-protocol v0.1.0 snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ but it does not claim EIP conformance and does not import Ensen-protocol runtime
 packages. Formal protocol mapping belongs to a later protocol or connector
 integration phase.
 
+## Ensen-protocol Snapshot
+
+The copied Ensen-protocol v0.1.0 schema and conformance fixture snapshot is
+documented in
+`protocol-snapshots/ensen-protocol/v0.1.0/README.md`. It is repo-owned fixture
+data, not a runtime package dependency or a pointer to a sibling checkout.
+
+Ensen-flow currently exposes an EIP version boundary for later connector tests:
+protocol version `0.1.0`, release tag `v0.1.0`, and
+`runtimeDependency: false`. Unsupported EIP major versions must fail closed
+until a future Ensen-flow connector boundary explicitly supports them.
+
 ## Local Sequential Runner
 
 The Phase 1 local runner can execute a validated workflow definition through a

--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ data, not a runtime package dependency or a pointer to a sibling checkout.
 
 Ensen-flow currently exposes an EIP version boundary for later connector tests:
 protocol version `0.1.0`, release tag `v0.1.0`, and
-`runtimeDependency: false`. Unsupported EIP major versions must fail closed
-until a future Ensen-flow connector boundary explicitly supports them.
+`runtimeDependency: false`. Workflow definitions may declare
+`protocolVersion: "0.1.0"` as an optional boundary marker. Unsupported EIP major
+versions must fail closed until a future Ensen-flow connector boundary explicitly
+supports them.
 
 ## Local Sequential Runner
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,5 +6,6 @@ Start here:
 
 - [Mission](./mission.md): the Ensen-flow short-form development charter.
 - [Workflow Definition Schema](./workflow-definition.md): the Phase 1 standalone workflow definition boundary and validation shape.
+- [Ensen-protocol v0.1.0 Snapshot](../protocol-snapshots/ensen-protocol/v0.1.0/README.md): copied protocol schemas and conformance fixtures for later connector tests.
 
 Ensen-flow documentation should preserve the product boundary: lightweight explainable workflow orchestration, no shared runtime dependency with Ensen-loop, and no premature Pharma/GxP compliance claims.

--- a/docs/workflow-definition.md
+++ b/docs/workflow-definition.md
@@ -9,6 +9,7 @@ services.
 
 The schema includes:
 
+- an optional supported EIP `protocolVersion` boundary marker
 - stable workflow and step IDs using kebab-case identifiers
 - one trigger per workflow
 - ordered step definitions with explicit `dependsOn` dependencies
@@ -41,6 +42,7 @@ runtime dispatch implementation.
 
 ```json
 {
+  "protocolVersion": "0.1.0",
   "schemaVersion": "flow.workflow.v1",
   "id": "local-manual-demo",
   "name": "Local manual demo",

--- a/protocol-snapshots/ensen-protocol/v0.1.0/README.md
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/README.md
@@ -1,0 +1,22 @@
+# Ensen-protocol v0.1.0 Snapshot
+
+This directory is a copied snapshot of the public Ensen Interop Protocol artifacts from `TommyKammy/Ensen-protocol` release tag `v0.1.0`, protocol version `0.1.0`, with the local corrections listed in `manifest.json`.
+
+It is intentionally repo-owned by Ensen-flow. Ensen-flow must not require an Ensen-protocol checkout, package, service, fixture path, or runtime dependency to build, test, or operate.
+
+## Contents
+
+- `schemas/eip.run-request.v1.schema.json`
+- `schemas/eip.run-status.v1.schema.json`
+- `schemas/eip.run-result.v1.schema.json`
+- `schemas/eip.evidence-bundle-ref.v1.schema.json`
+- `schemas/eip.common.v1.schema.json`, copied as schema support for `$ref` resolution
+- valid and invalid public conformance fixtures for RunRequest, RunStatusSnapshot, RunResult, and EvidenceBundleRef
+
+## Update Policy
+
+Treat this directory as read-only protocol fixture data. Runtime code should access it only through explicit test or protocol helper boundaries.
+
+To update the snapshot, replace this versioned directory from a tagged Ensen-protocol release and update `manifest.json` in the same change. Do not point tests or runtime code at a sibling checkout as a mutable shared dependency.
+
+If the next tagged Ensen-protocol release already includes the local corrections recorded in `manifest.json`, remove those correction entries during the replacement.

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/evidence-bundle-ref/v1/invalid/bad-checksum.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/evidence-bundle-ref/v1/invalid/bad-checksum.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": "eip.evidence-bundle-ref.v1",
+  "id": "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "type": "local_path",
+  "uri": "artifacts/evidence/run-01HV9ZX8J2K6T3QW4R5Y7M8N9Q/bundle.json",
+  "createdAt": "2026-04-29T00:15:00Z",
+  "checksum": {
+    "algorithm": "md5",
+    "value": "not-a-sha256-digest"
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": "eip.evidence-bundle-ref.v1",
+  "id": "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "type": "file_uri",
+  "uri": "file://evidence.example.test/bundle.json?placeholder=REDACTED_FIXTURE_SECRET_PLACEHOLDER",
+  "createdAt": "2026-04-29T00:10:00Z"
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/evidence-bundle-ref/v1/valid/file-uri.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/evidence-bundle-ref/v1/valid/file-uri.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "eip.evidence-bundle-ref.v1",
+  "id": "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9T",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "type": "file_uri",
+  "uri": "file:///var/lib/ensen/evidence/run-01HV9ZX8J2K6T3QW4R5Y7M8N9Q/bundle.json",
+  "createdAt": "2026-04-29T00:05:00Z",
+  "contentType": "application/json"
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/evidence-bundle-ref/v1/valid/local-path.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/evidence-bundle-ref/v1/valid/local-path.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "eip.evidence-bundle-ref.v1",
+  "id": "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9S",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "type": "local_path",
+  "uri": "artifacts/evidence/run-01HV9ZX8J2K6T3QW4R5Y7M8N9Q/bundle.json",
+  "createdAt": "2026-04-29T00:00:00Z",
+  "contentType": "application/json",
+  "checksum": {
+    "algorithm": "sha256",
+    "value": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  },
+  "metadata": {
+    "producer": "ensen-loop",
+    "command": "npm test",
+    "redacted": true
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/invalid/bad-schema-version.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/invalid/bad-schema-version.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "eip.run-request.v2",
+  "id": "req_01HV7Y8M8F2KQ5W3P9R6T4N2CA",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2CB",
+  "idempotencyKey": "github-issue-4-attempt-1",
+  "source": {
+    "sourceId": "source_01HV7Y8M8F2KQ5W3P9R6T4N2CC",
+    "sourceType": "github"
+  },
+  "requestedBy": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2CD",
+    "actorType": "api_client"
+  },
+  "workItem": {
+    "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2CE",
+    "externalId": "4"
+  },
+  "mode": "plan",
+  "createdAt": "2026-04-29T01:45:45Z"
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/invalid/raw-secret.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/invalid/raw-secret.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "eip.run-request.v1",
+  "id": "req_01HV7Y8M8F2KQ5W3P9R6T4N2DA",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2DB",
+  "idempotencyKey": "manual-request-20260429-2",
+  "source": {
+    "sourceId": "source_01HV7Y8M8F2KQ5W3P9R6T4N2DC",
+    "sourceType": "manual"
+  },
+  "requestedBy": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2DD",
+    "actorType": "human"
+  },
+  "workItem": {
+    "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2DE",
+    "externalId": "manual-secret-check"
+  },
+  "mode": "validate",
+  "createdAt": "2026-04-29T02:00:00Z",
+  "extensions": {
+    "raw-secret": "REDACTED_FIXTURE_SECRET_PLACEHOLDER"
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/invalid/source-string.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/invalid/source-string.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "eip.run-request.v1",
+  "id": "req_01HV7Y8M8F2KQ5W3P9R6T4N2EA",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2EB",
+  "idempotencyKey": "manual-request-20260429-3",
+  "source": "github",
+  "requestedBy": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2EC",
+    "actorType": "api_client"
+  },
+  "workItem": {
+    "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2ED",
+    "externalId": "4"
+  },
+  "mode": "plan",
+  "createdAt": "2026-04-29T01:45:45Z"
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/invalid/unknown-top-level-field.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/invalid/unknown-top-level-field.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "eip.run-request.v1",
+  "id": "req_01HV7Y8M8F2KQ5W3P9R6T4N2FA",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2FB",
+  "idempotencyKey": "github-issue-4-attempt-1",
+  "source": {
+    "sourceId": "source_01HV7Y8M8F2KQ5W3P9R6T4N2FC",
+    "sourceType": "github"
+  },
+  "requestedBy": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2FD",
+    "actorType": "api_client"
+  },
+  "workItem": {
+    "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2FE",
+    "externalId": "4"
+  },
+  "mode": "plan",
+  "createdAt": "2026-04-29T01:45:45Z",
+  "transport": "github-webhook"
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/valid/github-issue-request.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/valid/github-issue-request.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "eip.run-request.v1",
+  "id": "req_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
+  "idempotencyKey": "github-issue-4",
+  "source": {
+    "sourceId": "source_01HV7Y8M8F2KQ5W3P9R6T4N2AD",
+    "sourceType": "github",
+    "externalRef": "TommyKammy/Ensen-protocol"
+  },
+  "requestedBy": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2AE",
+    "actorType": "api_client",
+    "displayName": "Ensen issue dispatcher"
+  },
+  "workItem": {
+    "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2AF",
+    "externalId": "4",
+    "title": "EIP-0001: Define RunRequest v1 schema",
+    "url": "https://github.com/TommyKammy/Ensen-protocol/issues/4"
+  },
+  "mode": "plan",
+  "createdAt": "2026-04-29T01:45:45Z",
+  "target": {
+    "targetType": "repository",
+    "targetId": "repo_01HV7Y8M8F2KQ5W3P9R6T4N2AG",
+    "externalRef": "TommyKammy/Ensen-protocol"
+  },
+  "policyContext": {
+    "policySetId": "policy_01HV7Y8M8F2KQ5W3P9R6T4N2AH",
+    "riskClasses": ["secrets"],
+    "requiresApproval": true
+  },
+  "dataClassification": "public",
+  "extensions": {
+    "x-fixture-note": "synthetic GitHub issue request"
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/valid/manual-request.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-request/v1/valid/manual-request.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": "eip.run-request.v1",
+  "id": "req_01HV7Y8M8F2KQ5W3P9R6T4N2BA",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2BB",
+  "idempotencyKey": "manual-request-20260429-1",
+  "source": {
+    "sourceId": "source_01HV7Y8M8F2KQ5W3P9R6T4N2BC",
+    "sourceType": "manual",
+    "externalRef": "operator-intake"
+  },
+  "requestedBy": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2BD",
+    "actorType": "human",
+    "displayName": "Example Operator"
+  },
+  "workItem": {
+    "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2BE",
+    "externalId": "manual-2026-04-29-001",
+    "title": "Review protocol fixture coverage"
+  },
+  "mode": "validate",
+  "createdAt": "2026-04-29T02:00:00Z",
+  "dataClassification": "public"
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/invalid/missing-request-id.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/invalid/missing-request-id.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": "eip.run-result.v1",
+  "id": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9W",
+  "status": "succeeded",
+  "completedAt": "2026-04-29T03:00:00Z"
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/invalid/running-status.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/invalid/running-status.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": "eip.run-result.v1",
+  "id": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9X",
+  "requestId": "req_01HV7Y8M8F2KQ5W3P9R6T4N2DA",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9Y",
+  "status": "running",
+  "completedAt": "2026-04-29T03:10:00Z"
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/valid/blocked-result.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/valid/blocked-result.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": "eip.run-result.v1",
+  "id": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9S",
+  "requestId": "req_01HV7Y8M8F2KQ5W3P9R6T4N2BA",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2BB",
+  "status": "blocked",
+  "completedAt": "2026-04-29T02:40:00Z",
+  "verification": {
+    "status": "blocked",
+    "summary": "Required approval was not available."
+  },
+  "warnings": [
+    {
+      "code": "APPROVAL_REQUIRED",
+      "message": "The run stopped before making changes because approval was required."
+    }
+  ],
+  "metrics": {
+    "durationMs": 30000,
+    "attempts": 1
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/valid/failed-result.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/valid/failed-result.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "eip.run-result.v1",
+  "id": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9T",
+  "requestId": "req_01HV7Y8M8F2KQ5W3P9R6T4N2CA",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+  "status": "failed",
+  "completedAt": "2026-04-29T02:50:00Z",
+  "verification": {
+    "status": "failed",
+    "commands": [
+      {
+        "command": "npm test",
+        "status": "failed",
+        "completedAt": "2026-04-29T02:49:50Z",
+        "summary": "A schema validation test failed."
+      }
+    ],
+    "summary": "Run failed during verification."
+  },
+  "errors": [
+    {
+      "code": "VERIFICATION_FAILED",
+      "message": "Focused verification failed.",
+      "retryable": true
+    }
+  ],
+  "metrics": {
+    "durationMs": 120000,
+    "attempts": 2
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/valid/succeeded-result.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-result/v1/valid/succeeded-result.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "eip.run-result.v1",
+  "id": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9P",
+  "requestId": "req_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
+  "status": "succeeded",
+  "completedAt": "2026-04-29T02:30:00Z",
+  "changeRequests": [
+    {
+      "changeRequestId": "cr_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+      "status": "open"
+    }
+  ],
+  "evidenceBundles": [
+    {
+      "evidenceBundleId": "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+      "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    }
+  ],
+  "verification": {
+    "status": "passed",
+    "commands": [
+      {
+        "command": "npm test",
+        "status": "passed",
+        "completedAt": "2026-04-29T02:29:45Z",
+        "summary": "Contract tests passed."
+      }
+    ],
+    "summary": "Run completed and verification passed."
+  },
+  "metrics": {
+    "durationMs": 180000,
+    "attempts": 1,
+    "tokensInput": 2400,
+    "tokensOutput": 900
+  },
+  "extensions": {
+    "x-fixture-note": "synthetic succeeded result"
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-status/v1/invalid/final-result-only-fields.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-status/v1/invalid/final-result-only-fields.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": "eip.run-status.v1",
+  "id": "sts_01HV9ZX8J2K6T3QW4R5Y7M8N9W",
+  "requestId": "req_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "status": "completed",
+  "observedAt": "2026-04-29T00:05:00Z",
+  "completedAt": "2026-04-29T00:05:00Z",
+  "changeRequests": [
+    {
+      "changeRequestId": "pr_01HV9ZX8J2K6T3QW4R5Y7M8N9X"
+    }
+  ]
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-status/v1/valid/accepted-snapshot.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-status/v1/valid/accepted-snapshot.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "eip.run-status.v1",
+  "id": "sts_01HV9ZX8J2K6T3QW4R5Y7M8N9S",
+  "requestId": "req_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "status": "accepted",
+  "observedAt": "2026-04-29T00:00:00Z",
+  "message": "Run request accepted by the executor boundary."
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-status/v1/valid/completed-snapshot.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-status/v1/valid/completed-snapshot.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": "eip.run-status.v1",
+  "id": "sts_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+  "requestId": "req_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "runId": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
+  "status": "completed",
+  "observedAt": "2026-04-29T00:05:00Z",
+  "message": "Run completed. Retrieve final details from RunResult."
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-status/v1/valid/running-snapshot.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/fixtures/run-status/v1/valid/running-snapshot.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": "eip.run-status.v1",
+  "id": "sts_01HV9ZX8J2K6T3QW4R5Y7M8N9T",
+  "requestId": "req_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "runId": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
+  "status": "running",
+  "observedAt": "2026-04-29T00:01:00Z",
+  "message": "Executor is running validation.",
+  "progress": {
+    "current": 2,
+    "total": 5,
+    "percent": 40,
+    "unit": "steps"
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/manifest.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/manifest.json
@@ -1,0 +1,42 @@
+{
+  "source": {
+    "repository": "TommyKammy/Ensen-protocol",
+    "releaseTag": "v0.1.0",
+    "protocolVersion": "0.1.0"
+  },
+  "policy": {
+    "updatePolicy": "Copied snapshot. Update only by replacing this directory from a tagged Ensen-protocol release.",
+    "runtimeDependency": false,
+    "localCorrections": [
+      {
+        "path": "fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json",
+        "reason": "Use a scanner-safe invalid URI placeholder."
+      },
+      {
+        "path": "fixtures/run-request/v1/invalid/raw-secret.json",
+        "reason": "Keep the invalid fixture deterministically invalid under ExtensionMap rules."
+      },
+      {
+        "path": "schemas/eip.run-result.v1.schema.json",
+        "reason": "Require VerificationSummary.status for unambiguous verification payloads."
+      }
+    ]
+  },
+  "includes": {
+    "schemas": [
+      "schemas/eip.evidence-bundle-ref.v1.schema.json",
+      "schemas/eip.run-request.v1.schema.json",
+      "schemas/eip.run-result.v1.schema.json",
+      "schemas/eip.run-status.v1.schema.json"
+    ],
+    "supportSchemas": [
+      "schemas/eip.common.v1.schema.json"
+    ],
+    "fixtureFamilies": [
+      "evidence-bundle-ref",
+      "run-request",
+      "run-result",
+      "run-status"
+    ]
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.common.v1.schema.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.common.v1.schema.json
@@ -1,0 +1,208 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eip.ensen.dev/schemas/eip.common.v1.schema.json",
+  "title": "EIP Common v1 Fixture Envelope",
+  "description": "Common schema conventions and reusable v1 type definitions for EIP artifacts.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifactId",
+    "correlationId",
+    "createdAt",
+    "actor",
+    "source",
+    "workItem",
+    "changeRequest",
+    "evidenceBundle",
+    "classification"
+  ],
+  "properties": {
+    "artifactId": {
+      "$ref": "#/$defs/PrefixedId"
+    },
+    "correlationId": {
+      "$ref": "#/$defs/CorrelationId"
+    },
+    "createdAt": {
+      "$ref": "#/$defs/IsoDateTimeUtc"
+    },
+    "actor": {
+      "$ref": "#/$defs/ActorRef"
+    },
+    "source": {
+      "$ref": "#/$defs/SourceRef"
+    },
+    "workItem": {
+      "$ref": "#/$defs/WorkItemRef"
+    },
+    "changeRequest": {
+      "$ref": "#/$defs/ChangeRequestRef"
+    },
+    "evidenceBundle": {
+      "$ref": "#/$defs/EvidenceBundleRef"
+    },
+    "classification": {
+      "$ref": "#/$defs/DataClassification"
+    },
+    "error": {
+      "$ref": "#/$defs/ErrorInfo"
+    },
+    "extensions": {
+      "$ref": "#/$defs/ExtensionMap"
+    }
+  },
+  "$defs": {
+    "PrefixedId": {
+      "type": "string",
+      "description": "Stable protocol identifier with a registered 2-8 character lowercase semantic prefix, underscore separator, and opaque suffix.",
+      "pattern": "^(?:actor|artifact|corr|cr|evb|evt|flowstep|policy|pr|repo|req|run|source|sts|workitem)_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$"
+    },
+    "CorrelationId": {
+      "type": "string",
+      "description": "Opaque idempotency and tracing identifier shared by related protocol artifacts.",
+      "pattern": "^corr_[A-Za-z0-9][A-Za-z0-9._~-]{11,127}$"
+    },
+    "IsoDateTimeUtc": {
+      "type": "string",
+      "description": "UTC timestamp using ISO 8601 extended format with a literal Z offset.",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
+    },
+    "ActorRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["actorId", "actorType"],
+      "properties": {
+        "actorId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "actorType": {
+          "type": "string",
+          "enum": ["human", "workflow", "system", "api_client", "connector", "executor", "agent"]
+        },
+        "displayName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160
+        }
+      }
+    },
+    "SourceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sourceId", "sourceType"],
+      "properties": {
+        "sourceId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "sourceType": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80,
+          "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+        },
+        "externalRef": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        }
+      }
+    },
+    "WorkItemRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workItemId"],
+      "properties": {
+        "workItemId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        }
+      }
+    },
+    "ChangeRequestRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["changeRequestId"],
+      "properties": {
+        "changeRequestId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["draft", "open", "accepted", "rejected", "superseded"]
+        }
+      }
+    },
+    "EvidenceBundleRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidenceBundleId"],
+      "properties": {
+        "evidenceBundleId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        }
+      }
+    },
+    "ErrorInfo": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Z0-9_]{2,63}$"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        },
+        "retryable": {
+          "type": "boolean"
+        },
+        "details": {
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "ExtensionMap": {
+      "type": "object",
+      "description": "Vendor or artifact-specific extension values. Extension keys must use the x- prefix.",
+      "propertyNames": {
+        "pattern": "^x-.+$"
+      },
+      "additionalProperties": true
+    },
+    "DataClassification": {
+      "type": "string",
+      "description": "Classification label for fixture and production data handling.",
+      "enum": ["public", "internal", "confidential", "restricted"]
+    }
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.evidence-bundle-ref.v1.schema.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.evidence-bundle-ref.v1.schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eip.ensen.dev/schemas/eip.evidence-bundle-ref.v1.schema.json",
+  "title": "EIP-0004 EvidenceBundleRef v1",
+  "description": "Transport-neutral reference to durable evidence material. This artifact identifies where evidence can be found; it does not embed the evidence body.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "id",
+    "correlationId",
+    "type",
+    "uri",
+    "createdAt"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "eip.evidence-bundle-ref.v1"
+    },
+    "id": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "correlationId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/CorrelationId"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["local_path", "file_uri"]
+    },
+    "uri": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1000,
+      "not": {
+        "pattern": "^[A-Za-z][A-Za-z0-9+.-]*://[^/?#\\s]*[^/?#\\s:@]+:[^/?#\\s:@]+@"
+      }
+    },
+    "createdAt": {
+      "$ref": "eip.common.v1.schema.json#/$defs/IsoDateTimeUtc"
+    },
+    "contentType": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*(?:; ?[A-Za-z0-9_.-]+=[A-Za-z0-9_.+-]+)*$"
+    },
+    "checksum": {
+      "$ref": "#/$defs/Checksum"
+    },
+    "metadata": {
+      "$ref": "#/$defs/Metadata"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "local_path"
+          }
+        },
+        "required": ["type"]
+      },
+      "then": {
+        "properties": {
+          "uri": {
+            "type": "string",
+            "pattern": "^(?![A-Za-z][A-Za-z0-9+.-]*://)(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))[A-Za-z0-9._~@/-]+$"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "file_uri"
+          }
+        },
+        "required": ["type"]
+      },
+      "then": {
+        "properties": {
+          "uri": {
+            "type": "string",
+            "pattern": "^file:///(?!.*(?:^|/)\\.\\.(?:/|$))[^\\s?#]+$"
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "Checksum": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "value"],
+      "properties": {
+        "algorithm": {
+          "type": "string",
+          "enum": ["sha256"]
+        },
+        "value": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "Metadata": {
+      "type": "object",
+      "description": "Small public descriptors about the referenced evidence. Do not put evidence bodies or credentials here.",
+      "propertyNames": {
+        "pattern": "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$"
+      },
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "integer"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "maxProperties": 20
+    }
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.run-request.v1.schema.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.run-request.v1.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eip.ensen.dev/schemas/eip.run-request.v1.schema.json",
+  "title": "EIP-0001 RunRequest v1",
+  "description": "Transport-neutral request contract for asking an Ensen-compatible executor to run work.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "id",
+    "correlationId",
+    "idempotencyKey",
+    "source",
+    "requestedBy",
+    "workItem",
+    "mode",
+    "createdAt"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "eip.run-request.v1"
+    },
+    "id": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "correlationId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/CorrelationId"
+    },
+    "idempotencyKey": {
+      "type": "string",
+      "minLength": 12,
+      "maxLength": 160,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{11,159}$"
+    },
+    "source": {
+      "$ref": "eip.common.v1.schema.json#/$defs/SourceRef"
+    },
+    "requestedBy": {
+      "$ref": "eip.common.v1.schema.json#/$defs/ActorRef"
+    },
+    "workItem": {
+      "$ref": "#/$defs/RunRequestWorkItem"
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["plan", "apply", "validate"]
+    },
+    "createdAt": {
+      "$ref": "eip.common.v1.schema.json#/$defs/IsoDateTimeUtc"
+    },
+    "target": {
+      "$ref": "#/$defs/RunTarget"
+    },
+    "policyContext": {
+      "$ref": "#/$defs/PolicyContext"
+    },
+    "dataClassification": {
+      "$ref": "eip.common.v1.schema.json#/$defs/DataClassification"
+    },
+    "extensions": {
+      "$ref": "eip.common.v1.schema.json#/$defs/ExtensionMap"
+    }
+  },
+  "$defs": {
+    "RunRequestWorkItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workItemId", "externalId"],
+      "properties": {
+        "workItemId": {
+          "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+        },
+        "externalId": {
+          "type": "string",
+          "description": "Identifier used by the external source system, such as a GitHub issue number or manual ticket id.",
+          "minLength": 1,
+          "maxLength": 240
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        },
+        "url": {
+          "type": "string",
+          "pattern": "^https://[^\\s]+$",
+          "maxLength": 400
+        }
+      }
+    },
+    "RunTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["targetType", "targetId"],
+      "properties": {
+        "targetType": {
+          "type": "string",
+          "enum": ["repository", "workspace", "environment", "manual"]
+        },
+        "targetId": {
+          "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+        },
+        "externalRef": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        }
+      }
+    },
+    "PolicyContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policySetId": {
+          "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+        },
+        "riskClasses": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+          },
+          "uniqueItems": true,
+          "maxItems": 20
+        },
+        "requiresApproval": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.run-result.v1.schema.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.run-result.v1.schema.json
@@ -1,0 +1,164 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eip.ensen.dev/schemas/eip.run-result.v1.schema.json",
+  "title": "EIP-0002 RunResult v1",
+  "description": "Transport-neutral terminal result contract for completed Ensen-compatible executor runs.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "id",
+    "requestId",
+    "correlationId",
+    "status",
+    "completedAt"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "eip.run-result.v1"
+    },
+    "id": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "requestId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "correlationId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/CorrelationId"
+    },
+    "status": {
+      "$ref": "#/$defs/RunResultStatus"
+    },
+    "completedAt": {
+      "$ref": "eip.common.v1.schema.json#/$defs/IsoDateTimeUtc"
+    },
+    "changeRequests": {
+      "type": "array",
+      "items": {
+        "$ref": "eip.common.v1.schema.json#/$defs/ChangeRequestRef"
+      },
+      "maxItems": 50
+    },
+    "evidenceBundles": {
+      "type": "array",
+      "items": {
+        "$ref": "eip.common.v1.schema.json#/$defs/EvidenceBundleRef"
+      },
+      "maxItems": 50
+    },
+    "verification": {
+      "$ref": "#/$defs/VerificationSummary"
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "$ref": "eip.common.v1.schema.json#/$defs/ErrorInfo"
+      },
+      "maxItems": 50
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WarningInfo"
+      },
+      "maxItems": 50
+    },
+    "metrics": {
+      "$ref": "#/$defs/RunMetrics"
+    },
+    "extensions": {
+      "$ref": "eip.common.v1.schema.json#/$defs/ExtensionMap"
+    }
+  },
+  "$defs": {
+    "RunResultStatus": {
+      "type": "string",
+      "enum": ["succeeded", "failed", "blocked", "needs_review", "cancelled"]
+    },
+    "VerificationSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["passed", "failed", "blocked", "not_run"]
+        },
+        "commands": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/VerificationCommand"
+          },
+          "maxItems": 50
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        }
+      }
+    },
+    "VerificationCommand": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command", "status"],
+      "properties": {
+        "command": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        },
+        "status": {
+          "type": "string",
+          "enum": ["passed", "failed", "blocked", "not_run"]
+        },
+        "completedAt": {
+          "$ref": "eip.common.v1.schema.json#/$defs/IsoDateTimeUtc"
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500
+        }
+      }
+    },
+    "WarningInfo": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Z0-9_]{2,63}$"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        }
+      }
+    },
+    "RunMetrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "durationMs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "attempts": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "tokensInput": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "tokensOutput": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.run-status.v1.schema.json
+++ b/protocol-snapshots/ensen-protocol/v0.1.0/schemas/eip.run-status.v1.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eip.ensen.dev/schemas/eip.run-status.v1.schema.json",
+  "title": "EIP-0005 RunStatusSnapshot v1",
+  "description": "Transport-neutral polling snapshot contract for Ensen-compatible async executor runs.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "id",
+    "requestId",
+    "correlationId",
+    "status",
+    "observedAt"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "eip.run-status.v1"
+    },
+    "id": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "requestId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "correlationId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/CorrelationId"
+    },
+    "runId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "status": {
+      "$ref": "#/$defs/RunStatus"
+    },
+    "observedAt": {
+      "$ref": "eip.common.v1.schema.json#/$defs/IsoDateTimeUtc"
+    },
+    "message": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1000
+    },
+    "progress": {
+      "$ref": "#/$defs/RunProgress"
+    },
+    "extensions": {
+      "$ref": "eip.common.v1.schema.json#/$defs/ExtensionMap"
+    }
+  },
+  "$defs": {
+    "RunStatus": {
+      "type": "string",
+      "enum": [
+        "accepted",
+        "queued",
+        "running",
+        "cancelling",
+        "cancelled",
+        "completed",
+        "failed",
+        "blocked",
+        "unknown"
+      ]
+    },
+    "RunProgress": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "current": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "total": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "percent": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "unit": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        }
+      }
+    }
+  }
+}

--- a/src/eip-version.ts
+++ b/src/eip-version.ts
@@ -1,0 +1,19 @@
+export interface EipVersionBoundary {
+  sourceRepository: "TommyKammy/Ensen-protocol";
+  snapshotReleaseTag: "v0.1.0";
+  supportedProtocolVersion: "0.1.0";
+  runtimeDependency: false;
+  unsupportedMajorVersionPolicy: "fail-closed until an explicit Ensen-flow connector boundary supports the new EIP major version";
+}
+
+export const eipVersionBoundary: EipVersionBoundary = {
+  sourceRepository: "TommyKammy/Ensen-protocol",
+  snapshotReleaseTag: "v0.1.0",
+  supportedProtocolVersion: "0.1.0",
+  runtimeDependency: false,
+  unsupportedMajorVersionPolicy:
+    "fail-closed until an explicit Ensen-flow connector boundary supports the new EIP major version"
+};
+
+export const isSupportedEipProtocolVersion = (protocolVersion: string): boolean =>
+  protocolVersion === eipVersionBoundary.supportedProtocolVersion;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,13 @@ export const baselineInfo: BaselineInfo = {
 };
 
 export {
+  eipVersionBoundary,
+  isSupportedEipProtocolVersion
+} from "./eip-version.js";
+
+export type { EipVersionBoundary } from "./eip-version.js";
+
+export {
   appendWorkflowRunEvent,
   createWorkflowRun,
   readWorkflowRunState

--- a/src/workflow-definition.ts
+++ b/src/workflow-definition.ts
@@ -40,6 +40,7 @@ const INPUT_IDEMPOTENCY_KEY_ALLOWED_KEYS = new Set(["source", "field", "required
 const WORKFLOW_IDEMPOTENCY_KEY_ALLOWED_KEYS = new Set(["source", "template"]);
 const STATIC_IDEMPOTENCY_KEY_ALLOWED_KEYS = new Set(["source", "value"]);
 const WORKFLOW_ALLOWED_KEYS = new Set([
+  "protocolVersion",
   "schemaVersion",
   "id",
   "name",
@@ -61,6 +62,7 @@ const STEP_ALLOWED_KEYS = new Set([
 export type WorkflowSchemaVersion = typeof WORKFLOW_SCHEMA_VERSION;
 
 export interface WorkflowDefinition {
+  protocolVersion?: string;
   schemaVersion: WorkflowSchemaVersion;
   id: string;
   name?: string;

--- a/src/workflow-definition.ts
+++ b/src/workflow-definition.ts
@@ -1,3 +1,8 @@
+import {
+  eipVersionBoundary,
+  isSupportedEipProtocolVersion
+} from "./eip-version.js";
+
 const WORKFLOW_SCHEMA_VERSION = "flow.workflow.v1";
 
 const TRIGGER_TYPES = new Set(["manual", "schedule", "webhook"]);
@@ -153,6 +158,7 @@ export const validateWorkflowDefinition = (
   }
 
   rejectEnsenLoopSpecificFields(value, "", errors);
+  rejectUnsupportedEipProtocolVersion(value, errors);
   rejectUnknownKeys(value, WORKFLOW_ALLOWED_KEYS, "", errors);
   requireLiteral(value, "schemaVersion", WORKFLOW_SCHEMA_VERSION, errors);
   requireStableId(value, "id", "workflow.id", errors);
@@ -532,6 +538,26 @@ const rejectEnsenLoopSpecificFields = (
         message: `${key} is outside the workflow definition schema boundary`
       });
     }
+  }
+};
+
+const rejectUnsupportedEipProtocolVersion = (
+  value: Record<string, unknown>,
+  errors: WorkflowDefinitionValidationError[]
+): void => {
+  if (!("protocolVersion" in value)) {
+    return;
+  }
+
+  const protocolVersion = value.protocolVersion;
+  if (
+    typeof protocolVersion !== "string" ||
+    !isSupportedEipProtocolVersion(protocolVersion)
+  ) {
+    errors.push({
+      path: "workflow.protocolVersion",
+      message: `unsupported EIP protocolVersion ${JSON.stringify(protocolVersion)}; ${eipVersionBoundary.unsupportedMajorVersionPolicy}`
+    });
   }
 };
 

--- a/src/workflow-runner.ts
+++ b/src/workflow-runner.ts
@@ -12,6 +12,10 @@ import type {
   WorkflowRunState
 } from "./workflow-run-state.js";
 import {
+  eipVersionBoundary,
+  isSupportedEipProtocolVersion
+} from "./eip-version.js";
+import {
   validateWorkflowDefinition,
   workflowDefinitionSchemaVersion
 } from "./workflow-definition.js";
@@ -43,6 +47,8 @@ export interface WorkflowStepHandlerInput {
 export type WorkflowStepHandler = (input: WorkflowStepHandlerInput) => Promise<void> | void;
 
 export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunState> => {
+  assertSupportedWorkflowEipProtocolVersion(input.definition);
+
   const validation = validateWorkflowDefinition(input.definition);
   if (!validation.valid) {
     const details = validation.errors
@@ -230,6 +236,8 @@ export const loadWorkflowDefinitionFile = async (
   definitionPath: string
 ): Promise<WorkflowDefinition> => {
   const parsed = JSON.parse(await readFile(definitionPath, "utf8")) as unknown;
+  assertSupportedWorkflowEipProtocolVersion(parsed);
+
   const validation = validateWorkflowDefinition(parsed);
   if (!validation.valid) {
     const details = validation.errors
@@ -239,6 +247,22 @@ export const loadWorkflowDefinitionFile = async (
   }
 
   return parsed as WorkflowDefinition;
+};
+
+const assertSupportedWorkflowEipProtocolVersion = (definition: unknown): void => {
+  if (!isRecord(definition) || !("protocolVersion" in definition)) {
+    return;
+  }
+
+  const protocolVersion = definition.protocolVersion;
+  if (
+    typeof protocolVersion !== "string" ||
+    !isSupportedEipProtocolVersion(protocolVersion)
+  ) {
+    throw new Error(
+      `unsupported EIP protocolVersion ${JSON.stringify(protocolVersion)}; ${eipVersionBoundary.unsupportedMajorVersionPolicy}`
+    );
+  }
 };
 
 const defaultWorkflowStepHandler: WorkflowStepHandler = ({ step }) => {
@@ -422,3 +446,6 @@ const writeStepAuditEvent = async (
 
 const isNodeError = (error: unknown): error is NodeJS.ErrnoException =>
   error instanceof Error && "code" in error;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);

--- a/test/protocol-snapshot.test.ts
+++ b/test/protocol-snapshot.test.ts
@@ -88,23 +88,48 @@ describe("Ensen-protocol snapshot boundary", () => {
 
   it("includes valid and invalid fixtures for each Phase 2 EIP surface", async () => {
     for (const fixtureFamily of expectedFixtureFamilies) {
-      await expect(
-        listJsonFixtures(join("fixtures", fixtureFamily, "v1", "valid"))
-      ).resolves.not.toHaveLength(0);
-      await expect(
-        listJsonFixtures(join("fixtures", fixtureFamily, "v1", "invalid"))
-      ).resolves.not.toHaveLength(0);
+      const validFixturePath = join("fixtures", fixtureFamily, "v1", "valid");
+      const invalidFixturePath = join("fixtures", fixtureFamily, "v1", "invalid");
+      const validFixtures = await listJsonFixtures(validFixturePath);
+      const invalidFixtures = await listJsonFixtures(invalidFixturePath);
+
+      expect(validFixtures).not.toHaveLength(0);
+      expect(invalidFixtures).not.toHaveLength(0);
+
+      for (const fixtureName of validFixtures) {
+        await expect(readJson(join(validFixturePath, fixtureName))).resolves.toEqual(
+          expect.any(Object)
+        );
+      }
+
+      for (const fixtureName of invalidFixtures) {
+        await expect(readJson(join(invalidFixturePath, fixtureName))).resolves.toEqual(
+          expect.any(Object)
+        );
+      }
     }
   });
 
   it("exposes a fail-closed EIP version boundary without a runtime protocol dependency", async () => {
-    const packageJson = JSON.parse(await readFile("package.json", "utf8")) as {
-      dependencies?: Record<string, string>;
-      devDependencies?: Record<string, string>;
-    };
+    const packageJson = JSON.parse(await readFile("package.json", "utf8")) as Record<
+      string,
+      unknown
+    >;
 
-    expect(packageJson.dependencies ?? {}).not.toHaveProperty("ensen-protocol");
-    expect(packageJson.devDependencies ?? {}).not.toHaveProperty("ensen-protocol");
+    for (const dependencyKey of [
+      "dependencies",
+      "devDependencies",
+      "peerDependencies",
+      "optionalDependencies",
+      "bundledDependencies",
+      "bundleDependencies",
+      "peerDependenciesMeta",
+      "overrides"
+    ]) {
+      const dependencyBucket = packageJson[dependencyKey];
+      expect(JSON.stringify(dependencyBucket ?? {})).not.toContain("ensen-protocol");
+    }
+
     expect(eipVersionBoundary).toEqual({
       sourceRepository: "TommyKammy/Ensen-protocol",
       snapshotReleaseTag: "v0.1.0",

--- a/test/protocol-snapshot.test.ts
+++ b/test/protocol-snapshot.test.ts
@@ -1,0 +1,120 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  eipVersionBoundary,
+  isSupportedEipProtocolVersion
+} from "../src/index.js";
+
+const snapshotRoot = join(
+  process.cwd(),
+  "protocol-snapshots",
+  "ensen-protocol",
+  "v0.1.0"
+);
+
+const expectedSchemas = [
+  "schemas/eip.evidence-bundle-ref.v1.schema.json",
+  "schemas/eip.run-request.v1.schema.json",
+  "schemas/eip.run-result.v1.schema.json",
+  "schemas/eip.run-status.v1.schema.json"
+];
+
+const supportSchemas = ["schemas/eip.common.v1.schema.json"];
+
+const expectedFixtureFamilies = [
+  "evidence-bundle-ref",
+  "run-request",
+  "run-result",
+  "run-status"
+];
+
+const readJson = async (relativePath: string): Promise<unknown> =>
+  JSON.parse(await readFile(join(snapshotRoot, relativePath), "utf8")) as unknown;
+
+const listJsonFixtures = async (relativePath: string): Promise<string[]> => {
+  const entries = await readdir(join(snapshotRoot, relativePath), {
+    withFileTypes: true
+  });
+
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => entry.name)
+    .sort();
+};
+
+describe("Ensen-protocol snapshot boundary", () => {
+  it("vendors the Ensen-protocol v0.1.0 protocol snapshot with provenance", async () => {
+    await expect(readJson("manifest.json")).resolves.toEqual({
+      source: {
+        repository: "TommyKammy/Ensen-protocol",
+        releaseTag: "v0.1.0",
+        protocolVersion: "0.1.0"
+      },
+      policy: {
+        updatePolicy:
+          "Copied snapshot. Update only by replacing this directory from a tagged Ensen-protocol release.",
+        runtimeDependency: false,
+        localCorrections: [
+          {
+            path: "fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json",
+            reason: "Use a scanner-safe invalid URI placeholder."
+          },
+          {
+            path: "fixtures/run-request/v1/invalid/raw-secret.json",
+            reason:
+              "Keep the invalid fixture deterministically invalid under ExtensionMap rules."
+          },
+          {
+            path: "schemas/eip.run-result.v1.schema.json",
+            reason:
+              "Require VerificationSummary.status for unambiguous verification payloads."
+          }
+        ]
+      },
+      includes: {
+        schemas: expectedSchemas,
+        supportSchemas,
+        fixtureFamilies: expectedFixtureFamilies
+      }
+    });
+
+    for (const schemaPath of [...expectedSchemas, ...supportSchemas]) {
+      await expect(readJson(schemaPath)).resolves.toEqual(expect.any(Object));
+    }
+  });
+
+  it("includes valid and invalid fixtures for each Phase 2 EIP surface", async () => {
+    for (const fixtureFamily of expectedFixtureFamilies) {
+      await expect(
+        listJsonFixtures(join("fixtures", fixtureFamily, "v1", "valid"))
+      ).resolves.not.toHaveLength(0);
+      await expect(
+        listJsonFixtures(join("fixtures", fixtureFamily, "v1", "invalid"))
+      ).resolves.not.toHaveLength(0);
+    }
+  });
+
+  it("exposes a fail-closed EIP version boundary without a runtime protocol dependency", async () => {
+    const packageJson = JSON.parse(await readFile("package.json", "utf8")) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+
+    expect(packageJson.dependencies ?? {}).not.toHaveProperty("ensen-protocol");
+    expect(packageJson.devDependencies ?? {}).not.toHaveProperty("ensen-protocol");
+    expect(eipVersionBoundary).toEqual({
+      sourceRepository: "TommyKammy/Ensen-protocol",
+      snapshotReleaseTag: "v0.1.0",
+      supportedProtocolVersion: "0.1.0",
+      runtimeDependency: false,
+      unsupportedMajorVersionPolicy:
+        "fail-closed until an explicit Ensen-flow connector boundary supports the new EIP major version"
+    });
+    expect(isSupportedEipProtocolVersion("0.1.0")).toBe(true);
+    expect(isSupportedEipProtocolVersion("1.0.0")).toBe(false);
+    expect(isSupportedEipProtocolVersion("bad-version")).toBe(false);
+  });
+});

--- a/test/workflow-definition.test.ts
+++ b/test/workflow-definition.test.ts
@@ -33,6 +33,16 @@ describe("workflow definition schema", () => {
     expect(result.errors).toEqual([]);
   });
 
+  it("accepts the supported optional EIP protocol version", () => {
+    const workflow = readMutableWorkflowFixture();
+    workflow.protocolVersion = "0.1.0";
+
+    const result = validateWorkflowDefinition(workflow);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
   it.each([
     [
       "missing workflow id",

--- a/test/workflow-definition.test.ts
+++ b/test/workflow-definition.test.ts
@@ -213,4 +213,18 @@ describe("workflow definition schema", () => {
       }
     ]);
   });
+
+  it("fails closed when an unsupported EIP protocol version is declared", () => {
+    const workflow = readMutableWorkflowFixture();
+    workflow.protocolVersion = "1.0.0";
+
+    const result = validateWorkflowDefinition(workflow);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual({
+      path: "workflow.protocolVersion",
+      message:
+        "unsupported EIP protocolVersion \"1.0.0\"; fail-closed until an explicit Ensen-flow connector boundary supports the new EIP major version"
+    });
+  });
 });

--- a/test/workflow-runner.test.ts
+++ b/test/workflow-runner.test.ts
@@ -158,6 +158,34 @@ describe("sequential workflow runner", () => {
     await expect(readFile(auditPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("rejects unsupported EIP protocol versions before writing state or audit records", async () => {
+    const definition = readWorkflowFixture("simple-manual.valid.json");
+    (definition as WorkflowDefinition & { protocolVersion: string }).protocolVersion = "1.0.0";
+    const statePath = await createTempStatePath();
+    const auditPath = await createTempAuditPath();
+    let stepHandlerCalled = false;
+
+    await expect(
+      runWorkflow({
+        definition,
+        statePath,
+        auditPath,
+        triggerContext: {
+          requestId: "manual-unsupported-eip"
+        },
+        stepHandler: () => {
+          stepHandlerCalled = true;
+        }
+      })
+    ).rejects.toThrow(
+      "unsupported EIP protocolVersion \"1.0.0\"; fail-closed until an explicit Ensen-flow connector boundary supports the new EIP major version"
+    );
+
+    expect(stepHandlerCalled).toBe(false);
+    await expect(readFile(statePath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(auditPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("runs a valid manual workflow without trigger idempotency metadata", async () => {
     const definition = readWorkflowFixture("simple-manual.valid.json");
     delete definition.trigger.idempotencyKey;

--- a/test/workflow-runner.test.ts
+++ b/test/workflow-runner.test.ts
@@ -136,6 +136,23 @@ describe("sequential workflow runner", () => {
     ]);
   });
 
+  it("runs a workflow that declares the supported EIP protocol version", async () => {
+    const definition = readWorkflowFixture("simple-manual.valid.json");
+    definition.protocolVersion = "0.1.0";
+    const statePath = await createTempStatePath();
+
+    const result = await runWorkflow({
+      definition,
+      statePath,
+      triggerContext: {
+        requestId: "manual-supported-eip"
+      }
+    });
+
+    expect(result.run.status).toBe("succeeded");
+    expect(result.run.workflowId).toBe("local-manual-demo");
+  });
+
   it("rejects cyclic dependencies before writing state or audit records", async () => {
     const definition = readWorkflowFixture("simple-manual.valid.json");
     definition.steps[0].dependsOn = ["notify-operator"];


### PR DESCRIPTION
## Summary
- vendor the Ensen-protocol v0.1.0 schema and public fixture snapshot under a flow-owned protocol-snapshots path
- add snapshot provenance documentation and manifest checks for runtimeDependency=false
- expose the Ensen-flow EIP 0.1.0 version boundary with fail-closed unsupported-major behavior

## Verification
- npm test -- test/protocol-snapshot.test.ts
- npm run build
- npm test

Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ensen-protocol v0.1.0 snapshot with schemas and extensive valid/invalid fixtures.
  * Introduced a strict EIP protocol-version boundary (exports + runtime checks) that fails closed for unsupported major versions and accepts protocolVersion "0.1.0".

* **Documentation**
  * Updated READMEs and snapshot manifest with provenance, update policy, and connector boundary guidance.
  * Documented optional workflow.protocolVersion marker.

* **Tests**
  * Added tests validating snapshot contents and fail-closed version behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->