### PR TITLE
FLOW-FU-003: Validate required EIP run status fields

### DIFF
--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -276,7 +276,10 @@ export const createEnsenLoopEipExecutorConnector = (
 
 interface EipRunStatusSnapshotV1 {
   schemaVersion: "eip.run-status.v1";
+  id: string;
   requestId: string;
+  correlationId: string;
+  runId?: string;
   status:
     | "accepted"
     | "queued"
@@ -287,9 +290,10 @@ interface EipRunStatusSnapshotV1 {
     | "failed"
     | "blocked"
     | "unknown";
-  observedAt?: string;
+  observedAt: string;
   message?: string;
   progress?: Record<string, unknown>;
+  extensions?: Record<string, unknown>;
 }
 
 interface EipRunResultV1 {
@@ -429,16 +433,24 @@ const validateRunStatusSnapshot = (
     return failClosedReason(`EIP RunStatusSnapshot has unsupported field ${unknownProperty}`);
   }
 
-  if (typeof value.requestId !== "string" || value.requestId !== expectedRequestId) {
+  if (!isPrefixedId(value.id, "sts")) {
+    return failClosedReason("EIP RunStatusSnapshot id is malformed");
+  }
+
+  if (!isPrefixedId(value.requestId, "req") || value.requestId !== expectedRequestId) {
     return failClosedReason("EIP RunStatusSnapshot requestId does not match the submitted request");
+  }
+
+  if (!isCorrelationId(value.correlationId)) {
+    return failClosedReason("EIP RunStatusSnapshot correlationId is malformed");
   }
 
   if (!isRunStatus(value.status)) {
     return failClosedReason("EIP RunStatusSnapshot status is unsupported or malformed");
   }
 
-  if (value.observedAt !== undefined && typeof value.observedAt !== "string") {
-    return failClosedReason("EIP RunStatusSnapshot observedAt must be a string");
+  if (!isIsoDateTimeUtc(value.observedAt)) {
+    return failClosedReason("EIP RunStatusSnapshot observedAt is malformed");
   }
 
   if (value.message !== undefined && typeof value.message !== "string") {

--- a/test/executor-connector.test.ts
+++ b/test/executor-connector.test.ts
@@ -715,7 +715,9 @@ describe("Ensen-loop EIP executor connector", () => {
         observedStatusRequests.push(request.requestId);
         return {
           schemaVersion: "eip.run-status.v1",
+          id: "sts_loop_eip_status",
           requestId: request.requestId,
+          correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
           status: "running",
           observedAt: "2026-04-30T04:00:02.000Z"
         };
@@ -917,8 +919,11 @@ describe("Ensen-loop EIP executor connector", () => {
         getRunStatusSnapshot() {
           return {
             schemaVersion: "eip.run-status.v1",
+            id: "sts_loop_eip_status",
             requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+            correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
             status: "running",
+            observedAt: "2026-04-30T04:00:02.000Z",
             message: 123
           };
         },
@@ -947,6 +952,89 @@ describe("Ensen-loop EIP executor connector", () => {
     });
   });
 
+  it.each([
+    {
+      name: "missing id",
+      snapshot: {
+        schemaVersion: "eip.run-status.v1",
+        requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+        correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
+        status: "running",
+        observedAt: "2026-04-30T04:00:02.000Z"
+      },
+      reason: "EIP RunStatusSnapshot id is malformed"
+    },
+    {
+      name: "missing correlationId",
+      snapshot: {
+        schemaVersion: "eip.run-status.v1",
+        id: "sts_loop_eip_status",
+        requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+        status: "running",
+        observedAt: "2026-04-30T04:00:02.000Z"
+      },
+      reason: "EIP RunStatusSnapshot correlationId is malformed"
+    },
+    {
+      name: "missing observedAt",
+      snapshot: {
+        schemaVersion: "eip.run-status.v1",
+        id: "sts_loop_eip_status",
+        requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+        correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
+        status: "running"
+      },
+      reason: "EIP RunStatusSnapshot observedAt is malformed"
+    },
+    {
+      name: "malformed observedAt",
+      snapshot: {
+        schemaVersion: "eip.run-status.v1",
+        id: "sts_loop_eip_status",
+        requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+        correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
+        status: "running",
+        observedAt: "2026-04-30 04:00:02"
+      },
+      reason: "EIP RunStatusSnapshot observedAt is malformed"
+    }
+  ])("fails closed for required EIP RunStatusSnapshot field validation: $name", async ({
+    snapshot,
+    reason
+  }) => {
+    const connector = createEnsenLoopEipExecutorConnector({
+      transport: {
+        submitRunRequest(payload) {
+          return { requestId: payload.id };
+        },
+        getRunStatusSnapshot() {
+          return snapshot;
+        },
+        getRunResult() {
+          throw new Error("result should not be fetched for invalid status snapshots");
+        },
+        getEvidenceBundleRef() {
+          throw new Error("evidence should not be fetched for invalid status snapshots");
+        }
+      }
+    });
+    const submitted = await connector.submit(submitRequest);
+
+    if (!submitted.ok) {
+      throw new Error("submit should succeed");
+    }
+
+    expect(await connector.status({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: false,
+      operation: "status",
+      error: {
+        code: "invalid-request",
+        retryable: false,
+        reason
+      }
+    });
+  });
+
   it("fails closed for malformed optional EIP RunResult fields", async () => {
     const connector = createEnsenLoopEipExecutorConnector({
       transport: {
@@ -956,7 +1044,9 @@ describe("Ensen-loop EIP executor connector", () => {
         getRunStatusSnapshot() {
           return {
             schemaVersion: "eip.run-status.v1",
+            id: "sts_loop_eip_status",
             requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+            correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
             status: "completed",
             observedAt: "2026-04-30T04:00:02.000Z"
           };
@@ -1072,7 +1162,9 @@ describe("Ensen-loop EIP executor connector", () => {
         getRunStatusSnapshot() {
           return {
             schemaVersion: "eip.run-status.v1",
+            id: "sts_loop_eip_status",
             requestId,
+            correlationId: "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
             status: "completed",
             observedAt: "2026-04-29T00:05:00Z"
           };


### PR DESCRIPTION
## Summary
- require EIP RunStatusSnapshot id, requestId, correlationId, and observedAt at the connector boundary
- validate status ids with existing EIP prefix/correlation helpers and observedAt with the ISO UTC helper
- add focused regression coverage for missing id, correlationId, observedAt, and malformed observedAt

## Verification
- npm run build
- npm test

Closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced validation for status snapshots with stricter field and format requirements

* **Bug Fixes**
  * Status snapshots now require identifier, correlation ID, and timestamp fields for improved data consistency

* **Tests**
  * Added comprehensive validation tests for required snapshot fields and error handling behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->