### PR TITLE
FLOW-014: Implement Ensen-loop EIP executor connector

### DIFF
--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -1,5 +1,6 @@
 import {
   createExecutorConnectorCapabilities,
+  createUnsupportedExecutorConnectorOperationResult,
   mapExecutorPolicyDecisionToFlowControlState
 } from "./executor-connector.js";
 import type {
@@ -72,7 +73,6 @@ export const createEnsenLoopEipExecutorConnector = (
 ): ExecutorConnector => {
   const connectorId = input.connectorId ?? "ensen-loop-eip";
   const now = input.now ?? (() => new Date().toISOString());
-  const submittedRequests = new Map<string, EipRunRequestV1>();
 
   return {
     identity: {
@@ -80,12 +80,20 @@ export const createEnsenLoopEipExecutorConnector = (
       displayName: "Ensen-loop EIP Executor Connector",
       version: "eip.run-request.v1"
     },
-    capabilities: createExecutorConnectorCapabilities(),
+    capabilities: {
+      ...createExecutorConnectorCapabilities(),
+      cancel:
+        input.transport.cancelRunRequest === undefined
+          ? {
+              supported: false,
+              reason: "transport does not support cancellation"
+            }
+          : { supported: true }
+    },
     async submit(request: ExecutorSubmitRequest): Promise<ExecutorConnectorSubmitResult> {
       const payload = createRunRequestPayload(request, now());
       const submitted = await input.transport.submitRunRequest(payload);
       const requestId = submitted.requestId ?? payload.id;
-      submittedRequests.set(requestId, payload);
 
       return {
         ok: true,
@@ -102,10 +110,6 @@ export const createEnsenLoopEipExecutorConnector = (
       };
     },
     async status(request: ExecutorConnectorStatusRequest): Promise<ExecutorConnectorStatusResult> {
-      if (!submittedRequests.has(request.requestId)) {
-        return invalidRequest(connectorId, "status", "Ensen-loop EIP request is unknown");
-      }
-
       const snapshot = await input.transport.getRunStatusSnapshot(request);
       const statusVersion = requireSchemaVersion(
         snapshot,
@@ -184,32 +188,41 @@ export const createEnsenLoopEipExecutorConnector = (
       };
     },
     async cancel(request: ExecutorConnectorCancelRequest): Promise<ExecutorConnectorCancelResult> {
-      if (!submittedRequests.has(request.requestId)) {
-        return invalidRequest(connectorId, "cancel", "Ensen-loop EIP request is unknown");
+      if (input.transport.cancelRunRequest === undefined) {
+        return createUnsupportedExecutorConnectorOperationResult({
+          connectorId,
+          operation: "cancel",
+          reason: "transport does not support cancellation"
+        });
       }
 
-      const cancelled = input.transport.cancelRunRequest === undefined
-        ? { requestId: request.requestId, cancelled: true, observedAt: now() }
-        : await input.transport.cancelRunRequest(request);
+      const cancelled = await input.transport.cancelRunRequest(request);
+      const cancelValidation = validateCancelReceipt(cancelled);
+
+      if (cancelValidation !== undefined) {
+        return invalidRequest(connectorId, "cancel", cancelValidation.message, cancelValidation.reason);
+      }
+
+      const cancelReceipt = cancelled as {
+        requestId?: string;
+        cancelled: boolean;
+        observedAt?: string;
+      };
 
       return {
         ok: true,
         connectorId,
         operation: "cancel",
         value: {
-          requestId: cancelled.requestId ?? request.requestId,
-          cancelled: cancelled.cancelled ?? true,
-          observedAt: cancelled.observedAt
+          requestId: cancelReceipt.requestId ?? request.requestId,
+          cancelled: cancelReceipt.cancelled,
+          observedAt: cancelReceipt.observedAt
         }
       };
     },
     async fetchEvidence(
       request: ExecutorConnectorFetchEvidenceRequest
     ): Promise<ExecutorConnectorFetchEvidenceResult> {
-      if (!submittedRequests.has(request.requestId)) {
-        return invalidRequest(connectorId, "fetchEvidence", "Ensen-loop EIP request is unknown");
-      }
-
       const evidence = await input.transport.getEvidenceBundleRef(request);
       const evidenceVersion = requireSchemaVersion(
         evidence,
@@ -385,6 +398,40 @@ const validateRunStatusSnapshot = (
     return failClosedReason("EIP RunStatusSnapshot status is unsupported or malformed");
   }
 
+  if (value.observedAt !== undefined && typeof value.observedAt !== "string") {
+    return failClosedReason("EIP RunStatusSnapshot observedAt must be a string");
+  }
+
+  if (value.message !== undefined && typeof value.message !== "string") {
+    return failClosedReason("EIP RunStatusSnapshot message must be a string");
+  }
+
+  if (value.progress !== undefined && !isRecord(value.progress)) {
+    return failClosedReason("EIP RunStatusSnapshot progress must be an object");
+  }
+
+  return undefined;
+};
+
+const validateCancelReceipt = (
+  value: unknown
+): { message: string; reason: string } | undefined => {
+  if (!isRecord(value)) {
+    return failClosedReason("EIP cancel receipt must be an object");
+  }
+
+  if (value.requestId !== undefined && typeof value.requestId !== "string") {
+    return failClosedReason("EIP cancel receipt requestId must be a string");
+  }
+
+  if (typeof value.cancelled !== "boolean") {
+    return failClosedReason("EIP cancel receipt cancelled must be a boolean");
+  }
+
+  if (value.observedAt !== undefined && typeof value.observedAt !== "string") {
+    return failClosedReason("EIP cancel receipt observedAt must be a string");
+  }
+
   return undefined;
 };
 
@@ -402,6 +449,46 @@ const validateRunResult = (
 
   if (!isRunResultStatus(value.status)) {
     return failClosedReason("EIP RunResult status is unsupported or malformed");
+  }
+
+  if (value.completedAt !== undefined && typeof value.completedAt !== "string") {
+    return failClosedReason("EIP RunResult completedAt must be a string");
+  }
+
+  if (value.verification !== undefined) {
+    if (!isRecord(value.verification)) {
+      return failClosedReason("EIP RunResult verification must be an object");
+    }
+
+    if (
+      value.verification.status !== undefined &&
+      typeof value.verification.status !== "string"
+    ) {
+      return failClosedReason("EIP RunResult verification.status must be a string");
+    }
+
+    if (
+      value.verification.summary !== undefined &&
+      typeof value.verification.summary !== "string"
+    ) {
+      return failClosedReason("EIP RunResult verification.summary must be a string");
+    }
+  }
+
+  if (value.evidenceBundles !== undefined && !Array.isArray(value.evidenceBundles)) {
+    return failClosedReason("EIP RunResult evidenceBundles must be an array");
+  }
+
+  if (value.errors !== undefined && !Array.isArray(value.errors)) {
+    return failClosedReason("EIP RunResult errors must be an array");
+  }
+
+  if (value.warnings !== undefined && !Array.isArray(value.warnings)) {
+    return failClosedReason("EIP RunResult warnings must be an array");
+  }
+
+  if (value.metrics !== undefined && !isRecord(value.metrics)) {
+    return failClosedReason("EIP RunResult metrics must be an object");
   }
 
   return undefined;

--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -1,0 +1,521 @@
+import {
+  createExecutorConnectorCapabilities,
+  mapExecutorPolicyDecisionToFlowControlState
+} from "./executor-connector.js";
+import type {
+  ConnectorErrorBody,
+  ConnectorResult
+} from "./connector.js";
+import type {
+  EipRunRequestActorRef,
+  EipRunRequestMode,
+  EipRunRequestPolicyContext,
+  EipRunRequestSourceRef,
+  EipRunRequestTarget,
+  EipRunRequestWorkItem,
+  ExecutorConnector,
+  ExecutorConnectorCancelRequest,
+  ExecutorConnectorCancelResult,
+  ExecutorConnectorExecutionResult,
+  ExecutorConnectorExecutionStatus,
+  ExecutorConnectorFetchEvidenceRequest,
+  ExecutorConnectorFetchEvidenceResult,
+  ExecutorConnectorResultStatus,
+  ExecutorConnectorStatusRequest,
+  ExecutorConnectorStatusResult,
+  ExecutorConnectorStatusSnapshot,
+  ExecutorConnectorSubmitResult,
+  ExecutorFlowControlState,
+  ExecutorSubmitRequest
+} from "./executor-connector.js";
+
+export interface EipRunRequestV1 {
+  schemaVersion: "eip.run-request.v1";
+  id: string;
+  correlationId: string;
+  idempotencyKey: string;
+  source: EipRunRequestSourceRef;
+  requestedBy: EipRunRequestActorRef;
+  workItem: EipRunRequestWorkItem;
+  mode: EipRunRequestMode;
+  createdAt: string;
+  target?: EipRunRequestTarget;
+  policyContext?: EipRunRequestPolicyContext;
+  dataClassification?: string;
+  extensions?: Record<string, unknown>;
+}
+
+export interface EnsenLoopEipExecutorTransport {
+  submitRunRequest(
+    request: EipRunRequestV1
+  ):
+    | Promise<{ requestId?: string; acceptedAt?: string; evidence?: Record<string, unknown> }>
+    | { requestId?: string; acceptedAt?: string; evidence?: Record<string, unknown> };
+  getRunStatusSnapshot(request: { requestId: string }): Promise<unknown> | unknown;
+  getRunResult(request: { requestId: string }): Promise<unknown> | unknown;
+  getEvidenceBundleRef(request: { requestId: string }): Promise<unknown> | unknown;
+  cancelRunRequest?(
+    request: ExecutorConnectorCancelRequest
+  ):
+    | Promise<{ requestId?: string; cancelled?: boolean; observedAt?: string }>
+    | { requestId?: string; cancelled?: boolean; observedAt?: string };
+}
+
+export interface CreateEnsenLoopEipExecutorConnectorInput {
+  connectorId?: string;
+  transport: EnsenLoopEipExecutorTransport;
+  now?: () => string;
+}
+
+export const createEnsenLoopEipExecutorConnector = (
+  input: CreateEnsenLoopEipExecutorConnectorInput
+): ExecutorConnector => {
+  const connectorId = input.connectorId ?? "ensen-loop-eip";
+  const now = input.now ?? (() => new Date().toISOString());
+  const submittedRequests = new Map<string, EipRunRequestV1>();
+
+  return {
+    identity: {
+      id: connectorId,
+      displayName: "Ensen-loop EIP Executor Connector",
+      version: "eip.run-request.v1"
+    },
+    capabilities: createExecutorConnectorCapabilities(),
+    async submit(request: ExecutorSubmitRequest): Promise<ExecutorConnectorSubmitResult> {
+      const payload = createRunRequestPayload(request, now());
+      const submitted = await input.transport.submitRunRequest(payload);
+      const requestId = submitted.requestId ?? payload.id;
+      submittedRequests.set(requestId, payload);
+
+      return {
+        ok: true,
+        connectorId,
+        operation: "submit",
+        value: {
+          requestId,
+          acceptedAt: submitted.acceptedAt,
+          flowControl: mapExecutorPolicyDecisionToFlowControlState(
+            request.policyDecision ?? { decision: "allow" }
+          ),
+          ...(submitted.evidence === undefined ? {} : { evidence: submitted.evidence })
+        }
+      };
+    },
+    async status(request: ExecutorConnectorStatusRequest): Promise<ExecutorConnectorStatusResult> {
+      if (!submittedRequests.has(request.requestId)) {
+        return invalidRequest(connectorId, "status", "Ensen-loop EIP request is unknown");
+      }
+
+      const snapshot = await input.transport.getRunStatusSnapshot(request);
+      const statusVersion = requireSchemaVersion(
+        snapshot,
+        "eip.run-status.v1",
+        "RunStatusSnapshot"
+      );
+
+      if (statusVersion !== undefined) {
+        return invalidRequest(connectorId, "status", statusVersion.message, statusVersion.reason);
+      }
+
+      const statusValidation = validateRunStatusSnapshot(snapshot, request.requestId);
+
+      if (statusValidation !== undefined) {
+        return invalidRequest(
+          connectorId,
+          "status",
+          statusValidation.message,
+          statusValidation.reason
+        );
+      }
+
+      const status = snapshot as EipRunStatusSnapshotV1;
+      const mappedStatus = mapRunStatus(status.status);
+
+      if (status.status === "completed") {
+        const result = await input.transport.getRunResult(request);
+        const resultVersion = requireSchemaVersion(result, "eip.run-result.v1", "RunResult");
+
+        if (resultVersion !== undefined) {
+          return invalidRequest(connectorId, "status", resultVersion.message, resultVersion.reason);
+        }
+
+        const resultValidation = validateRunResult(result, request.requestId);
+
+        if (resultValidation !== undefined) {
+          return invalidRequest(
+            connectorId,
+            "status",
+            resultValidation.message,
+            resultValidation.reason
+          );
+        }
+
+        return {
+          ok: true,
+          connectorId,
+          operation: "status",
+          value: mapRunResultToStatusSnapshot(result as EipRunResultV1, status.observedAt)
+        };
+      }
+
+      return {
+        ok: true,
+        connectorId,
+        operation: "status",
+        value: {
+          requestId: status.requestId,
+          status: mappedStatus,
+          observedAt: status.observedAt,
+          ...(status.message === undefined
+            ? {}
+            : { evidence: { message: status.message, progress: status.progress } }),
+          ...(mappedStatus === "blocked" || mappedStatus === "needs-review"
+            ? { flowControl: flowControlForStatus(mappedStatus, status.message) }
+            : {}),
+          ...(mappedStatus === "failed" || mappedStatus === "cancelled" || mappedStatus === "blocked"
+            ? {
+                result: {
+                  status: resultStatusForExecutionStatus(mappedStatus),
+                  ...(status.message === undefined ? {} : { summary: status.message })
+                }
+              }
+            : {})
+        }
+      };
+    },
+    async cancel(request: ExecutorConnectorCancelRequest): Promise<ExecutorConnectorCancelResult> {
+      if (!submittedRequests.has(request.requestId)) {
+        return invalidRequest(connectorId, "cancel", "Ensen-loop EIP request is unknown");
+      }
+
+      const cancelled = input.transport.cancelRunRequest === undefined
+        ? { requestId: request.requestId, cancelled: true, observedAt: now() }
+        : await input.transport.cancelRunRequest(request);
+
+      return {
+        ok: true,
+        connectorId,
+        operation: "cancel",
+        value: {
+          requestId: cancelled.requestId ?? request.requestId,
+          cancelled: cancelled.cancelled ?? true,
+          observedAt: cancelled.observedAt
+        }
+      };
+    },
+    async fetchEvidence(
+      request: ExecutorConnectorFetchEvidenceRequest
+    ): Promise<ExecutorConnectorFetchEvidenceResult> {
+      if (!submittedRequests.has(request.requestId)) {
+        return invalidRequest(connectorId, "fetchEvidence", "Ensen-loop EIP request is unknown");
+      }
+
+      const evidence = await input.transport.getEvidenceBundleRef(request);
+      const evidenceVersion = requireSchemaVersion(
+        evidence,
+        "eip.evidence-bundle-ref.v1",
+        "EvidenceBundleRef"
+      );
+
+      if (evidenceVersion !== undefined) {
+        return invalidRequest(
+          connectorId,
+          "fetchEvidence",
+          evidenceVersion.message,
+          evidenceVersion.reason
+        );
+      }
+
+      return {
+        ok: true,
+        connectorId,
+        operation: "fetchEvidence",
+        value: {
+          requestId: request.requestId,
+          evidence: evidence as Record<string, unknown>
+        }
+      };
+    }
+  };
+};
+
+interface EipRunStatusSnapshotV1 {
+  schemaVersion: "eip.run-status.v1";
+  requestId: string;
+  status:
+    | "accepted"
+    | "queued"
+    | "running"
+    | "cancelling"
+    | "cancelled"
+    | "completed"
+    | "failed"
+    | "blocked"
+    | "unknown";
+  observedAt?: string;
+  message?: string;
+  progress?: Record<string, unknown>;
+}
+
+interface EipRunResultV1 {
+  schemaVersion: "eip.run-result.v1";
+  requestId: string;
+  status: "succeeded" | "failed" | "blocked" | "needs_review" | "cancelled";
+  completedAt?: string;
+  verification?: {
+    status?: string;
+    summary?: string;
+  };
+  evidenceBundles?: unknown[];
+  errors?: unknown[];
+  warnings?: unknown[];
+  metrics?: Record<string, unknown>;
+}
+
+const createRunRequestPayload = (
+  request: ExecutorSubmitRequest,
+  createdAt: string
+): EipRunRequestV1 => {
+  const suffix = safeIdentifier(`${request.run.id}-${request.step.id}-${request.step.attempt}`);
+  const idempotencyKey =
+    request.idempotencyKey ??
+    `${request.workflow.id}:${request.run.id}:${request.step.id}:${request.step.attempt}`;
+
+  return {
+    schemaVersion: "eip.run-request.v1",
+    id: `req_${suffix}`,
+    correlationId: `corr_${suffix}`,
+    idempotencyKey,
+    source: request.source ?? {
+      sourceId: `source_${safeIdentifier(request.workflow.id)}`,
+      sourceType: "manual"
+    },
+    requestedBy: request.requestedBy ?? {
+      actorId: "actor_ensen_flow",
+      actorType: "system",
+      displayName: "Ensen-flow"
+    },
+    workItem: request.workItem ?? {
+      workItemId: `workitem_${suffix}`,
+      externalId: request.step.id,
+      title: request.step.id
+    },
+    mode: request.mode ?? "validate",
+    createdAt,
+    ...(request.target === undefined ? {} : { target: request.target }),
+    ...(request.policyContext === undefined ? {} : { policyContext: request.policyContext }),
+    ...(request.dataClassification === undefined
+      ? {}
+      : { dataClassification: request.dataClassification }),
+    extensions: {
+      "x-ensen-flow": {
+        workflowId: request.workflow.id,
+        workflowVersion: request.workflow.version,
+        runId: request.run.id,
+        stepId: request.step.id,
+        attempt: request.step.attempt,
+        ...(request.input === undefined ? {} : { input: request.input })
+      }
+    }
+  };
+};
+
+const mapRunStatus = (status: EipRunStatusSnapshotV1["status"]): ExecutorConnectorExecutionStatus => {
+  switch (status) {
+    case "accepted":
+    case "queued":
+      return "accepted";
+    case "running":
+    case "cancelling":
+      return "running";
+    case "cancelled":
+      return "cancelled";
+    case "completed":
+      return "succeeded";
+    case "failed":
+      return "failed";
+    case "blocked":
+      return "blocked";
+    case "unknown":
+      return "needs-review";
+  }
+};
+
+const mapRunResultToStatusSnapshot = (
+  result: EipRunResultV1,
+  observedAt?: string
+): ExecutorConnectorStatusSnapshot => {
+  const resultStatus = mapRunResultStatus(result.status);
+  const summary = result.verification?.summary;
+  const evidence = {
+    ...(result.evidenceBundles === undefined ? {} : { evidenceBundles: result.evidenceBundles }),
+    ...(result.errors === undefined ? {} : { errors: result.errors }),
+    ...(result.warnings === undefined ? {} : { warnings: result.warnings }),
+    ...(result.metrics === undefined ? {} : { metrics: result.metrics })
+  };
+
+  return {
+    requestId: result.requestId,
+    status: resultStatus,
+    observedAt: result.completedAt ?? observedAt,
+    ...(resultStatus === "blocked" || resultStatus === "needs-review"
+      ? { flowControl: flowControlForStatus(resultStatus, summary) }
+      : {}),
+    result: {
+      status: resultStatusForExecutionStatus(resultStatus),
+      ...(summary === undefined ? {} : { summary }),
+      ...(Object.keys(evidence).length === 0 ? {} : { evidence })
+    } satisfies ExecutorConnectorExecutionResult
+  };
+};
+
+const validateRunStatusSnapshot = (
+  value: unknown,
+  expectedRequestId: string
+): { message: string; reason: string } | undefined => {
+  if (!isRecord(value)) {
+    return failClosedReason("EIP RunStatusSnapshot must be an object");
+  }
+
+  if (typeof value.requestId !== "string" || value.requestId !== expectedRequestId) {
+    return failClosedReason("EIP RunStatusSnapshot requestId does not match the submitted request");
+  }
+
+  if (!isRunStatus(value.status)) {
+    return failClosedReason("EIP RunStatusSnapshot status is unsupported or malformed");
+  }
+
+  return undefined;
+};
+
+const validateRunResult = (
+  value: unknown,
+  expectedRequestId: string
+): { message: string; reason: string } | undefined => {
+  if (!isRecord(value)) {
+    return failClosedReason("EIP RunResult must be an object");
+  }
+
+  if (typeof value.requestId !== "string" || value.requestId !== expectedRequestId) {
+    return failClosedReason("EIP RunResult requestId does not match the submitted request");
+  }
+
+  if (!isRunResultStatus(value.status)) {
+    return failClosedReason("EIP RunResult status is unsupported or malformed");
+  }
+
+  return undefined;
+};
+
+const mapRunResultStatus = (status: EipRunResultV1["status"]): ExecutorConnectorExecutionStatus => {
+  switch (status) {
+    case "succeeded":
+      return "succeeded";
+    case "failed":
+      return "failed";
+    case "blocked":
+      return "blocked";
+    case "needs_review":
+      return "needs-review";
+    case "cancelled":
+      return "cancelled";
+  }
+};
+
+const resultStatusForExecutionStatus = (
+  status: ExecutorConnectorExecutionStatus
+): ExecutorConnectorResultStatus => {
+  switch (status) {
+    case "approval-required":
+      return "approval-required";
+    case "blocked":
+      return "blocked";
+    case "needs-review":
+      return "needs-review";
+    case "cancelled":
+      return "cancelled";
+    case "failed":
+      return "failed";
+    case "accepted":
+    case "running":
+    case "succeeded":
+      return "succeeded";
+  }
+};
+
+const flowControlForStatus = (
+  status: "blocked" | "needs-review",
+  reason: string | undefined
+): ExecutorFlowControlState => ({
+  state: status,
+  authority: "ensen-flow",
+  ...(reason === undefined ? {} : { reason })
+});
+
+const requireSchemaVersion = (
+  value: unknown,
+  expected: string,
+  shapeName: string
+): { message: string; reason: string } | undefined => {
+  const schemaVersion = isRecord(value) ? value.schemaVersion : undefined;
+
+  if (schemaVersion === expected) {
+    return undefined;
+  }
+
+  const versionText = typeof schemaVersion === "string" ? schemaVersion : "missing";
+  return {
+    message: `unsupported EIP ${shapeName} schemaVersion ${versionText}`,
+    reason: `unsupported EIP ${shapeName} schemaVersion ${versionText}`
+  };
+};
+
+const failClosedReason = (reason: string): { message: string; reason: string } => ({
+  message: reason,
+  reason
+});
+
+const isRunStatus = (value: unknown): value is EipRunStatusSnapshotV1["status"] =>
+  value === "accepted" ||
+  value === "queued" ||
+  value === "running" ||
+  value === "cancelling" ||
+  value === "cancelled" ||
+  value === "completed" ||
+  value === "failed" ||
+  value === "blocked" ||
+  value === "unknown";
+
+const isRunResultStatus = (value: unknown): value is EipRunResultV1["status"] =>
+  value === "succeeded" ||
+  value === "failed" ||
+  value === "blocked" ||
+  value === "needs_review" ||
+  value === "cancelled";
+
+const invalidRequest = <TValue>(
+  connectorId: string,
+  operation: "submit" | "status" | "cancel" | "fetchEvidence",
+  message: string,
+  reason?: string
+): ConnectorResult<TValue> => ({
+  ok: false,
+  connectorId,
+  operation,
+  error: {
+    code: "invalid-request",
+    message,
+    retryable: false,
+    ...(reason === undefined ? {} : { reason })
+  } satisfies ConnectorErrorBody
+});
+
+const safeIdentifier = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 120) || "local";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);

--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -197,7 +197,7 @@ export const createEnsenLoopEipExecutorConnector = (
       }
 
       const cancelled = await input.transport.cancelRunRequest(request);
-      const cancelValidation = validateCancelReceipt(cancelled);
+      const cancelValidation = validateCancelReceipt(cancelled, request.requestId);
 
       if (cancelValidation !== undefined) {
         return invalidRequest(connectorId, "cancel", cancelValidation.message, cancelValidation.reason);
@@ -414,14 +414,21 @@ const validateRunStatusSnapshot = (
 };
 
 const validateCancelReceipt = (
-  value: unknown
+  value: unknown,
+  expectedRequestId: string
 ): { message: string; reason: string } | undefined => {
   if (!isRecord(value)) {
     return failClosedReason("EIP cancel receipt must be an object");
   }
 
-  if (value.requestId !== undefined && typeof value.requestId !== "string") {
-    return failClosedReason("EIP cancel receipt requestId must be a string");
+  if (value.requestId !== undefined) {
+    if (typeof value.requestId !== "string") {
+      return failClosedReason("EIP cancel receipt requestId must be a string");
+    }
+
+    if (value.requestId !== expectedRequestId) {
+      return failClosedReason("EIP cancel receipt requestId does not match the submitted request");
+    }
   }
 
   if (typeof value.cancelled !== "boolean") {

--- a/src/executor-connector.ts
+++ b/src/executor-connector.ts
@@ -53,6 +53,46 @@ export interface ExecutorSubmitRequest {
   input?: Record<string, unknown>;
   idempotencyKey?: string;
   policyDecision?: ExecutorPolicyDecisionPayload;
+  source?: EipRunRequestSourceRef;
+  requestedBy?: EipRunRequestActorRef;
+  workItem?: EipRunRequestWorkItem;
+  mode?: EipRunRequestMode;
+  target?: EipRunRequestTarget;
+  policyContext?: EipRunRequestPolicyContext;
+  dataClassification?: string;
+}
+
+export type EipRunRequestMode = "plan" | "apply" | "validate";
+
+export interface EipRunRequestSourceRef {
+  sourceId: string;
+  sourceType: string;
+  externalRef?: string;
+}
+
+export interface EipRunRequestActorRef {
+  actorId: string;
+  actorType: string;
+  displayName?: string;
+}
+
+export interface EipRunRequestWorkItem {
+  workItemId: string;
+  externalId: string;
+  title?: string;
+  url?: string;
+}
+
+export interface EipRunRequestTarget {
+  targetType: "repository" | "workspace" | "environment" | "manual";
+  targetId: string;
+  externalRef?: string;
+}
+
+export interface EipRunRequestPolicyContext {
+  policySetId?: string;
+  riskClasses?: string[];
+  requiresApproval?: boolean;
 }
 
 export interface ExecutorConnectorSubmitReceipt {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,10 @@ export {
 } from "./connector.js";
 
 export {
+  createEnsenLoopEipExecutorConnector
+} from "./ensen-loop-eip-executor-connector.js";
+
+export {
   createExecutorConnectorCapabilities,
   createUnsupportedExecutorConnectorOperationResult,
   mapExecutorPolicyDecisionToFlowControlState
@@ -54,6 +58,12 @@ export type {
 } from "./connector.js";
 
 export type {
+  CreateEnsenLoopEipExecutorConnectorInput,
+  EipRunRequestV1,
+  EnsenLoopEipExecutorTransport
+} from "./ensen-loop-eip-executor-connector.js";
+
+export type {
   ExecutorConnector,
   ExecutorConnectorCancelReceipt,
   ExecutorConnectorCancelRequest,
@@ -71,6 +81,12 @@ export type {
   ExecutorConnectorSubmitResult,
   ExecutorFlowControlState,
   ExecutorFlowControlStateName,
+  EipRunRequestActorRef,
+  EipRunRequestMode,
+  EipRunRequestPolicyContext,
+  EipRunRequestSourceRef,
+  EipRunRequestTarget,
+  EipRunRequestWorkItem,
   ExecutorPolicyDecision,
   ExecutorPolicyDecisionPayload,
   ExecutorSubmitRequest

--- a/test/executor-connector.test.ts
+++ b/test/executor-connector.test.ts
@@ -638,6 +638,49 @@ describe("Ensen-loop EIP executor connector", () => {
     });
   });
 
+  it("fails closed when an EIP cancel receipt belongs to a different request", async () => {
+    const connector = createEnsenLoopEipExecutorConnector({
+      transport: {
+        submitRunRequest(payload) {
+          return { requestId: payload.id };
+        },
+        getRunStatusSnapshot() {
+          return {
+            schemaVersion: "eip.run-status.v1",
+            requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+            status: "running"
+          };
+        },
+        getRunResult() {
+          throw new Error("result should not be fetched for a mismatched cancel receipt");
+        },
+        getEvidenceBundleRef() {
+          throw new Error("evidence should not be fetched for a mismatched cancel receipt");
+        },
+        cancelRunRequest() {
+          return {
+            requestId: "req_other_loop_run",
+            cancelled: true
+          };
+        }
+      }
+    });
+    const submitted = await connector.submit(submitRequest);
+
+    if (!submitted.ok) {
+      throw new Error("submit should succeed");
+    }
+
+    expect(await connector.cancel({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: false,
+      operation: "cancel",
+      error: {
+        code: "invalid-request",
+        reason: "EIP cancel receipt requestId does not match the submitted request"
+      }
+    });
+  });
+
   it("uses remote EIP payload validation instead of same-instance submit state", async () => {
     const observedStatusRequests: string[] = [];
     const transport = {

--- a/test/executor-connector.test.ts
+++ b/test/executor-connector.test.ts
@@ -550,6 +550,163 @@ describe("Ensen-loop EIP executor connector", () => {
     });
   });
 
+  it("does not advertise or synthesize cancellation when the EIP transport has no cancel endpoint", async () => {
+    const connector = createEnsenLoopEipExecutorConnector({
+      transport: {
+        submitRunRequest(payload) {
+          return { requestId: payload.id };
+        },
+        getRunStatusSnapshot() {
+          return {
+            schemaVersion: "eip.run-status.v1",
+            requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+            status: "running"
+          };
+        },
+        getRunResult() {
+          throw new Error("result should not be fetched for a running status");
+        },
+        getEvidenceBundleRef() {
+          return {
+            schemaVersion: "eip.evidence-bundle-ref.v1",
+            id: "evb_loop_eip_bundle"
+          };
+        }
+      }
+    });
+
+    expect(connector.capabilities.cancel).toEqual({
+      supported: false,
+      reason: "transport does not support cancellation"
+    });
+
+    const submitted = await connector.submit(submitRequest);
+
+    if (!submitted.ok) {
+      throw new Error("submit should succeed");
+    }
+
+    expect(await connector.cancel({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: false,
+      operation: "cancel",
+      error: {
+        code: "unsupported-operation",
+        reason: "transport does not support cancellation"
+      }
+    });
+  });
+
+  it("fails closed when an EIP cancel endpoint omits the cancelled receipt", async () => {
+    const connector = createEnsenLoopEipExecutorConnector({
+      transport: {
+        submitRunRequest(payload) {
+          return { requestId: payload.id };
+        },
+        getRunStatusSnapshot() {
+          return {
+            schemaVersion: "eip.run-status.v1",
+            requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+            status: "running"
+          };
+        },
+        getRunResult() {
+          throw new Error("result should not be fetched for a cancel receipt");
+        },
+        getEvidenceBundleRef() {
+          throw new Error("evidence should not be fetched for a cancel receipt");
+        },
+        cancelRunRequest() {
+          return {
+            requestId: "req_loop_eip_demo_run_loop_executor_step_1"
+          };
+        }
+      }
+    });
+    const submitted = await connector.submit(submitRequest);
+
+    if (!submitted.ok) {
+      throw new Error("submit should succeed");
+    }
+
+    expect(await connector.cancel({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: false,
+      operation: "cancel",
+      error: {
+        code: "invalid-request",
+        reason: "EIP cancel receipt cancelled must be a boolean"
+      }
+    });
+  });
+
+  it("uses remote EIP payload validation instead of same-instance submit state", async () => {
+    const observedStatusRequests: string[] = [];
+    const transport = {
+      submitRunRequest(payload: { id: string }) {
+        return { requestId: payload.id };
+      },
+      getRunStatusSnapshot(request: { requestId: string }) {
+        observedStatusRequests.push(request.requestId);
+        return {
+          schemaVersion: "eip.run-status.v1",
+          requestId: request.requestId,
+          status: "running",
+          observedAt: "2026-04-30T04:00:02.000Z"
+        };
+      },
+      getRunResult() {
+        throw new Error("result should not be fetched for a running status");
+      },
+      getEvidenceBundleRef(request: { requestId: string }) {
+        return {
+          schemaVersion: "eip.evidence-bundle-ref.v1",
+          id: "evb_loop_eip_bundle",
+          requestId: request.requestId
+        };
+      },
+      cancelRunRequest(request: { requestId: string }) {
+        return {
+          requestId: request.requestId,
+          cancelled: true,
+          observedAt: "2026-04-30T04:00:04.000Z"
+        };
+      }
+    };
+    const submittingConnector = createEnsenLoopEipExecutorConnector({ transport });
+    const submitted = await submittingConnector.submit(submitRequest);
+
+    if (!submitted.ok) {
+      throw new Error("submit should succeed");
+    }
+
+    const followUpConnector = createEnsenLoopEipExecutorConnector({ transport });
+
+    expect(await followUpConnector.status({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: true,
+      value: {
+        requestId: submitted.value.requestId,
+        status: "running"
+      }
+    });
+    expect(await followUpConnector.fetchEvidence({ requestId: submitted.value.requestId }))
+      .toMatchObject({
+        ok: true,
+        value: {
+          requestId: submitted.value.requestId,
+          evidence: {
+            schemaVersion: "eip.evidence-bundle-ref.v1"
+          }
+        }
+      });
+    expect(await followUpConnector.cancel({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: true,
+      value: {
+        requestId: submitted.value.requestId,
+        cancelled: true
+      }
+    });
+    expect(observedStatusRequests).toEqual([submitted.value.requestId]);
+  });
+
   it("maps blocked and needs-review EIP RunResult statuses to flow-owned states", async () => {
     const createTerminalConnector = (status: "blocked" | "needs_review", summary: string) =>
       createEnsenLoopEipExecutorConnector({
@@ -677,6 +834,92 @@ describe("Ensen-loop EIP executor connector", () => {
         code: "invalid-request",
         retryable: false,
         reason: "unsupported EIP RunStatusSnapshot schemaVersion eip.run-status.v2"
+      }
+    });
+  });
+
+  it("fails closed for malformed optional EIP RunStatusSnapshot fields", async () => {
+    const connector = createEnsenLoopEipExecutorConnector({
+      transport: {
+        submitRunRequest(payload) {
+          return { requestId: payload.id };
+        },
+        getRunStatusSnapshot() {
+          return {
+            schemaVersion: "eip.run-status.v1",
+            requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+            status: "running",
+            message: 123
+          };
+        },
+        getRunResult() {
+          throw new Error("result should not be fetched for malformed status snapshots");
+        },
+        getEvidenceBundleRef() {
+          throw new Error("evidence should not be fetched for malformed status snapshots");
+        }
+      }
+    });
+    const submitted = await connector.submit(submitRequest);
+
+    if (!submitted.ok) {
+      throw new Error("submit should succeed");
+    }
+
+    expect(await connector.status({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: false,
+      operation: "status",
+      error: {
+        code: "invalid-request",
+        retryable: false,
+        reason: "EIP RunStatusSnapshot message must be a string"
+      }
+    });
+  });
+
+  it("fails closed for malformed optional EIP RunResult fields", async () => {
+    const connector = createEnsenLoopEipExecutorConnector({
+      transport: {
+        submitRunRequest(payload) {
+          return { requestId: payload.id };
+        },
+        getRunStatusSnapshot() {
+          return {
+            schemaVersion: "eip.run-status.v1",
+            requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+            status: "completed",
+            observedAt: "2026-04-30T04:00:02.000Z"
+          };
+        },
+        getRunResult() {
+          return {
+            schemaVersion: "eip.run-result.v1",
+            requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+            status: "succeeded",
+            verification: {
+              status: "passed",
+              summary: 123
+            }
+          };
+        },
+        getEvidenceBundleRef() {
+          throw new Error("evidence should not be fetched for malformed run results");
+        }
+      }
+    });
+    const submitted = await connector.submit(submitRequest);
+
+    if (!submitted.ok) {
+      throw new Error("submit should succeed");
+    }
+
+    expect(await connector.status({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: false,
+      operation: "status",
+      error: {
+        code: "invalid-request",
+        retryable: false,
+        reason: "EIP RunResult verification.summary must be a string"
       }
     });
   });

--- a/test/executor-connector.test.ts
+++ b/test/executor-connector.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  createEnsenLoopEipExecutorConnector,
   createImmediateOnlyConnectorCapabilities,
   createUnsupportedExecutorConnectorOperationResult,
   mapExecutorPolicyDecisionToFlowControlState
@@ -381,5 +382,302 @@ describe("executor connector abstraction", () => {
 
     expect(snapshot.status).toBe("needs-review");
     expect(snapshot.flowControl?.state).toBe("needs-review");
+  });
+});
+
+describe("Ensen-loop EIP executor connector", () => {
+  const submitRequest: ExecutorSubmitRequest = {
+    workflow: { id: "loop-eip-demo", version: "flow.workflow.v1" },
+    run: { id: "loop-eip-demo-run" },
+    step: { id: "loop-executor-step", attempt: 1 },
+    input: { issue: 22 },
+    idempotencyKey: "loop-eip-demo-run:loop-executor-step:1",
+    source: {
+      sourceId: "source_ensen_flow",
+      sourceType: "manual",
+      externalRef: "flow-local"
+    },
+    requestedBy: {
+      actorId: "actor_ensen_flow",
+      actorType: "system",
+      displayName: "Ensen-flow"
+    },
+    workItem: {
+      workItemId: "workitem_issue_22",
+      externalId: "22",
+      title: "Implement Ensen-loop executor connector via EIP",
+      url: "https://github.com/TommyKammy/Ensen-flow/issues/22"
+    },
+    mode: "validate",
+    target: {
+      targetType: "repository",
+      targetId: "repo_ensen_flow",
+      externalRef: "TommyKammy/Ensen-flow"
+    },
+    policyContext: {
+      policySetId: "policy_phase_1",
+      riskClasses: ["external-executor"],
+      requiresApproval: false
+    }
+  };
+
+  it("converts bounded executor requests to EIP RunRequest and consumes terminal RunResult evidence", async () => {
+    const submittedPayloads: unknown[] = [];
+    const connector = createEnsenLoopEipExecutorConnector({
+      transport: {
+        submitRunRequest(payload) {
+          submittedPayloads.push(payload);
+          return { requestId: payload.id, acceptedAt: "2026-04-30T04:00:00.000Z" };
+        },
+        getRunStatusSnapshot() {
+          return {
+            schemaVersion: "eip.run-status.v1",
+            id: "sts_loop_eip_done",
+            requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+            correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
+            status: "completed",
+            observedAt: "2026-04-30T04:00:02.000Z",
+            message: "Run completed. Retrieve final details from RunResult."
+          };
+        },
+        getRunResult() {
+          return {
+            schemaVersion: "eip.run-result.v1",
+            id: "run_loop_eip_result",
+            requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+            correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
+            status: "succeeded",
+            completedAt: "2026-04-30T04:00:03.000Z",
+            verification: {
+              status: "passed",
+              summary: "Run completed and verification passed."
+            },
+            evidenceBundles: [
+              {
+                evidenceBundleId: "evb_loop_eip_bundle",
+                digest:
+                  "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+              }
+            ]
+          };
+        },
+        getEvidenceBundleRef() {
+          return {
+            schemaVersion: "eip.evidence-bundle-ref.v1",
+            id: "evb_loop_eip_bundle",
+            correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
+            type: "local_path",
+            uri: "artifacts/evidence/loop-eip-demo-run/bundle.json",
+            createdAt: "2026-04-30T04:00:03.000Z",
+            contentType: "application/json"
+          };
+        }
+      },
+      now: () => "2026-04-30T04:00:00.000Z"
+    });
+
+    const submitted = await connector.submit(submitRequest);
+
+    expect(submitted).toMatchObject({
+      ok: true,
+      operation: "submit",
+      value: {
+        requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+        flowControl: { state: "ready", authority: "ensen-flow" }
+      }
+    });
+    expect(submittedPayloads).toEqual([
+      {
+        schemaVersion: "eip.run-request.v1",
+        id: "req_loop_eip_demo_run_loop_executor_step_1",
+        correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
+        idempotencyKey: "loop-eip-demo-run:loop-executor-step:1",
+        source: submitRequest.source,
+        requestedBy: submitRequest.requestedBy,
+        workItem: submitRequest.workItem,
+        mode: "validate",
+        createdAt: "2026-04-30T04:00:00.000Z",
+        target: submitRequest.target,
+        policyContext: submitRequest.policyContext,
+        extensions: {
+          "x-ensen-flow": {
+            workflowId: "loop-eip-demo",
+            workflowVersion: "flow.workflow.v1",
+            runId: "loop-eip-demo-run",
+            stepId: "loop-executor-step",
+            attempt: 1,
+            input: { issue: 22 }
+          }
+        }
+      }
+    ]);
+
+    if (!submitted.ok) {
+      throw new Error("submit should succeed");
+    }
+
+    expect(await connector.status({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: true,
+      operation: "status",
+      value: {
+        requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+        status: "succeeded",
+        result: {
+          status: "succeeded",
+          summary: "Run completed and verification passed.",
+          evidence: {
+            evidenceBundles: [
+              {
+                evidenceBundleId: "evb_loop_eip_bundle"
+              }
+            ]
+          }
+        }
+      }
+    });
+
+    expect(await connector.fetchEvidence({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: true,
+      operation: "fetchEvidence",
+      value: {
+        requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+        evidence: {
+          schemaVersion: "eip.evidence-bundle-ref.v1",
+          type: "local_path",
+          uri: "artifacts/evidence/loop-eip-demo-run/bundle.json"
+        }
+      }
+    });
+  });
+
+  it("maps blocked and needs-review EIP RunResult statuses to flow-owned states", async () => {
+    const createTerminalConnector = (status: "blocked" | "needs_review", summary: string) =>
+      createEnsenLoopEipExecutorConnector({
+        transport: {
+          submitRunRequest(payload) {
+            return { requestId: payload.id };
+          },
+          getRunStatusSnapshot() {
+            return {
+              schemaVersion: "eip.run-status.v1",
+              id: "sts_loop_eip_done",
+              requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+              correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
+              status: "completed",
+              observedAt: "2026-04-30T04:00:02.000Z"
+            };
+          },
+          getRunResult() {
+            return {
+              schemaVersion: "eip.run-result.v1",
+              id: "run_loop_eip_result",
+              requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+              correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
+              status,
+              completedAt: "2026-04-30T04:00:03.000Z",
+              verification: {
+                status: "blocked",
+                summary
+              }
+            };
+          },
+          getEvidenceBundleRef() {
+            return {
+              schemaVersion: "eip.evidence-bundle-ref.v1",
+              id: "evb_loop_eip_bundle",
+              correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
+              type: "local_path",
+              uri: "artifacts/evidence/loop-eip-demo-run/bundle.json",
+              createdAt: "2026-04-30T04:00:03.000Z"
+            };
+          }
+        }
+      });
+    const connector = createTerminalConnector("needs_review", "Executor returned ambiguous evidence.");
+    const submitted = await connector.submit(submitRequest);
+
+    if (!submitted.ok) {
+      throw new Error("submit should succeed");
+    }
+
+    expect(await connector.status({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: true,
+      value: {
+        status: "needs-review",
+        flowControl: {
+          state: "needs-review",
+          authority: "ensen-flow",
+          reason: "Executor returned ambiguous evidence."
+        },
+        result: {
+          status: "needs-review",
+          summary: "Executor returned ambiguous evidence."
+        }
+      }
+    });
+
+    const blocked = createTerminalConnector("blocked", "Required approval was not available.");
+    const blockedSubmit = await blocked.submit(submitRequest);
+
+    if (!blockedSubmit.ok) {
+      throw new Error("blocked submit should succeed");
+    }
+
+    expect(await blocked.status({ requestId: blockedSubmit.value.requestId })).toMatchObject({
+      ok: true,
+      value: {
+        status: "blocked",
+        flowControl: {
+          state: "blocked",
+          authority: "ensen-flow",
+          reason: "Required approval was not available."
+        },
+        result: {
+          status: "blocked",
+          summary: "Required approval was not available."
+        }
+      }
+    });
+  });
+
+  it("fails closed for unsupported EIP major versions", async () => {
+    const connector = createEnsenLoopEipExecutorConnector({
+      transport: {
+        submitRunRequest(payload) {
+          return { requestId: payload.id };
+        },
+        getRunStatusSnapshot() {
+          return {
+            schemaVersion: "eip.run-status.v2",
+            id: "sts_loop_eip_v2",
+            requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+            correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
+            status: "running",
+            observedAt: "2026-04-30T04:00:02.000Z"
+          };
+        },
+        getRunResult() {
+          throw new Error("result should not be fetched for unsupported status versions");
+        },
+        getEvidenceBundleRef() {
+          throw new Error("evidence should not be fetched for unsupported status versions");
+        }
+      }
+    });
+    const submitted = await connector.submit(submitRequest);
+
+    if (!submitted.ok) {
+      throw new Error("submit should succeed");
+    }
+
+    expect(await connector.status({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: false,
+      operation: "status",
+      error: {
+        code: "invalid-request",
+        retryable: false,
+        reason: "unsupported EIP RunStatusSnapshot schemaVersion eip.run-status.v2"
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add an optional Ensen-loop EIP executor connector behind the flow-owned executor abstraction
- Generate EIP RunRequest v1 payloads from bounded executor requests, including correlation, idempotency, source, requestedBy, workItem, mode, target, and policy context fields
- Map EIP RunStatusSnapshot and RunResult terminal, blocked, needs-review, and evidence outcomes into flow-owned connector results
- Fail closed on unsupported EIP schema versions, malformed statuses, and requestId mismatches

## Verification
- npm run build
- npm test
- rg -n "@tommykammy/ensen-loop|from .*ensen-loop|require\(.*ensen-loop|ensen-loop" package.json package-lock.json src test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an executor connector for EIP-style run requests: submission, status tracking, cancellation support, and evidence retrieval.
  * Extended executor requests with optional metadata: source, actor, work item, operation mode, target, policy context, and data classification.

* **Tests**
  * Added comprehensive tests covering submit/status/result mapping, cancellation behavior, evidence fetching, and schema/validation error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->