### PR TITLE
FLOW-FU-004 require EIP RunResult required fields

### DIFF
--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -298,9 +298,11 @@ interface EipRunStatusSnapshotV1 {
 
 interface EipRunResultV1 {
   schemaVersion: "eip.run-result.v1";
+  id: string;
   requestId: string;
+  correlationId: string;
   status: "succeeded" | "failed" | "blocked" | "needs_review" | "cancelled";
-  completedAt?: string;
+  completedAt: string;
   verification?: {
     status?: string;
     summary?: string;
@@ -609,12 +611,20 @@ const validateRunResult = (
     return failClosedReason("EIP RunResult requestId does not match the submitted request");
   }
 
+  if (!isPrefixedId(value.id, "run")) {
+    return failClosedReason("EIP RunResult id is malformed");
+  }
+
+  if (!isCorrelationId(value.correlationId)) {
+    return failClosedReason("EIP RunResult correlationId is malformed");
+  }
+
   if (!isRunResultStatus(value.status)) {
     return failClosedReason("EIP RunResult status is unsupported or malformed");
   }
 
-  if (value.completedAt !== undefined && typeof value.completedAt !== "string") {
-    return failClosedReason("EIP RunResult completedAt must be a string");
+  if (!isIsoDateTimeUtc(value.completedAt)) {
+    return failClosedReason("EIP RunResult completedAt is malformed");
   }
 
   if (value.verification !== undefined) {

--- a/test/executor-connector.test.ts
+++ b/test/executor-connector.test.ts
@@ -1035,6 +1035,96 @@ describe("Ensen-loop EIP executor connector", () => {
     });
   });
 
+  it.each([
+    {
+      name: "missing id",
+      result: {
+        schemaVersion: "eip.run-result.v1",
+        requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+        correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
+        status: "succeeded",
+        completedAt: "2026-04-30T04:00:03.000Z"
+      },
+      reason: "EIP RunResult id is malformed"
+    },
+    {
+      name: "missing correlationId",
+      result: {
+        schemaVersion: "eip.run-result.v1",
+        id: "run_loop_eip_result",
+        requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+        status: "succeeded",
+        completedAt: "2026-04-30T04:00:03.000Z"
+      },
+      reason: "EIP RunResult correlationId is malformed"
+    },
+    {
+      name: "missing completedAt",
+      result: {
+        schemaVersion: "eip.run-result.v1",
+        id: "run_loop_eip_result",
+        requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+        correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
+        status: "succeeded"
+      },
+      reason: "EIP RunResult completedAt is malformed"
+    },
+    {
+      name: "malformed completedAt",
+      result: {
+        schemaVersion: "eip.run-result.v1",
+        id: "run_loop_eip_result",
+        requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+        correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
+        status: "succeeded",
+        completedAt: "2026-04-30 04:00:03"
+      },
+      reason: "EIP RunResult completedAt is malformed"
+    }
+  ])("fails closed for required EIP RunResult field validation: $name", async ({
+    result,
+    reason
+  }) => {
+    const connector = createEnsenLoopEipExecutorConnector({
+      transport: {
+        submitRunRequest(payload) {
+          return { requestId: payload.id };
+        },
+        getRunStatusSnapshot() {
+          return {
+            schemaVersion: "eip.run-status.v1",
+            id: "sts_loop_eip_status",
+            requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+            correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
+            status: "completed",
+            observedAt: "2026-04-30T04:00:02.000Z"
+          };
+        },
+        getRunResult() {
+          return result;
+        },
+        getEvidenceBundleRef() {
+          throw new Error("evidence should not be fetched for invalid run results");
+        }
+      }
+    });
+    const submitted = await connector.submit(submitRequest);
+
+    if (!submitted.ok) {
+      throw new Error("submit should succeed");
+    }
+
+    expect(await connector.status({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: false,
+      operation: "status",
+      error: {
+        code: "invalid-request",
+        retryable: false,
+        reason
+      }
+    });
+  });
+
   it("fails closed for malformed optional EIP RunResult fields", async () => {
     const connector = createEnsenLoopEipExecutorConnector({
       transport: {
@@ -1054,8 +1144,11 @@ describe("Ensen-loop EIP executor connector", () => {
         getRunResult() {
           return {
             schemaVersion: "eip.run-result.v1",
+            id: "run_loop_eip_result",
             requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+            correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
             status: "succeeded",
+            completedAt: "2026-04-30T04:00:03.000Z",
             verification: {
               status: "passed",
               summary: 123
@@ -1123,7 +1216,9 @@ describe("Ensen-loop EIP executor connector", () => {
         getRunResult() {
           return {
             schemaVersion: "eip.run-result.v1",
+            id: "run_loop_eip_result",
             requestId,
+            correlationId: "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
             status: "succeeded",
             completedAt: "2026-04-29T00:05:00Z",
             verification: {
@@ -1269,7 +1364,9 @@ describe("Ensen-loop EIP executor connector", () => {
         getRunStatusSnapshot() {
           return {
             schemaVersion: "eip.run-status.v1",
+            id: "sts_loop_eip_status",
             requestId,
+            correlationId: "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
             status: "completed",
             observedAt: "2026-04-29T00:05:00Z"
           };


### PR DESCRIPTION
## Summary
- require EIP RunResult id, correlationId, and ISO UTC completedAt before mapping terminal executor output
- add focused fail-closed regression coverage for missing/malformed required RunResult fields
- keep valid/invalid EIP fixture coverage anchored at the terminal RunResult boundary

## Verification
- npm ci
- npx vitest run test/executor-connector.test.ts --testNamePattern "required EIP RunResult|malformed optional EIP RunResult|valid EIP RunStatusSnapshot fixture|valid EIP RunResult fixture|invalid EIP RunResult fixture"
- npm run build
- npm test
- git diff --check

Closes #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for result data to enforce required fields and proper formatting, ensuring more reliable error detection.

* **Tests**
  * Added comprehensive test coverage for validation of critical result fields to prevent invalid data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->