### PR TITLE
FLOW-X2-002: Add CLI-backed Ensen-loop executor smoke path

### DIFF
--- a/src/connector.ts
+++ b/src/connector.ts
@@ -32,6 +32,7 @@ export interface ConnectorErrorBody {
   message: string;
   retryable: boolean;
   reason?: string;
+  failureClass?: "protocol-gap" | "loop-gap" | "flow-gap";
 }
 
 export type ConnectorResult<TValue = unknown> =

--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -90,6 +90,8 @@ export class EnsenLoopCliTransportError extends Error {
 
 export type EnsenLoopCliOperation = "submit" | "status" | "result" | "evidence";
 
+const cliTerminationGraceMs = 1000;
+
 export interface CreateCliEnsenLoopEipExecutorTransportInput {
   command: string;
   args?: string[];
@@ -391,9 +393,17 @@ const invokeEnsenLoopCli = async (
   const stdoutChunks: Buffer[] = [];
   const stderrChunks: Buffer[] = [];
   let timeout: NodeJS.Timeout | undefined;
-  let timedOut = false;
+  let escalationTimeout: NodeJS.Timeout | undefined;
 
-  const completion = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+  type CompletionResult = {
+    type: "completion";
+    code: number | null;
+    signal: NodeJS.Signals | null;
+  };
+  type TimeoutResult = { type: "timeout" };
+  type CliResult = CompletionResult | TimeoutResult;
+
+  const completion = new Promise<CliResult>(
     (resolve, reject) => {
       child.once("error", (error) => {
         reject(
@@ -405,7 +415,7 @@ const invokeEnsenLoopCli = async (
         );
       });
       child.once("close", (code, signal) => {
-        resolve({ code, signal });
+        resolve({ type: "completion", code, signal });
       });
     }
   );
@@ -417,23 +427,36 @@ const invokeEnsenLoopCli = async (
     stderrChunks.push(chunk);
   });
 
-  if (input.timeoutMs !== undefined) {
-    timeout = setTimeout(() => {
-      timedOut = true;
-      child.kill("SIGTERM");
-    }, input.timeoutMs);
-  }
+  const timeoutPromise =
+    input.timeoutMs === undefined
+      ? undefined
+      : new Promise<CliResult>((resolve) => {
+          timeout = setTimeout(() => {
+            child.kill("SIGTERM");
+            escalationTimeout = setTimeout(() => {
+              if (child.exitCode === null && child.signalCode === null) {
+                child.kill("SIGKILL");
+              }
+              resolve({ type: "timeout" });
+            }, cliTerminationGraceMs);
+          }, input.timeoutMs);
+        });
 
   child.stdin.end(`${JSON.stringify(envelope)}\n`);
 
-  const { code, signal } = await completion.finally(() => {
+  const result = await (timeoutPromise === undefined
+    ? completion
+    : Promise.race([completion, timeoutPromise])).finally(() => {
     if (timeout !== undefined) {
       clearTimeout(timeout);
+    }
+    if (escalationTimeout !== undefined) {
+      clearTimeout(escalationTimeout);
     }
   });
   const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
 
-  if (timedOut) {
+  if (result.type === "timeout") {
     throw new EnsenLoopCliTransportError({
       message: `Ensen-loop CLI transport timed out during ${operation}`,
       failureClass: "loop-gap",
@@ -441,6 +464,8 @@ const invokeEnsenLoopCli = async (
       stderr
     });
   }
+
+  const { code, signal } = result;
 
   if (code !== 0) {
     throw new EnsenLoopCliTransportError({

--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -1,3 +1,5 @@
+import { spawn } from "node:child_process";
+
 import {
   createExecutorConnectorCapabilities,
   createUnsupportedExecutorConnectorOperationResult,
@@ -62,6 +64,40 @@ export interface EnsenLoopEipExecutorTransport {
     | { requestId?: string; cancelled?: boolean; observedAt?: string };
 }
 
+export type EnsenLoopCliFailureClass = "protocol-gap" | "loop-gap" | "flow-gap";
+
+export class EnsenLoopCliTransportError extends Error {
+  readonly failureClass: EnsenLoopCliFailureClass;
+  readonly operation: EnsenLoopCliOperation;
+  readonly exitCode?: number;
+  readonly stderr?: string;
+
+  constructor(input: {
+    message: string;
+    failureClass: EnsenLoopCliFailureClass;
+    operation: EnsenLoopCliOperation;
+    exitCode?: number;
+    stderr?: string;
+  }) {
+    super(input.message);
+    this.name = "EnsenLoopCliTransportError";
+    this.failureClass = input.failureClass;
+    this.operation = input.operation;
+    this.exitCode = input.exitCode;
+    this.stderr = input.stderr;
+  }
+}
+
+export type EnsenLoopCliOperation = "submit" | "status" | "result" | "evidence";
+
+export interface CreateCliEnsenLoopEipExecutorTransportInput {
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+}
+
 export interface CreateEnsenLoopEipExecutorConnectorInput {
   connectorId?: string;
   transport: EnsenLoopEipExecutorTransport;
@@ -101,6 +137,35 @@ interface FakeEnsenLoopEipRecord {
   statusIndex: number;
 }
 
+export const createCliEnsenLoopEipExecutorTransport = (
+  input: CreateCliEnsenLoopEipExecutorTransportInput
+): EnsenLoopEipExecutorTransport => ({
+  submitRunRequest(request: EipRunRequestV1) {
+    return invokeEnsenLoopCli(input, {
+      operation: "submit",
+      request
+    }) as Promise<{ requestId?: string; acceptedAt?: string; evidence?: Record<string, unknown> }>;
+  },
+  getRunStatusSnapshot(request: { requestId: string }) {
+    return invokeEnsenLoopCli(input, {
+      operation: "status",
+      requestId: request.requestId
+    });
+  },
+  getRunResult(request: { requestId: string }) {
+    return invokeEnsenLoopCli(input, {
+      operation: "result",
+      requestId: request.requestId
+    });
+  },
+  getEvidenceBundleRef(request: { requestId: string }) {
+    return invokeEnsenLoopCli(input, {
+      operation: "evidence",
+      requestId: request.requestId
+    });
+  }
+});
+
 export const createEnsenLoopEipExecutorConnector = (
   input: CreateEnsenLoopEipExecutorConnectorInput
 ): ExecutorConnector => {
@@ -132,7 +197,8 @@ export const createEnsenLoopEipExecutorConnector = (
           connectorId,
           "submit",
           payloadValidation.message,
-          payloadValidation.reason
+          payloadValidation.reason,
+          "flow-gap"
         );
       }
 
@@ -305,6 +371,107 @@ export const createEnsenLoopEipExecutorConnector = (
       };
     }
   };
+};
+
+const invokeEnsenLoopCli = async (
+  input: CreateCliEnsenLoopEipExecutorTransportInput,
+  envelope: {
+    operation: EnsenLoopCliOperation;
+    request?: EipRunRequestV1;
+    requestId?: string;
+  }
+): Promise<unknown> => {
+  const operation = envelope.operation;
+  const child = spawn(input.command, input.args ?? [], {
+    cwd: input.cwd,
+    env: input.env,
+    stdio: ["pipe", "pipe", "pipe"],
+    shell: false
+  });
+  const stdoutChunks: Buffer[] = [];
+  const stderrChunks: Buffer[] = [];
+  let timeout: NodeJS.Timeout | undefined;
+  let timedOut = false;
+
+  const completion = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+    (resolve, reject) => {
+      child.once("error", (error) => {
+        reject(
+          new EnsenLoopCliTransportError({
+            message: `failed to start Ensen-loop CLI transport: ${error.message}`,
+            failureClass: "flow-gap",
+            operation
+          })
+        );
+      });
+      child.once("close", (code, signal) => {
+        resolve({ code, signal });
+      });
+    }
+  );
+
+  child.stdout.on("data", (chunk: Buffer) => {
+    stdoutChunks.push(chunk);
+  });
+  child.stderr.on("data", (chunk: Buffer) => {
+    stderrChunks.push(chunk);
+  });
+
+  if (input.timeoutMs !== undefined) {
+    timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+    }, input.timeoutMs);
+  }
+
+  child.stdin.end(`${JSON.stringify(envelope)}\n`);
+
+  const { code, signal } = await completion.finally(() => {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
+  });
+  const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
+
+  if (timedOut) {
+    throw new EnsenLoopCliTransportError({
+      message: `Ensen-loop CLI transport timed out during ${operation}`,
+      failureClass: "loop-gap",
+      operation,
+      stderr
+    });
+  }
+
+  if (code !== 0) {
+    throw new EnsenLoopCliTransportError({
+      message: `Ensen-loop CLI transport failed during ${operation} with exit code ${code ?? signal ?? "unknown"}`,
+      failureClass: "loop-gap",
+      operation,
+      ...(code === null ? {} : { exitCode: code }),
+      ...(stderr.length === 0 ? {} : { stderr })
+    });
+  }
+
+  const stdout = Buffer.concat(stdoutChunks).toString("utf8").trim();
+  if (stdout.length === 0) {
+    throw new EnsenLoopCliTransportError({
+      message: `Ensen-loop CLI transport returned empty stdout during ${operation}`,
+      failureClass: "protocol-gap",
+      operation,
+      ...(stderr.length === 0 ? {} : { stderr })
+    });
+  }
+
+  try {
+    return JSON.parse(stdout) as unknown;
+  } catch (error) {
+    throw new EnsenLoopCliTransportError({
+      message: `Ensen-loop CLI transport returned non-JSON stdout during ${operation}`,
+      failureClass: "protocol-gap",
+      operation,
+      ...(stderr.length === 0 ? {} : { stderr })
+    });
+  }
 };
 
 export const createFakeEnsenLoopEipExecutorTransport = (
@@ -1215,7 +1382,8 @@ const invalidRequest = <TValue>(
   connectorId: string,
   operation: "submit" | "status" | "cancel" | "fetchEvidence",
   message: string,
-  reason?: string
+  reason?: string,
+  failureClass: EnsenLoopCliFailureClass = "protocol-gap"
 ): ConnectorResult<TValue> => ({
   ok: false,
   connectorId,
@@ -1224,7 +1392,8 @@ const invalidRequest = <TValue>(
     code: "invalid-request",
     message,
     retryable: false,
-    ...(reason === undefined ? {} : { reason })
+    ...(reason === undefined ? {} : { reason }),
+    failureClass
   } satisfies ConnectorErrorBody
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ export {
 } from "./connector.js";
 
 export {
+  EnsenLoopCliTransportError,
+  createCliEnsenLoopEipExecutorTransport,
   createEnsenLoopEipExecutorConnector,
   createFakeEnsenLoopEipExecutorTransport
 } from "./ensen-loop-eip-executor-connector.js";
@@ -59,9 +61,12 @@ export type {
 } from "./connector.js";
 
 export type {
+  CreateCliEnsenLoopEipExecutorTransportInput,
   CreateEnsenLoopEipExecutorConnectorInput,
   CreateFakeEnsenLoopEipExecutorTransportInput,
   EipRunRequestV1,
+  EnsenLoopCliFailureClass,
+  EnsenLoopCliOperation,
   EnsenLoopEipExecutorTransport,
   FakeEnsenLoopEipExecutorTransport,
   FakeEnsenLoopEipPayload,

--- a/test/cli-loop-executor-smoke.test.ts
+++ b/test/cli-loop-executor-smoke.test.ts
@@ -1,0 +1,273 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  EnsenLoopCliTransportError,
+  createCliEnsenLoopEipExecutorTransport,
+  createEnsenLoopEipExecutorConnector,
+  readWorkflowRunState,
+  runWorkflow
+} from "../src/index.js";
+import type {
+  ExecutorSubmitRequest,
+  WorkflowDefinition
+} from "../src/index.js";
+
+describe("CLI-backed Ensen-loop executor smoke", () => {
+  it("drives a workflow step through a local CLI stdout EIP boundary", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-cli-loop-smoke-"));
+    const cliPath = join(tempRoot, "loop-dry-run-cli.mjs");
+    const statePath = join(tempRoot, "runs", "cli-loop-smoke.jsonl");
+
+    await writeFile(
+      cliPath,
+      [
+        "#!/usr/bin/env node",
+        "const chunks = [];",
+        "for await (const chunk of process.stdin) chunks.push(chunk);",
+        "const envelope = JSON.parse(Buffer.concat(chunks).toString('utf8'));",
+        "const requestId = envelope.request?.id ?? envelope.requestId;",
+        "const correlationId = envelope.request?.correlationId ?? `corr_${requestId.slice(4)}`;",
+        "switch (envelope.operation) {",
+        "  case 'submit':",
+        "    process.stdout.write(JSON.stringify({ requestId, acceptedAt: '2026-04-30T04:00:00.000Z' }));",
+        "    break;",
+        "  case 'status':",
+        "    process.stdout.write(JSON.stringify({",
+        "      schemaVersion: 'eip.run-status.v1',",
+        "      id: 'sts_cli_loop_smoke',",
+        "      requestId,",
+        "      correlationId,",
+        "      status: 'completed',",
+        "      observedAt: '2026-04-30T04:00:02.000Z'",
+        "    }));",
+        "    break;",
+        "  case 'result':",
+        "    process.stdout.write(JSON.stringify({",
+        "      schemaVersion: 'eip.run-result.v1',",
+        "      id: 'run_cli_loop_smoke',",
+        "      requestId,",
+        "      correlationId,",
+        "      status: 'succeeded',",
+        "      completedAt: '2026-04-30T04:00:03.000Z',",
+        "      verification: { status: 'passed', summary: 'CLI dry-run smoke completed.' },",
+        "      evidenceBundles: [{ evidenceBundleId: 'evb_cli_loop_smoke', digest: 'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' }]",
+        "    }));",
+        "    break;",
+        "  case 'evidence':",
+        "    process.stdout.write(JSON.stringify({",
+        "      schemaVersion: 'eip.evidence-bundle-ref.v1',",
+        "      id: 'evb_cli_loop_smoke',",
+        "      correlationId,",
+        "      type: 'local_path',",
+        "      uri: 'artifacts/evidence/cli-loop-smoke/bundle.json',",
+        "      createdAt: '2026-04-30T04:00:03.000Z',",
+        "      contentType: 'application/json'",
+        "    }));",
+        "    break;",
+        "  default:",
+        "    process.stderr.write(`unsupported operation ${envelope.operation}`);",
+        "    process.exitCode = 2;",
+        "}",
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+    await chmod(cliPath, 0o755);
+
+    try {
+      const connector = createEnsenLoopEipExecutorConnector({
+        transport: createCliEnsenLoopEipExecutorTransport({
+          command: process.execPath,
+          args: [cliPath]
+        }),
+        now: () => "2026-04-30T04:00:00.000Z"
+      });
+      const definition: WorkflowDefinition = {
+        schemaVersion: "flow.workflow.v1",
+        id: "cli-loop-smoke",
+        trigger: {
+          type: "manual",
+          idempotencyKey: {
+            source: "input",
+            field: "requestId",
+            required: true
+          }
+        },
+        steps: [
+          {
+            id: "loop-dry-run",
+            action: {
+              type: "local",
+              name: "loop_dry_run_cli"
+            }
+          }
+        ]
+      };
+
+      const result = await runWorkflow({
+        definition,
+        statePath,
+        triggerContext: { requestId: "cli-loop-smoke" },
+        now: (() => {
+          let index = 0;
+          const timestamps = [
+            "2026-04-30T04:00:00.000Z",
+            "2026-04-30T04:00:01.000Z",
+            "2026-04-30T04:00:02.000Z",
+            "2026-04-30T04:00:04.000Z"
+          ];
+          return () => timestamps[index++] ?? "2026-04-30T04:00:05.000Z";
+        })(),
+        stepHandler: async ({ definition, runState, step, attempt }) => {
+          const submitRequest: ExecutorSubmitRequest = {
+            workflow: {
+              id: definition.id,
+              version: definition.schemaVersion
+            },
+            run: {
+              id: runState.run.runId
+            },
+            step: {
+              id: step.id,
+              attempt
+            },
+            idempotencyKey: `${runState.run.runId}:${step.id}:${attempt}`,
+            policyDecision: { decision: "allow" },
+            input: {
+              smoke: true
+            },
+            source: {
+              sourceId: "source_ensen_flow",
+              sourceType: "manual",
+              externalRef: "cli-smoke"
+            },
+            workItem: {
+              workItemId: "workitem_cli_loop_smoke",
+              externalId: "cli-loop-smoke",
+              title: "CLI Loop dry-run smoke"
+            }
+          };
+          const submitted = await connector.submit(submitRequest);
+
+          if (!submitted.ok) {
+            throw new Error(submitted.error.reason ?? submitted.error.message);
+          }
+
+          const status = await connector.status({ requestId: submitted.value.requestId });
+          if (!status.ok) {
+            throw new Error(status.error.reason ?? status.error.message);
+          }
+
+          expect(status.value).toMatchObject({
+            requestId: submitted.value.requestId,
+            status: "succeeded",
+            result: {
+              status: "succeeded",
+              summary: "CLI dry-run smoke completed.",
+              evidence: {
+                evidenceBundles: [
+                  {
+                    evidenceBundleId: "evb_cli_loop_smoke"
+                  }
+                ]
+              }
+            }
+          });
+
+          const evidence = await connector.fetchEvidence({ requestId: submitted.value.requestId });
+          if (!evidence.ok) {
+            throw new Error(evidence.error.reason ?? evidence.error.message);
+          }
+
+          expect(evidence.value.evidence).toMatchObject({
+            schemaVersion: "eip.evidence-bundle-ref.v1",
+            type: "local_path",
+            uri: "artifacts/evidence/cli-loop-smoke/bundle.json"
+          });
+        }
+      });
+
+      expect(result.run.status).toBe("succeeded");
+
+      const persisted = await readWorkflowRunState(statePath);
+      expect(persisted.events.map((event) => event.type)).toEqual([
+        "run.created",
+        "step.attempt.started",
+        "step.attempt.completed",
+        "run.completed"
+      ]);
+      expect(persisted.stepAttempts["loop-dry-run"]).toMatchObject([
+        {
+          attempt: 1,
+          status: "succeeded"
+        }
+      ]);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    {
+      name: "protocol gap for non-JSON stdout",
+      scriptBody: "process.stdout.write('not-json');",
+      expectedClass: "protocol-gap"
+    },
+    {
+      name: "loop gap for non-zero CLI exit",
+      scriptBody: "process.stderr.write('dry-run CLI failed'); process.exitCode = 3;",
+      expectedClass: "loop-gap"
+    }
+  ])("classifies CLI smoke failures as $name", async ({
+    scriptBody,
+    expectedClass
+  }) => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-cli-loop-failure-"));
+    const cliPath = join(tempRoot, "loop-dry-run-cli.mjs");
+
+    await writeFile(
+      cliPath,
+      [
+        "#!/usr/bin/env node",
+        "for await (const _chunk of process.stdin) { }",
+        scriptBody,
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+    await chmod(cliPath, 0o755);
+
+    try {
+      const transport = createCliEnsenLoopEipExecutorTransport({
+        command: process.execPath,
+        args: [cliPath]
+      });
+
+      await expect(transport.getRunStatusSnapshot({ requestId: "req_cli_loop_smoke" }))
+        .rejects.toMatchObject({
+          failureClass: expectedClass,
+          operation: "status"
+        });
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("classifies an unstartable CLI command as a flow gap", async () => {
+    const transport = createCliEnsenLoopEipExecutorTransport({
+      command: "ensen-flow-missing-loop-cli-command"
+    });
+
+    await expect(transport.getRunStatusSnapshot({ requestId: "req_cli_loop_smoke" }))
+      .rejects.toBeInstanceOf(EnsenLoopCliTransportError);
+    await expect(transport.getRunStatusSnapshot({ requestId: "req_cli_loop_smoke" }))
+      .rejects.toMatchObject({
+        failureClass: "flow-gap",
+        operation: "status"
+      });
+  });
+});

--- a/test/cli-loop-executor-smoke.test.ts
+++ b/test/cli-loop-executor-smoke.test.ts
@@ -257,6 +257,88 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
     }
   });
 
+  it("times out a CLI process that ignores SIGTERM", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-cli-loop-timeout-"));
+    const cliPath = join(tempRoot, "loop-dry-run-cli.mjs");
+
+    await writeFile(
+      cliPath,
+      [
+        "#!/usr/bin/env node",
+        "process.on('SIGTERM', () => {",
+        "  process.stderr.write('ignored SIGTERM');",
+        "});",
+        "for await (const _chunk of process.stdin) { }",
+        "setInterval(() => {}, 1000);",
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+    await chmod(cliPath, 0o755);
+
+    try {
+      const transport = createCliEnsenLoopEipExecutorTransport({
+        command: process.execPath,
+        args: [cliPath],
+        timeoutMs: 100
+      });
+
+      await expect(transport.getRunStatusSnapshot({ requestId: "req_cli_loop_smoke" }))
+        .rejects.toMatchObject({
+          failureClass: "loop-gap",
+          operation: "status",
+          stderr: "ignored SIGTERM"
+        });
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("does not classify a CLI process that closes during timeout grace as timed out", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-cli-loop-timeout-"));
+    const cliPath = join(tempRoot, "loop-dry-run-cli.mjs");
+
+    await writeFile(
+      cliPath,
+      [
+        "#!/usr/bin/env node",
+        "process.on('SIGTERM', () => {",
+        "  process.stdout.write(JSON.stringify({",
+        "    schemaVersion: 'eip.run-status.v1',",
+        "    id: 'sts_cli_loop_timeout_grace',",
+        "    requestId: 'req_cli_loop_smoke',",
+        "    correlationId: 'corr_cli_loop_timeout_grace',",
+        "    status: 'completed',",
+        "    observedAt: '2026-04-30T04:00:02.000Z'",
+        "  }));",
+        "  process.exit(0);",
+        "});",
+        "for await (const _chunk of process.stdin) { }",
+        "setInterval(() => {}, 1000);",
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+    await chmod(cliPath, 0o755);
+
+    try {
+      const transport = createCliEnsenLoopEipExecutorTransport({
+        command: process.execPath,
+        args: [cliPath],
+        timeoutMs: 100
+      });
+
+      await expect(transport.getRunStatusSnapshot({ requestId: "req_cli_loop_smoke" }))
+        .resolves.toMatchObject({
+          schemaVersion: "eip.run-status.v1",
+          requestId: "req_cli_loop_smoke",
+          status: "completed"
+        });
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("classifies an unstartable CLI command as a flow gap", async () => {
     const transport = createCliEnsenLoopEipExecutorTransport({
       command: "ensen-flow-missing-loop-cli-command"


### PR DESCRIPTION
## Summary
- add a CLI/stdout-backed Ensen-loop EIP executor transport for local dry-run smoke boundaries
- expose transport failure classes for protocol-gap, loop-gap, and flow-gap failures
- add a focused workflow smoke test that drives the connector through a temp local CLI and records run state from returned EIP artifacts

## Verification
- npm ci
- npm test -- test/cli-loop-executor-smoke.test.ts
- npm run build
- npm test

Closes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI-backed executor transport to run external commands with configurable timeout, env, and cwd; returns structured, classified errors for operational failures.
  * Exposed a new runtime error type and transport factory for CLI-based executors.

* **Bug Fixes**
  * Invalid requests and various failure modes are now categorized as protocol-gap, loop-gap, or flow-gap for clearer diagnostics.

* **Tests**
  * Added end-to-end smoke tests covering normal operation, timeouts, and failure classifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->