### PR TITLE
FLOW-X2-001: Add fake Ensen-loop EIP transport

### DIFF
--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -68,6 +68,39 @@ export interface CreateEnsenLoopEipExecutorConnectorInput {
   now?: () => string;
 }
 
+export interface CreateFakeEnsenLoopEipExecutorTransportInput {
+  acceptedAt?: string;
+  observedAt?: string;
+  completedAt?: string;
+  verificationSummary?: string;
+  statusSnapshots?: FakeEnsenLoopEipPayload[];
+  result?: FakeEnsenLoopEipPayload;
+  evidenceBundleRef?: FakeEnsenLoopEipPayload;
+}
+
+export interface FakeEnsenLoopEipExecutorTransport extends EnsenLoopEipExecutorTransport {
+  readonly submittedRunRequests: EipRunRequestV1[];
+}
+
+export type FakeEnsenLoopEipPayload =
+  | Record<string, unknown>
+  | unknown[]
+  | string
+  | number
+  | boolean
+  | null
+  | ((context: FakeEnsenLoopEipPayloadContext) => unknown);
+
+export interface FakeEnsenLoopEipPayloadContext {
+  requestId: string;
+  request?: EipRunRequestV1;
+}
+
+interface FakeEnsenLoopEipRecord {
+  request: EipRunRequestV1;
+  statusIndex: number;
+}
+
 export const createEnsenLoopEipExecutorConnector = (
   input: CreateEnsenLoopEipExecutorConnectorInput
 ): ExecutorConnector => {
@@ -274,6 +307,109 @@ export const createEnsenLoopEipExecutorConnector = (
   };
 };
 
+export const createFakeEnsenLoopEipExecutorTransport = (
+  input: CreateFakeEnsenLoopEipExecutorTransportInput = {}
+): FakeEnsenLoopEipExecutorTransport => {
+  const submittedRunRequests: EipRunRequestV1[] = [];
+  const records = new Map<string, FakeEnsenLoopEipRecord>();
+
+  return {
+    get submittedRunRequests() {
+      return submittedRunRequests;
+    },
+    submitRunRequest(request: EipRunRequestV1) {
+      submittedRunRequests.push(request);
+      records.set(request.id, {
+        request,
+        statusIndex: 0
+      });
+
+      return {
+        requestId: request.id,
+        acceptedAt: input.acceptedAt ?? "2026-04-30T04:00:00.000Z",
+        evidence: {
+          kind: "fake-ensen-loop-eip-transport",
+          requestId: request.id
+        }
+      };
+    },
+    getRunStatusSnapshot(request: { requestId: string }) {
+      const record = records.get(request.requestId);
+      const context = {
+        requestId: request.requestId,
+        ...(record === undefined ? {} : { request: record.request })
+      };
+      const scripted = nextFakeScriptedPayload(record, input.statusSnapshots);
+
+      if (scripted !== undefined) {
+        return resolveFakePayload(scripted, context);
+      }
+
+      return {
+        schemaVersion: "eip.run-status.v1",
+        id: `sts_${safeIdentifier(request.requestId)}`,
+        requestId: request.requestId,
+        correlationId: record?.request.correlationId ?? `corr_${safeIdentifier(request.requestId)}`,
+        status: "completed",
+        observedAt: input.observedAt ?? "2026-04-30T04:00:02.000Z",
+        message: "Fake Ensen-loop EIP transport completed the run request."
+      };
+    },
+    getRunResult(request: { requestId: string }) {
+      const record = records.get(request.requestId);
+      const context = {
+        requestId: request.requestId,
+        ...(record === undefined ? {} : { request: record.request })
+      };
+
+      if (input.result !== undefined) {
+        return resolveFakePayload(input.result, context);
+      }
+
+      return {
+        schemaVersion: "eip.run-result.v1",
+        id: `run_${safeIdentifier(request.requestId)}`,
+        requestId: request.requestId,
+        correlationId: record?.request.correlationId ?? `corr_${safeIdentifier(request.requestId)}`,
+        status: "succeeded",
+        completedAt: input.completedAt ?? "2026-04-30T04:00:03.000Z",
+        verification: {
+          status: "passed",
+          summary: input.verificationSummary ?? "Fake Ensen-loop EIP transport succeeded."
+        },
+        evidenceBundles: [
+          {
+            evidenceBundleId: `evb_${safeIdentifier(request.requestId)}`,
+            digest:
+              "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+          }
+        ]
+      };
+    },
+    getEvidenceBundleRef(request: { requestId: string }) {
+      const record = records.get(request.requestId);
+      const context = {
+        requestId: request.requestId,
+        ...(record === undefined ? {} : { request: record.request })
+      };
+
+      if (input.evidenceBundleRef !== undefined) {
+        return resolveFakePayload(input.evidenceBundleRef, context);
+      }
+
+      return {
+        schemaVersion: "eip.evidence-bundle-ref.v1",
+        id: `evb_${safeIdentifier(request.requestId)}`,
+        correlationId: record?.request.correlationId ?? `corr_${safeIdentifier(request.requestId)}`,
+        type: "local_path",
+        uri: `artifacts/evidence/${request.requestId}/bundle.json`,
+        createdAt: input.completedAt ?? "2026-04-30T04:00:03.000Z",
+        contentType: "application/json"
+      };
+    }
+  };
+};
+
 interface EipRunStatusSnapshotV1 {
   schemaVersion: "eip.run-status.v1";
   id: string;
@@ -295,6 +431,33 @@ interface EipRunStatusSnapshotV1 {
   progress?: Record<string, unknown>;
   extensions?: Record<string, unknown>;
 }
+
+const nextFakeScriptedPayload = (
+  record: FakeEnsenLoopEipRecord | undefined,
+  script: FakeEnsenLoopEipPayload[] | undefined
+): FakeEnsenLoopEipPayload | undefined => {
+  if (script === undefined || script.length === 0) {
+    return undefined;
+  }
+
+  const index = record?.statusIndex ?? 0;
+  if (record !== undefined) {
+    record.statusIndex += 1;
+  }
+
+  return script[Math.min(index, script.length - 1)];
+};
+
+const resolveFakePayload = (
+  payload: FakeEnsenLoopEipPayload,
+  context: FakeEnsenLoopEipPayloadContext
+): unknown => {
+  if (typeof payload === "function") {
+    return payload(context);
+  }
+
+  return payload;
+};
 
 interface EipRunResultV1 {
   schemaVersion: "eip.run-result.v1";

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,8 @@ export {
 } from "./connector.js";
 
 export {
-  createEnsenLoopEipExecutorConnector
+  createEnsenLoopEipExecutorConnector,
+  createFakeEnsenLoopEipExecutorTransport
 } from "./ensen-loop-eip-executor-connector.js";
 
 export {
@@ -59,8 +60,12 @@ export type {
 
 export type {
   CreateEnsenLoopEipExecutorConnectorInput,
+  CreateFakeEnsenLoopEipExecutorTransportInput,
   EipRunRequestV1,
-  EnsenLoopEipExecutorTransport
+  EnsenLoopEipExecutorTransport,
+  FakeEnsenLoopEipExecutorTransport,
+  FakeEnsenLoopEipPayload,
+  FakeEnsenLoopEipPayloadContext
 } from "./ensen-loop-eip-executor-connector.js";
 
 export type {

--- a/test/executor-connector.test.ts
+++ b/test/executor-connector.test.ts
@@ -1,18 +1,22 @@
-import { readFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
 import {
   createEnsenLoopEipExecutorConnector,
+  createFakeEnsenLoopEipExecutorTransport,
   createImmediateOnlyConnectorCapabilities,
   createUnsupportedExecutorConnectorOperationResult,
   mapExecutorPolicyDecisionToFlowControlState
 } from "../src/index.js";
 import type {
   ExecutorConnectorStatusSnapshot,
-  ExecutorSubmitRequest
+  ExecutorSubmitRequest,
+  WorkflowDefinition
 } from "../src/index.js";
+import { readWorkflowRunState, runWorkflow } from "../src/index.js";
 import {
   createFakeExecutorTransport,
   fakeFlowControlForDecision
@@ -570,6 +574,185 @@ describe("Ensen-loop EIP executor connector", () => {
           type: "local_path",
           uri: "artifacts/evidence/loop-eip-demo-run/bundle.json"
         }
+      }
+    });
+  });
+
+  it("drives a workflow step through fake Ensen-loop EIP transport and persists the resulting run state", async () => {
+    const transport = createFakeEnsenLoopEipExecutorTransport({
+      completedAt: "2026-04-30T04:00:03.000Z",
+      verificationSummary: "Fake loop-like execution completed."
+    });
+    const connector = createEnsenLoopEipExecutorConnector({
+      transport,
+      now: () => "2026-04-30T04:00:00.000Z"
+    });
+    const definition: WorkflowDefinition = {
+      schemaVersion: "flow.workflow.v1",
+      id: "loop-fake-transport-demo",
+      trigger: {
+        type: "manual",
+        idempotencyKey: {
+          source: "input",
+          field: "requestId",
+          required: true
+        }
+      },
+      steps: [
+        {
+          id: "loop-like-executor",
+          action: {
+            type: "local",
+            name: "fake_loop_eip_executor"
+          }
+        }
+      ]
+    };
+    const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-loop-fake-"));
+    const statePath = join(tempRoot, "runs", "loop-fake-transport.jsonl");
+
+    try {
+      const result = await runWorkflow({
+        definition,
+        statePath,
+        triggerContext: {
+          requestId: "fake-loop-run"
+        },
+        now: (() => {
+          let index = 0;
+          const timestamps = [
+            "2026-04-30T04:00:00.000Z",
+            "2026-04-30T04:00:01.000Z",
+            "2026-04-30T04:00:02.000Z",
+            "2026-04-30T04:00:04.000Z"
+          ];
+          return () => timestamps[index++] ?? "2026-04-30T04:00:05.000Z";
+        })(),
+        stepHandler: async ({ definition, runState, step, attempt }) => {
+          const submitted = await connector.submit({
+            workflow: {
+              id: definition.id,
+              version: definition.schemaVersion
+            },
+            run: {
+              id: runState.run.runId
+            },
+            step: {
+              id: step.id,
+              attempt
+            },
+            idempotencyKey: `${runState.run.runId}:${step.id}:${attempt}`,
+            policyDecision: { decision: "allow" },
+            input: {
+              requestId: "fake-loop-run"
+            }
+          });
+
+          if (!submitted.ok) {
+            throw new Error(submitted.error.reason ?? submitted.error.message);
+          }
+
+          const status = await connector.status({ requestId: submitted.value.requestId });
+
+          if (!status.ok) {
+            throw new Error(status.error.reason ?? status.error.message);
+          }
+
+          expect(status.value).toMatchObject({
+            requestId: submitted.value.requestId,
+            status: "succeeded",
+            result: {
+              status: "succeeded",
+              summary: "Fake loop-like execution completed."
+            }
+          });
+        }
+      });
+
+      expect(result.run.status).toBe("succeeded");
+      expect(transport.submittedRunRequests).toHaveLength(1);
+      expect(transport.submittedRunRequests[0]).toMatchObject({
+        schemaVersion: "eip.run-request.v1",
+        id: "req_loop_fake_transport_demo_fake_loop_run_loop_like_executor_1",
+        mode: "validate"
+      });
+
+      const persisted = await readWorkflowRunState(statePath);
+      expect(persisted.events.map((event) => event.type)).toEqual([
+        "run.created",
+        "step.attempt.started",
+        "step.attempt.completed",
+        "run.completed"
+      ]);
+      expect(persisted.stepAttempts["loop-like-executor"]).toMatchObject([
+        {
+          attempt: 1,
+          status: "succeeded"
+        }
+      ]);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps malformed fake Ensen-loop EIP status output fail-closed", async () => {
+    const connector = createEnsenLoopEipExecutorConnector({
+      transport: createFakeEnsenLoopEipExecutorTransport({
+        statusSnapshots: [
+          {
+            schemaVersion: "eip.run-status.v1",
+            requestId: "req_loop_eip_demo_run_loop_executor_step_1",
+            correlationId: "corr_loop_eip_demo_run_loop_executor_step_1",
+            status: "completed",
+            observedAt: "2026-04-30T04:00:02.000Z"
+          }
+        ]
+      }),
+      now: () => "2026-04-30T04:00:00.000Z"
+    });
+    const submitted = await connector.submit(submitRequest);
+
+    if (!submitted.ok) {
+      throw new Error("submit should succeed");
+    }
+
+    expect(await connector.status({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: false,
+      operation: "status",
+      error: {
+        code: "invalid-request",
+        retryable: false,
+        reason: "EIP RunStatusSnapshot id is malformed"
+      }
+    });
+  });
+
+  it("keeps malformed fake Ensen-loop EIP result output fail-closed", async () => {
+    const connector = createEnsenLoopEipExecutorConnector({
+      transport: createFakeEnsenLoopEipExecutorTransport({
+        result: ({ requestId, request }) => ({
+          schemaVersion: "eip.run-result.v1",
+          id: `run_${requestId}`,
+          requestId,
+          correlationId: request?.correlationId ?? "corr_loop_eip_demo_run_loop_executor_step_1",
+          status: "succeeded"
+        })
+      }),
+      now: () => "2026-04-30T04:00:00.000Z"
+    });
+    const submitted = await connector.submit(submitRequest);
+
+    if (!submitted.ok) {
+      throw new Error("submit should succeed");
+    }
+
+    expect(await connector.status({ requestId: submitted.value.requestId })).toMatchObject({
+      ok: false,
+      operation: "status",
+      error: {
+        code: "invalid-request",
+        retryable: false,
+        reason: "EIP RunResult completedAt is malformed"
       }
     });
   });


### PR DESCRIPTION
## Summary
- add a repo-owned fake Ensen-loop EIP transport for the executor connector boundary
- return EIP-shaped RunStatusSnapshot, RunResult, and EvidenceBundleRef fixtures without importing Ensen-loop code
- cover workflow run-state persistence plus malformed fake status/result fail-closed paths

## Verification
- npm ci
- npm test -- test/executor-connector.test.ts
- npm run build
- npm test

Closes #36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new testing utility enabling simulated executor transport behavior with customizable status snapshots, execution results, and evidence bundle references for validation scenarios.

* **Tests**
  * Expanded test suite with cases covering workflow execution integration, error handling for malformed payloads, and persistence of workflow run state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->