### PR TITLE
FLOW-012: Add executor connector abstraction

### DIFF
--- a/src/executor-connector.ts
+++ b/src/executor-connector.ts
@@ -1,0 +1,176 @@
+import {
+  createUnsupportedConnectorOperationResult
+} from "./connector.js";
+import type {
+  ConnectorCancelReceipt,
+  ConnectorCancelRequest,
+  ConnectorCancelResult,
+  ConnectorCapabilities,
+  ConnectorFetchEvidenceRequest,
+  ConnectorIdentity,
+  ConnectorOperation,
+  ConnectorResult
+} from "./connector.js";
+
+export type ExecutorPolicyDecision = "allow" | "approval-required" | "blocked" | "needs-review";
+
+export interface ExecutorPolicyDecisionPayload {
+  decision: ExecutorPolicyDecision;
+  reason?: string;
+  decidedAt?: string;
+  source?: {
+    type: "policy" | "connector" | "operator";
+    id: string;
+  };
+  evidence?: Record<string, unknown>;
+}
+
+export type ExecutorFlowControlStateName =
+  | "ready"
+  | "approval-required"
+  | "blocked"
+  | "needs-review";
+
+export interface ExecutorFlowControlState {
+  state: ExecutorFlowControlStateName;
+  authority: "ensen-flow";
+  reason?: string;
+  policyDecision?: ExecutorPolicyDecisionPayload;
+}
+
+export interface ExecutorSubmitRequest {
+  workflow: {
+    id: string;
+    version: string;
+  };
+  run: {
+    id: string;
+  };
+  step: {
+    id: string;
+    attempt: number;
+  };
+  input?: Record<string, unknown>;
+  idempotencyKey?: string;
+  policyDecision?: ExecutorPolicyDecisionPayload;
+}
+
+export interface ExecutorConnectorSubmitReceipt {
+  requestId: string;
+  acceptedAt?: string;
+  flowControl: ExecutorFlowControlState;
+  evidence?: Record<string, unknown>;
+}
+
+export type ExecutorConnectorSubmitResult =
+  ConnectorResult<ExecutorConnectorSubmitReceipt>;
+
+export interface ExecutorConnectorStatusRequest {
+  requestId: string;
+}
+
+export type ExecutorConnectorExecutionStatus =
+  | "accepted"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "approval-required"
+  | "blocked"
+  | "needs-review";
+
+export type ExecutorConnectorResultStatus =
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "blocked"
+  | "approval-required"
+  | "needs-review";
+
+export interface ExecutorConnectorExecutionResult {
+  status: ExecutorConnectorResultStatus;
+  summary?: string;
+  output?: Record<string, unknown>;
+  evidence?: Record<string, unknown>;
+}
+
+export interface ExecutorConnectorStatusSnapshot {
+  requestId: string;
+  status: ExecutorConnectorExecutionStatus;
+  observedAt?: string;
+  flowControl?: ExecutorFlowControlState;
+  result?: ExecutorConnectorExecutionResult;
+  evidence?: Record<string, unknown>;
+}
+
+export type ExecutorConnectorStatusResult =
+  ConnectorResult<ExecutorConnectorStatusSnapshot>;
+
+export type ExecutorConnectorCancelRequest = ConnectorCancelRequest;
+export type ExecutorConnectorCancelReceipt = ConnectorCancelReceipt;
+export type ExecutorConnectorCancelResult = ConnectorCancelResult;
+
+export type ExecutorConnectorFetchEvidenceRequest = ConnectorFetchEvidenceRequest;
+
+export interface ExecutorConnectorEvidenceBundle {
+  requestId: string;
+  evidence: Record<string, unknown>;
+}
+
+export type ExecutorConnectorFetchEvidenceResult =
+  ConnectorResult<ExecutorConnectorEvidenceBundle>;
+
+export interface ExecutorConnector {
+  identity: ConnectorIdentity;
+  capabilities: ConnectorCapabilities;
+  submit(
+    request: ExecutorSubmitRequest
+  ): Promise<ExecutorConnectorSubmitResult> | ExecutorConnectorSubmitResult;
+  status(
+    request: ExecutorConnectorStatusRequest
+  ): Promise<ExecutorConnectorStatusResult> | ExecutorConnectorStatusResult;
+  cancel(
+    request: ExecutorConnectorCancelRequest
+  ): Promise<ExecutorConnectorCancelResult> | ExecutorConnectorCancelResult;
+  fetchEvidence(
+    request: ExecutorConnectorFetchEvidenceRequest
+  ):
+    | Promise<ExecutorConnectorFetchEvidenceResult>
+    | ExecutorConnectorFetchEvidenceResult;
+}
+
+export const createExecutorConnectorCapabilities = (): ConnectorCapabilities => ({
+  submit: { supported: true },
+  status: { supported: true },
+  cancel: { supported: true },
+  fetchEvidence: { supported: true }
+});
+
+export const mapExecutorPolicyDecisionToFlowControlState = (
+  policyDecision: ExecutorPolicyDecisionPayload | undefined
+): ExecutorFlowControlState => {
+  if (policyDecision === undefined) {
+    return {
+      state: "blocked",
+      authority: "ensen-flow",
+      reason: "executor policy decision is missing"
+    };
+  }
+
+  const state = policyDecision.decision === "allow" ? "ready" : policyDecision.decision;
+
+  return {
+    state,
+    authority: "ensen-flow",
+    ...(policyDecision.reason === undefined ? {} : { reason: policyDecision.reason }),
+    policyDecision
+  };
+};
+
+export const createUnsupportedExecutorConnectorOperationResult = (
+  input: {
+    connectorId: string;
+    operation: ConnectorOperation;
+    reason: string;
+  }
+): ConnectorResult<never> => createUnsupportedConnectorOperationResult(input);

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,12 @@ export {
 } from "./connector.js";
 
 export {
+  createExecutorConnectorCapabilities,
+  createUnsupportedExecutorConnectorOperationResult,
+  mapExecutorPolicyDecisionToFlowControlState
+} from "./executor-connector.js";
+
+export {
   eipVersionBoundary,
   isSupportedEipProtocolVersion
 } from "./eip-version.js";
@@ -46,6 +52,29 @@ export type {
   UnsupportedConnectorOperationInput,
   WorkflowConnector
 } from "./connector.js";
+
+export type {
+  ExecutorConnector,
+  ExecutorConnectorCancelReceipt,
+  ExecutorConnectorCancelRequest,
+  ExecutorConnectorCancelResult,
+  ExecutorConnectorEvidenceBundle,
+  ExecutorConnectorExecutionResult,
+  ExecutorConnectorExecutionStatus,
+  ExecutorConnectorFetchEvidenceRequest,
+  ExecutorConnectorFetchEvidenceResult,
+  ExecutorConnectorResultStatus,
+  ExecutorConnectorStatusRequest,
+  ExecutorConnectorStatusResult,
+  ExecutorConnectorStatusSnapshot,
+  ExecutorConnectorSubmitReceipt,
+  ExecutorConnectorSubmitResult,
+  ExecutorFlowControlState,
+  ExecutorFlowControlStateName,
+  ExecutorPolicyDecision,
+  ExecutorPolicyDecisionPayload,
+  ExecutorSubmitRequest
+} from "./executor-connector.js";
 
 export type { EipVersionBoundary } from "./eip-version.js";
 

--- a/test/executor-connector.test.ts
+++ b/test/executor-connector.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createExecutorConnectorCapabilities,
+  createUnsupportedExecutorConnectorOperationResult,
+  mapExecutorPolicyDecisionToFlowControlState
+} from "../src/index.js";
+import type {
+  ExecutorConnector,
+  ExecutorConnectorStatusSnapshot,
+  ExecutorSubmitRequest
+} from "../src/index.js";
+
+describe("executor connector abstraction", () => {
+  const submitRequest: ExecutorSubmitRequest = {
+    workflow: { id: "executor-demo", version: "flow.workflow.v1" },
+    run: { id: "executor-demo-run" },
+    step: { id: "bounded-executor-step", attempt: 1 },
+    input: { subject: "demo" },
+    idempotencyKey: "executor-demo-run:bounded-executor-step:1"
+  };
+
+  it("supports submit, status, cancel, and fetchEvidence through the connector capability model", async () => {
+    const connector: ExecutorConnector = {
+      identity: { id: "bounded-executor", displayName: "Bounded Executor" },
+      capabilities: createExecutorConnectorCapabilities(),
+      submit(request) {
+        return {
+          ok: true,
+          connectorId: "bounded-executor",
+          operation: "submit",
+          value: {
+            requestId: `exec-${request.run.id}`,
+            acceptedAt: "2026-04-30T04:00:00.000Z",
+            flowControl: mapExecutorPolicyDecisionToFlowControlState({
+              decision: "allow",
+              decidedAt: "2026-04-30T04:00:00.000Z",
+              source: { type: "policy", id: "local-policy" }
+            })
+          }
+        };
+      },
+      status(request) {
+        return {
+          ok: true,
+          connectorId: "bounded-executor",
+          operation: "status",
+          value: {
+            requestId: request.requestId,
+            status: "succeeded",
+            observedAt: "2026-04-30T04:00:01.000Z",
+            result: {
+              status: "succeeded",
+              summary: "executor completed bounded work"
+            }
+          }
+        };
+      },
+      cancel(request) {
+        return {
+          ok: true,
+          connectorId: "bounded-executor",
+          operation: "cancel",
+          value: {
+            requestId: request.requestId,
+            cancelled: true,
+            observedAt: "2026-04-30T04:00:02.000Z"
+          }
+        };
+      },
+      fetchEvidence(request) {
+        return {
+          ok: true,
+          connectorId: "bounded-executor",
+          operation: "fetchEvidence",
+          value: {
+            requestId: request.requestId,
+            evidence: {
+              kind: "local-jsonl",
+              uri: "file://<executor-evidence-path>"
+            }
+          }
+        };
+      }
+    };
+
+    expect(connector.capabilities).toEqual({
+      submit: { supported: true },
+      status: { supported: true },
+      cancel: { supported: true },
+      fetchEvidence: { supported: true }
+    });
+
+    const submitted = await connector.submit(submitRequest);
+    expect(submitted).toMatchObject({
+      ok: true,
+      operation: "submit",
+      value: {
+        requestId: "exec-executor-demo-run",
+        flowControl: {
+          state: "ready",
+          authority: "ensen-flow"
+        }
+      }
+    });
+
+    if (!submitted.ok) {
+      throw new Error("submit should succeed");
+    }
+
+    const status = await connector.status({ requestId: submitted.value.requestId });
+    expect(status).toMatchObject({
+      ok: true,
+      operation: "status",
+      value: {
+        requestId: "exec-executor-demo-run",
+        status: "succeeded",
+        result: { status: "succeeded" }
+      }
+    });
+
+    const cancel = await connector.cancel({ requestId: submitted.value.requestId });
+    expect(cancel).toMatchObject({
+      ok: true,
+      operation: "cancel",
+      value: {
+        requestId: "exec-executor-demo-run",
+        cancelled: true
+      }
+    });
+
+    const evidence = await connector.fetchEvidence({ requestId: submitted.value.requestId });
+    expect(evidence).toMatchObject({
+      ok: true,
+      operation: "fetchEvidence",
+      value: {
+        requestId: "exec-executor-demo-run",
+        evidence: {
+          kind: "local-jsonl"
+        }
+      }
+    });
+  });
+
+  it("carries approval-required and blocked policy decisions as flow-owned control state", () => {
+    expect(
+      mapExecutorPolicyDecisionToFlowControlState({
+        decision: "approval-required",
+        reason: "human approval is required before dispatch",
+        source: { type: "policy", id: "approval-policy" }
+      })
+    ).toEqual({
+      state: "approval-required",
+      authority: "ensen-flow",
+      reason: "human approval is required before dispatch",
+      policyDecision: {
+        decision: "approval-required",
+        reason: "human approval is required before dispatch",
+        source: { type: "policy", id: "approval-policy" }
+      }
+    });
+
+    expect(
+      mapExecutorPolicyDecisionToFlowControlState({
+        decision: "blocked",
+        reason: "executor scope is not authorized",
+        source: { type: "policy", id: "scope-policy" }
+      })
+    ).toMatchObject({
+      state: "blocked",
+      authority: "ensen-flow",
+      reason: "executor scope is not authorized"
+    });
+  });
+
+  it("keeps unsupported executor operations fail-closed and auditable", () => {
+    const result = createUnsupportedExecutorConnectorOperationResult({
+      connectorId: "submit-only-executor",
+      operation: "fetchEvidence",
+      reason: "connector does not expose durable evidence"
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      connectorId: "submit-only-executor",
+      operation: "fetchEvidence",
+      error: {
+        code: "unsupported-operation",
+        message:
+          "connector submit-only-executor does not support fetchEvidence: connector does not expose durable evidence",
+        retryable: false,
+        reason: "connector does not expose durable evidence"
+      }
+    });
+  });
+
+  it("represents needs-review without treating the executor status as terminal success", () => {
+    const snapshot: ExecutorConnectorStatusSnapshot = {
+      requestId: "exec-review",
+      status: "needs-review",
+      observedAt: "2026-04-30T04:00:03.000Z",
+      flowControl: {
+        state: "needs-review",
+        authority: "ensen-flow",
+        reason: "executor returned ambiguous evidence"
+      }
+    };
+
+    expect(snapshot.status).toBe("needs-review");
+    expect(snapshot.flowControl?.state).toBe("needs-review");
+  });
+});


### PR DESCRIPTION
## Summary
- Add Ensen-flow-owned executor connector request/status/result/evidence types over the generic connector capability model
- Add flow-owned policy decision mapping for ready, approval-required, blocked, and needs-review states
- Add fail-closed unsupported executor operation helper and focused coverage for submit/status/cancel/evidence flows

## Verification
- npx vitest run test/executor-connector.test.ts
- npm run build
- npm test

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Executor connector abstraction layer now available in the public API, enabling submission of operations, status tracking, operation cancellation, and evidence retrieval with support for policy decisions and flow control states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->