### PR TITLE
FLOW-013: Add fake executor transport tests

### DIFF
--- a/test/executor-connector.test.ts
+++ b/test/executor-connector.test.ts
@@ -1,15 +1,18 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  createExecutorConnectorCapabilities,
+  createImmediateOnlyConnectorCapabilities,
   createUnsupportedExecutorConnectorOperationResult,
   mapExecutorPolicyDecisionToFlowControlState
 } from "../src/index.js";
 import type {
-  ExecutorConnector,
   ExecutorConnectorStatusSnapshot,
   ExecutorSubmitRequest
 } from "../src/index.js";
+import {
+  createFakeExecutorTransport,
+  fakeFlowControlForDecision
+} from "./support/fake-executor-transport.js";
 
 describe("executor connector abstraction", () => {
   const submitRequest: ExecutorSubmitRequest = {
@@ -20,69 +23,24 @@ describe("executor connector abstraction", () => {
     idempotencyKey: "executor-demo-run:bounded-executor-step:1"
   };
 
-  it("supports submit, status, cancel, and fetchEvidence through the connector capability model", async () => {
-    const connector: ExecutorConnector = {
-      identity: { id: "bounded-executor", displayName: "Bounded Executor" },
-      capabilities: createExecutorConnectorCapabilities(),
-      submit(request) {
-        return {
-          ok: true,
-          connectorId: "bounded-executor",
-          operation: "submit",
-          value: {
-            requestId: `exec-${request.run.id}`,
-            acceptedAt: "2026-04-30T04:00:00.000Z",
-            flowControl: mapExecutorPolicyDecisionToFlowControlState({
-              decision: "allow",
-              decidedAt: "2026-04-30T04:00:00.000Z",
-              source: { type: "policy", id: "local-policy" }
-            })
-          }
-        };
-      },
-      status(request) {
-        return {
-          ok: true,
-          connectorId: "bounded-executor",
-          operation: "status",
-          value: {
-            requestId: request.requestId,
+  it("supports a fake submit-to-result flow through the connector capability model", async () => {
+    const connector = createFakeExecutorTransport({
+      connectorId: "bounded-executor",
+      statusScript: [
+        {
+          status: "succeeded",
+          observedAt: "2026-04-30T04:00:01.000Z",
+          result: {
             status: "succeeded",
-            observedAt: "2026-04-30T04:00:01.000Z",
-            result: {
-              status: "succeeded",
-              summary: "executor completed bounded work"
-            }
+            summary: "executor completed bounded work"
           }
-        };
-      },
-      cancel(request) {
-        return {
-          ok: true,
-          connectorId: "bounded-executor",
-          operation: "cancel",
-          value: {
-            requestId: request.requestId,
-            cancelled: true,
-            observedAt: "2026-04-30T04:00:02.000Z"
-          }
-        };
-      },
-      fetchEvidence(request) {
-        return {
-          ok: true,
-          connectorId: "bounded-executor",
-          operation: "fetchEvidence",
-          value: {
-            requestId: request.requestId,
-            evidence: {
-              kind: "local-jsonl",
-              uri: "file://<executor-evidence-path>"
-            }
-          }
-        };
+        }
+      ],
+      evidence: {
+        kind: "local-jsonl",
+        uri: "artifacts/fake-executor/evidence.json"
       }
-    };
+    });
 
     expect(connector.capabilities).toEqual({
       submit: { supported: true },
@@ -91,12 +49,19 @@ describe("executor connector abstraction", () => {
       fetchEvidence: { supported: true }
     });
 
-    const submitted = await connector.submit(submitRequest);
+    const submitted = await connector.submit({
+      ...submitRequest,
+      policyDecision: {
+        decision: "allow",
+        decidedAt: "2026-04-30T04:00:00.000Z",
+        source: { type: "policy", id: "local-policy" }
+      }
+    });
     expect(submitted).toMatchObject({
       ok: true,
       operation: "submit",
       value: {
-        requestId: "exec-executor-demo-run",
+        requestId: "fake-executor-demo-run-bounded-executor-step-1",
         flowControl: {
           state: "ready",
           authority: "ensen-flow"
@@ -113,7 +78,7 @@ describe("executor connector abstraction", () => {
       ok: true,
       operation: "status",
       value: {
-        requestId: "exec-executor-demo-run",
+        requestId: "fake-executor-demo-run-bounded-executor-step-1",
         status: "succeeded",
         result: { status: "succeeded" }
       }
@@ -124,7 +89,7 @@ describe("executor connector abstraction", () => {
       ok: true,
       operation: "cancel",
       value: {
-        requestId: "exec-executor-demo-run",
+        requestId: "fake-executor-demo-run-bounded-executor-step-1",
         cancelled: true
       }
     });
@@ -134,10 +99,192 @@ describe("executor connector abstraction", () => {
       ok: true,
       operation: "fetchEvidence",
       value: {
-        requestId: "exec-executor-demo-run",
+        requestId: "fake-executor-demo-run-bounded-executor-step-1",
         evidence: {
           kind: "local-jsonl"
         }
+      }
+    });
+  });
+
+  it("scripts pending and running fake executor status before a terminal result", async () => {
+    const connector = createFakeExecutorTransport({
+      statusScript: [
+        { status: "accepted", observedAt: "2026-04-30T04:00:01.000Z" },
+        { status: "running", observedAt: "2026-04-30T04:00:02.000Z" },
+        {
+          status: "succeeded",
+          observedAt: "2026-04-30T04:00:03.000Z",
+          result: { status: "succeeded", summary: "fake executor finished" }
+        }
+      ]
+    });
+
+    const submitted = await connector.submit({
+      ...submitRequest,
+      policyDecision: { decision: "allow" }
+    });
+
+    if (!submitted.ok) {
+      throw new Error("submit should succeed");
+    }
+
+    expect(await connector.status({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: true,
+      value: { status: "accepted" }
+    });
+    expect(await connector.status({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: true,
+      value: { status: "running" }
+    });
+    expect(await connector.status({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: true,
+      value: {
+        status: "succeeded",
+        result: { status: "succeeded" }
+      }
+    });
+  });
+
+  it("maps blocked and needs-review fake outcomes to flow-owned control state", async () => {
+    const blocked = createFakeExecutorTransport({
+      statusScript: [
+        {
+          status: "blocked",
+          flowControl: fakeFlowControlForDecision({
+            decision: "blocked",
+            reason: "executor scope is not authorized",
+            source: { type: "policy", id: "scope-policy" }
+          }),
+          result: {
+            status: "blocked",
+            summary: "executor scope is not authorized"
+          }
+        }
+      ]
+    });
+    const needsReview = createFakeExecutorTransport({
+      statusScript: [
+        {
+          status: "needs-review",
+          flowControl: fakeFlowControlForDecision({
+            decision: "needs-review",
+            reason: "executor returned ambiguous evidence",
+            source: { type: "connector", id: "fake-executor-transport" }
+          })
+        }
+      ]
+    });
+
+    const blockedSubmit = await blocked.submit({
+      ...submitRequest,
+      policyDecision: { decision: "allow" }
+    });
+    const reviewSubmit = await needsReview.submit({
+      ...submitRequest,
+      run: { id: "executor-review-run" },
+      policyDecision: { decision: "allow" }
+    });
+
+    if (!blockedSubmit.ok || !reviewSubmit.ok) {
+      throw new Error("submits should succeed");
+    }
+
+    expect(await blocked.status({ requestId: blockedSubmit.value.requestId })).toMatchObject({
+      ok: true,
+      value: {
+        status: "blocked",
+        flowControl: {
+          state: "blocked",
+          authority: "ensen-flow",
+          reason: "executor scope is not authorized"
+        },
+        result: { status: "blocked" }
+      }
+    });
+    expect(await needsReview.status({ requestId: reviewSubmit.value.requestId })).toMatchObject({
+      ok: true,
+      value: {
+        status: "needs-review",
+        flowControl: {
+          state: "needs-review",
+          authority: "ensen-flow",
+          reason: "executor returned ambiguous evidence"
+        }
+      }
+    });
+  });
+
+  it("makes cancellation visible in later fake status reads", async () => {
+    const connector = createFakeExecutorTransport({
+      statusScript: [{ status: "running" }]
+    });
+    const submitted = await connector.submit({
+      ...submitRequest,
+      policyDecision: { decision: "allow" }
+    });
+
+    if (!submitted.ok) {
+      throw new Error("submit should succeed");
+    }
+
+    expect(await connector.cancel({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: true,
+      value: {
+        requestId: submitted.value.requestId,
+        cancelled: true
+      }
+    });
+    expect(await connector.status({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: true,
+      value: {
+        status: "cancelled",
+        result: { status: "cancelled" }
+      }
+    });
+  });
+
+  it("keeps immediate-only and partial fake executor capabilities fail-closed", async () => {
+    const immediateOnly = createFakeExecutorTransport({
+      connectorId: "fake-immediate-only",
+      capabilities: createImmediateOnlyConnectorCapabilities({
+        unsupportedReason: "fake immediate executor has no durable async handle"
+      })
+    });
+    const partial = createFakeExecutorTransport({
+      connectorId: "fake-partial-executor",
+      capabilities: {
+        fetchEvidence: {
+          supported: false,
+          reason: "fake partial executor does not expose durable evidence"
+        }
+      }
+    });
+
+    expect(await immediateOnly.status({ requestId: "fake-request" })).toMatchObject({
+      ok: false,
+      operation: "status",
+      error: {
+        code: "unsupported-operation",
+        reason: "fake immediate executor has no durable async handle"
+      }
+    });
+
+    const submitted = await partial.submit({
+      ...submitRequest,
+      policyDecision: { decision: "allow" }
+    });
+
+    if (!submitted.ok) {
+      throw new Error("partial submit should succeed");
+    }
+
+    expect(await partial.fetchEvidence({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: false,
+      operation: "fetchEvidence",
+      error: {
+        code: "unsupported-operation",
+        reason: "fake partial executor does not expose durable evidence"
       }
     });
   });

--- a/test/executor-connector.test.ts
+++ b/test/executor-connector.test.ts
@@ -146,6 +146,32 @@ describe("executor connector abstraction", () => {
     });
   });
 
+  it("keeps empty fake status scripts well-formed by using the default terminal status", async () => {
+    const connector = createFakeExecutorTransport({
+      statusScript: []
+    });
+    const submitted = await connector.submit({
+      ...submitRequest,
+      policyDecision: { decision: "allow" }
+    });
+
+    if (!submitted.ok) {
+      throw new Error("submit should succeed");
+    }
+
+    expect(await connector.status({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: true,
+      value: {
+        requestId: submitted.value.requestId,
+        status: "succeeded",
+        result: {
+          status: "succeeded",
+          summary: "fake executor completed bounded work"
+        }
+      }
+    });
+  });
+
   it("maps blocked and needs-review fake outcomes to flow-owned control state", async () => {
     const blocked = createFakeExecutorTransport({
       statusScript: [

--- a/test/support/fake-executor-transport.ts
+++ b/test/support/fake-executor-transport.ts
@@ -1,0 +1,241 @@
+import {
+  createExecutorConnectorCapabilities,
+  createUnsupportedExecutorConnectorOperationResult,
+  mapExecutorPolicyDecisionToFlowControlState
+} from "../../src/index.js";
+import type {
+  ConnectorCapabilities,
+  ConnectorOperation,
+  ConnectorOperationSupport,
+  ExecutorConnector,
+  ExecutorConnectorCancelRequest,
+  ExecutorConnectorCancelResult,
+  ExecutorConnectorExecutionResult,
+  ExecutorConnectorExecutionStatus,
+  ExecutorConnectorFetchEvidenceRequest,
+  ExecutorConnectorFetchEvidenceResult,
+  ExecutorConnectorStatusRequest,
+  ExecutorConnectorStatusResult,
+  ExecutorConnectorStatusSnapshot,
+  ExecutorConnectorSubmitResult,
+  ExecutorFlowControlState,
+  ExecutorPolicyDecisionPayload,
+  ExecutorSubmitRequest
+} from "../../src/index.js";
+
+// Phase 2 test boundary only: this fake transport exercises connector semantics
+// without invoking Ensen-loop, Codex, GitHub, Docker, ERPNext, or any service.
+export interface FakeExecutorTransportInput {
+  connectorId?: string;
+  capabilities?: Partial<Record<ConnectorOperation, ConnectorOperationSupport>>;
+  statusScript?: FakeExecutorStatusScriptItem[];
+  evidence?: Record<string, unknown>;
+}
+
+export interface FakeExecutorStatusScriptItem {
+  status: ExecutorConnectorExecutionStatus;
+  observedAt?: string;
+  flowControl?: ExecutorFlowControlState;
+  result?: ExecutorConnectorExecutionResult;
+  evidence?: Record<string, unknown>;
+}
+
+interface FakeExecutorRecord {
+  request: ExecutorSubmitRequest;
+  requestId: string;
+  cancelled: boolean;
+  statusIndex: number;
+}
+
+export const createFakeExecutorTransport = (
+  input: FakeExecutorTransportInput = {}
+): ExecutorConnector => {
+  const connectorId = input.connectorId ?? "fake-executor-transport";
+  const capabilities = createFakeCapabilities(input.capabilities);
+  const records = new Map<string, FakeExecutorRecord>();
+  const statusScript = input.statusScript ?? [
+    {
+      status: "succeeded",
+      observedAt: "2026-04-30T04:00:01.000Z",
+      result: {
+        status: "succeeded",
+        summary: "fake executor completed bounded work"
+      }
+    }
+  ];
+  const evidence = input.evidence ?? {
+    kind: "fake-executor-evidence",
+    uri: "artifacts/fake-executor/evidence.json"
+  };
+
+  const unsupported = (
+    operation: ConnectorOperation
+  ):
+    | ReturnType<typeof createUnsupportedExecutorConnectorOperationResult>
+    | undefined => {
+    const support = capabilities[operation];
+
+    if (support.supported) {
+      return undefined;
+    }
+
+    return createUnsupportedExecutorConnectorOperationResult({
+      connectorId,
+      operation,
+      reason: support.reason
+    });
+  };
+
+  return {
+    identity: {
+      id: connectorId,
+      displayName: "Fake Executor Transport",
+      version: "test-only"
+    },
+    capabilities,
+    submit(request: ExecutorSubmitRequest): ExecutorConnectorSubmitResult {
+      const blocked = unsupported("submit");
+
+      if (blocked !== undefined) {
+        return blocked;
+      }
+
+      const requestId = `fake-${request.run.id}-${request.step.id}-${request.step.attempt}`;
+      records.set(requestId, {
+        request,
+        requestId,
+        cancelled: false,
+        statusIndex: 0
+      });
+
+      return {
+        ok: true,
+        connectorId,
+        operation: "submit",
+        value: {
+          requestId,
+          acceptedAt: "2026-04-30T04:00:00.000Z",
+          flowControl: mapExecutorPolicyDecisionToFlowControlState(request.policyDecision)
+        }
+      };
+    },
+    status(request: ExecutorConnectorStatusRequest): ExecutorConnectorStatusResult {
+      const blocked = unsupported("status");
+
+      if (blocked !== undefined) {
+        return blocked;
+      }
+
+      const record = records.get(request.requestId);
+
+      if (record === undefined) {
+        return invalidRequest(connectorId, "status", "fake executor request is unknown");
+      }
+
+      if (record.cancelled) {
+        return {
+          ok: true,
+          connectorId,
+          operation: "status",
+          value: {
+            requestId: request.requestId,
+            status: "cancelled",
+            observedAt: "2026-04-30T04:00:05.000Z",
+            result: {
+              status: "cancelled",
+              summary: "fake executor request was cancelled"
+            }
+          }
+        };
+      }
+
+      const scripted = statusScript[Math.min(record.statusIndex, statusScript.length - 1)];
+      record.statusIndex += 1;
+
+      return {
+        ok: true,
+        connectorId,
+        operation: "status",
+        value: {
+          requestId: request.requestId,
+          ...scripted
+        } satisfies ExecutorConnectorStatusSnapshot
+      };
+    },
+    cancel(request: ExecutorConnectorCancelRequest): ExecutorConnectorCancelResult {
+      const blocked = unsupported("cancel");
+
+      if (blocked !== undefined) {
+        return blocked;
+      }
+
+      const record = records.get(request.requestId);
+
+      if (record === undefined) {
+        return invalidRequest(connectorId, "cancel", "fake executor request is unknown");
+      }
+
+      record.cancelled = true;
+
+      return {
+        ok: true,
+        connectorId,
+        operation: "cancel",
+        value: {
+          requestId: request.requestId,
+          cancelled: true,
+          observedAt: "2026-04-30T04:00:04.000Z"
+        }
+      };
+    },
+    fetchEvidence(
+      request: ExecutorConnectorFetchEvidenceRequest
+    ): ExecutorConnectorFetchEvidenceResult {
+      const blocked = unsupported("fetchEvidence");
+
+      if (blocked !== undefined) {
+        return blocked;
+      }
+
+      if (!records.has(request.requestId)) {
+        return invalidRequest(connectorId, "fetchEvidence", "fake executor request is unknown");
+      }
+
+      return {
+        ok: true,
+        connectorId,
+        operation: "fetchEvidence",
+        value: {
+          requestId: request.requestId,
+          evidence
+        }
+      };
+    }
+  };
+};
+
+export const fakeFlowControlForDecision = (
+  decision: ExecutorPolicyDecisionPayload
+): ExecutorFlowControlState => mapExecutorPolicyDecisionToFlowControlState(decision);
+
+const createFakeCapabilities = (
+  overrides: Partial<Record<ConnectorOperation, ConnectorOperationSupport>> | undefined
+): ConnectorCapabilities => ({
+  ...createExecutorConnectorCapabilities(),
+  ...overrides
+});
+
+const invalidRequest = (
+  connectorId: string,
+  operation: ConnectorOperation,
+  message: string
+) => ({
+  ok: false,
+  connectorId,
+  operation,
+  error: {
+    code: "invalid-request" as const,
+    message,
+    retryable: false
+  }
+});

--- a/test/support/fake-executor-transport.ts
+++ b/test/support/fake-executor-transport.ts
@@ -53,7 +53,7 @@ export const createFakeExecutorTransport = (
   const connectorId = input.connectorId ?? "fake-executor-transport";
   const capabilities = createFakeCapabilities(input.capabilities);
   const records = new Map<string, FakeExecutorRecord>();
-  const statusScript = input.statusScript ?? [
+  const defaultStatusScript: FakeExecutorStatusScriptItem[] = [
     {
       status: "succeeded",
       observedAt: "2026-04-30T04:00:01.000Z",
@@ -63,6 +63,10 @@ export const createFakeExecutorTransport = (
       }
     }
   ];
+  const statusScript =
+    Array.isArray(input.statusScript) && input.statusScript.length > 0
+      ? input.statusScript
+      : defaultStatusScript;
   const evidence = input.evidence ?? {
     kind: "fake-executor-evidence",
     uri: "artifacts/fake-executor/evidence.json"


### PR DESCRIPTION
## Summary
- Add a test-only scripted fake executor transport for Phase 2 connector coverage.
- Cover submit-to-result, accepted/running polling, blocked and needs-review flow control, cancellation visibility, evidence lookup, and unsupported immediate-only or partial capabilities.
- Keep fake transport under test/support so no production connector path defaults to it.

## Verification
- npm run build
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded executor connector test coverage with a scripted fake transport to simulate multi-step status flows (including intermediate accepted/running → succeeded).
  * Added tests verifying cancellation is reflected in later status reads and that connectors with limited capabilities fail closed for unsupported operations.
  * Added utilities to simulate transport behavior and to map policy decisions into flow-control outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->