### PR TITLE
Consume Loop X-Gate 2 smoke aggregate output

### DIFF
--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -158,13 +158,13 @@ export const createCliEnsenLoopEipExecutorTransport = (
       };
     },
     getRunStatusSnapshot(request: { requestId: string }) {
-      return requireSmokeAggregate(smokeAggregates, request.requestId).statusSnapshot;
+      return requireSmokeAggregate(smokeAggregates, request.requestId, "status").statusSnapshot;
     },
     getRunResult(request: { requestId: string }) {
-      return requireSmokeAggregate(smokeAggregates, request.requestId).runResult;
+      return requireSmokeAggregate(smokeAggregates, request.requestId, "result").runResult;
     },
     getEvidenceBundleRef(request: { requestId: string }) {
-      return requireSmokeAggregate(smokeAggregates, request.requestId).evidenceBundleRef;
+      return requireSmokeAggregate(smokeAggregates, request.requestId, "evidence").evidenceBundleRef;
     }
   };
 };
@@ -446,7 +446,7 @@ const invokeEnsenLoopXGate2SmokeCli = async (
       });
     }
 
-    const aggregateValidation = validateXGate2SmokeAggregate(aggregate);
+    const aggregateValidation = validateXGate2SmokeAggregate(aggregate, request.id);
 
     if (aggregateValidation !== undefined) {
       throw new EnsenLoopCliTransportError({
@@ -464,7 +464,8 @@ const invokeEnsenLoopXGate2SmokeCli = async (
 
 const requireSmokeAggregate = (
   smokeAggregates: Map<string, EnsenLoopXGate2SmokeAggregateV1>,
-  requestId: string
+  requestId: string,
+  operation: EnsenLoopCliOperation
 ): EnsenLoopXGate2SmokeAggregateV1 => {
   const aggregate = smokeAggregates.get(requestId);
 
@@ -472,7 +473,7 @@ const requireSmokeAggregate = (
     throw new EnsenLoopCliTransportError({
       message: `Ensen-loop X-Gate 2 smoke aggregate is unavailable for request ${requestId}`,
       failureClass: "flow-gap",
-      operation: "status"
+      operation
     });
   }
 
@@ -945,7 +946,8 @@ const validateRunStatusSnapshot = (
 };
 
 const validateXGate2SmokeAggregate = (
-  value: Record<string, unknown>
+  value: Record<string, unknown>,
+  expectedRequestId: string
 ): { message: string; reason: string } | undefined => {
   const unknownProperty = findUnknownProperty(value, [
     "schemaVersion",
@@ -968,6 +970,46 @@ const validateXGate2SmokeAggregate = (
 
   if (value.evidenceBundleRef !== undefined && !isRecord(value.evidenceBundleRef)) {
     return failClosedReason("EIP XGate2SmokeAggregate evidenceBundleRef must be an object");
+  }
+
+  const statusVersion = requireSchemaVersion(
+    value.statusSnapshot,
+    "eip.run-status.v1",
+    "RunStatusSnapshot"
+  );
+  if (statusVersion !== undefined) {
+    return statusVersion;
+  }
+
+  const statusValidation = validateRunStatusSnapshot(value.statusSnapshot, expectedRequestId);
+  if (statusValidation !== undefined) {
+    return statusValidation;
+  }
+
+  const resultVersion = requireSchemaVersion(value.runResult, "eip.run-result.v1", "RunResult");
+  if (resultVersion !== undefined) {
+    return resultVersion;
+  }
+
+  const resultValidation = validateRunResult(value.runResult, expectedRequestId);
+  if (resultValidation !== undefined) {
+    return resultValidation;
+  }
+
+  if (value.evidenceBundleRef !== undefined) {
+    const evidenceVersion = requireSchemaVersion(
+      value.evidenceBundleRef,
+      "eip.evidence-bundle-ref.v1",
+      "EvidenceBundleRef"
+    );
+    if (evidenceVersion !== undefined) {
+      return evidenceVersion;
+    }
+
+    const evidenceValidation = validateEvidenceBundleRef(value.evidenceBundleRef);
+    if (evidenceValidation !== undefined) {
+      return evidenceValidation;
+    }
   }
 
   return undefined;

--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -1,4 +1,7 @@
 import { spawn } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   createExecutorConnectorCapabilities,
@@ -141,27 +144,57 @@ interface FakeEnsenLoopEipRecord {
 
 export const createCliEnsenLoopEipExecutorTransport = (
   input: CreateCliEnsenLoopEipExecutorTransportInput
+): EnsenLoopEipExecutorTransport => {
+  const smokeAggregates = new Map<string, EnsenLoopXGate2SmokeAggregateV1>();
+
+  return {
+    async submitRunRequest(request: EipRunRequestV1) {
+      const aggregate = await invokeEnsenLoopXGate2SmokeCli(input, request);
+      smokeAggregates.set(request.id, aggregate);
+
+      return {
+        requestId: request.id,
+        acceptedAt: aggregate.statusSnapshot.observedAt
+      };
+    },
+    getRunStatusSnapshot(request: { requestId: string }) {
+      return requireSmokeAggregate(smokeAggregates, request.requestId).statusSnapshot;
+    },
+    getRunResult(request: { requestId: string }) {
+      return requireSmokeAggregate(smokeAggregates, request.requestId).runResult;
+    },
+    getEvidenceBundleRef(request: { requestId: string }) {
+      return requireSmokeAggregate(smokeAggregates, request.requestId).evidenceBundleRef;
+    }
+  };
+};
+
+// Lower-level helper for CLIs that explicitly support Flow's per-operation stdin envelope.
+// The real Ensen-loop X-Gate 2 smoke command is a one-shot aggregate stdout contract;
+// use createCliEnsenLoopEipExecutorTransport for that boundary.
+export const createPerOperationCliEnsenLoopEipExecutorTransport = (
+  input: CreateCliEnsenLoopEipExecutorTransportInput
 ): EnsenLoopEipExecutorTransport => ({
   submitRunRequest(request: EipRunRequestV1) {
-    return invokeEnsenLoopCli(input, {
+    return invokePerOperationEnsenLoopCli(input, {
       operation: "submit",
       request
     }) as Promise<{ requestId?: string; acceptedAt?: string; evidence?: Record<string, unknown> }>;
   },
   getRunStatusSnapshot(request: { requestId: string }) {
-    return invokeEnsenLoopCli(input, {
+    return invokePerOperationEnsenLoopCli(input, {
       operation: "status",
       requestId: request.requestId
     });
   },
   getRunResult(request: { requestId: string }) {
-    return invokeEnsenLoopCli(input, {
+    return invokePerOperationEnsenLoopCli(input, {
       operation: "result",
       requestId: request.requestId
     });
   },
   getEvidenceBundleRef(request: { requestId: string }) {
-    return invokeEnsenLoopCli(input, {
+    return invokePerOperationEnsenLoopCli(input, {
       operation: "evidence",
       requestId: request.requestId
     });
@@ -375,7 +408,78 @@ export const createEnsenLoopEipExecutorConnector = (
   };
 };
 
-const invokeEnsenLoopCli = async (
+const invokeEnsenLoopXGate2SmokeCli = async (
+  input: CreateCliEnsenLoopEipExecutorTransportInput,
+  request: EipRunRequestV1
+): Promise<EnsenLoopXGate2SmokeAggregateV1> => {
+  const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-x-gate2-smoke-"));
+  const requestPath = join(tempRoot, "run-request.json");
+
+  try {
+    await writeFile(requestPath, `${JSON.stringify(request, null, 2)}\n`, "utf8");
+    const aggregate = await invokeJsonCli({
+      input: {
+        ...input,
+        args: [...(input.args ?? []), requestPath]
+      },
+      operation: "submit"
+    });
+    const version = requireSchemaVersion(
+      aggregate,
+      "ensen-loop.x-gate2-smoke.v1",
+      "XGate2SmokeAggregate"
+    );
+
+    if (version !== undefined) {
+      throw new EnsenLoopCliTransportError({
+        message: version.message,
+        failureClass: "protocol-gap",
+        operation: "submit"
+      });
+    }
+
+    if (!isRecord(aggregate)) {
+      throw new EnsenLoopCliTransportError({
+        message: "Ensen-loop X-Gate 2 smoke aggregate must be an object",
+        failureClass: "protocol-gap",
+        operation: "submit"
+      });
+    }
+
+    const aggregateValidation = validateXGate2SmokeAggregate(aggregate);
+
+    if (aggregateValidation !== undefined) {
+      throw new EnsenLoopCliTransportError({
+        message: aggregateValidation.message,
+        failureClass: "protocol-gap",
+        operation: "submit"
+      });
+    }
+
+    return aggregate as unknown as EnsenLoopXGate2SmokeAggregateV1;
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+};
+
+const requireSmokeAggregate = (
+  smokeAggregates: Map<string, EnsenLoopXGate2SmokeAggregateV1>,
+  requestId: string
+): EnsenLoopXGate2SmokeAggregateV1 => {
+  const aggregate = smokeAggregates.get(requestId);
+
+  if (aggregate === undefined) {
+    throw new EnsenLoopCliTransportError({
+      message: `Ensen-loop X-Gate 2 smoke aggregate is unavailable for request ${requestId}`,
+      failureClass: "flow-gap",
+      operation: "status"
+    });
+  }
+
+  return aggregate;
+};
+
+const invokePerOperationEnsenLoopCli = async (
   input: CreateCliEnsenLoopEipExecutorTransportInput,
   envelope: {
     operation: EnsenLoopCliOperation;
@@ -383,7 +487,19 @@ const invokeEnsenLoopCli = async (
     requestId?: string;
   }
 ): Promise<unknown> => {
-  const operation = envelope.operation;
+  return invokeJsonCli({
+    input,
+    operation: envelope.operation,
+    stdin: `${JSON.stringify(envelope)}\n`
+  });
+};
+
+const invokeJsonCli = async (run: {
+  input: CreateCliEnsenLoopEipExecutorTransportInput;
+  operation: EnsenLoopCliOperation;
+  stdin?: string;
+}): Promise<unknown> => {
+  const { input, operation } = run;
   const child = spawn(input.command, input.args ?? [], {
     cwd: input.cwd,
     env: input.env,
@@ -442,7 +558,7 @@ const invokeEnsenLoopCli = async (
           }, input.timeoutMs);
         });
 
-  child.stdin.end(`${JSON.stringify(envelope)}\n`);
+  child.stdin.end(run.stdin ?? "");
 
   const result = await (timeoutPromise === undefined
     ? completion
@@ -668,6 +784,13 @@ interface EipRunResultV1 {
   metrics?: Record<string, unknown>;
 }
 
+interface EnsenLoopXGate2SmokeAggregateV1 {
+  schemaVersion: "ensen-loop.x-gate2-smoke.v1";
+  statusSnapshot: EipRunStatusSnapshotV1;
+  runResult: EipRunResultV1;
+  evidenceBundleRef?: Record<string, unknown>;
+}
+
 const createRunRequestPayload = (
   request: ExecutorSubmitRequest,
   createdAt: string
@@ -816,6 +939,35 @@ const validateRunStatusSnapshot = (
 
   if (value.progress !== undefined && !isRecord(value.progress)) {
     return failClosedReason("EIP RunStatusSnapshot progress must be an object");
+  }
+
+  return undefined;
+};
+
+const validateXGate2SmokeAggregate = (
+  value: Record<string, unknown>
+): { message: string; reason: string } | undefined => {
+  const unknownProperty = findUnknownProperty(value, [
+    "schemaVersion",
+    "statusSnapshot",
+    "runResult",
+    "evidenceBundleRef"
+  ]);
+
+  if (unknownProperty !== undefined) {
+    return failClosedReason(`EIP XGate2SmokeAggregate has unsupported field ${unknownProperty}`);
+  }
+
+  if (!isRecord(value.statusSnapshot)) {
+    return failClosedReason("EIP XGate2SmokeAggregate statusSnapshot must be an object");
+  }
+
+  if (!isRecord(value.runResult)) {
+    return failClosedReason("EIP XGate2SmokeAggregate runResult must be an object");
+  }
+
+  if (value.evidenceBundleRef !== undefined && !isRecord(value.evidenceBundleRef)) {
+    return failClosedReason("EIP XGate2SmokeAggregate evidenceBundleRef must be an object");
   }
 
   return undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,8 @@ export {
   EnsenLoopCliTransportError,
   createCliEnsenLoopEipExecutorTransport,
   createEnsenLoopEipExecutorConnector,
-  createFakeEnsenLoopEipExecutorTransport
+  createFakeEnsenLoopEipExecutorTransport,
+  createPerOperationCliEnsenLoopEipExecutorTransport
 } from "./ensen-loop-eip-executor-connector.js";
 
 export {

--- a/test/cli-loop-executor-smoke.test.ts
+++ b/test/cli-loop-executor-smoke.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../src/index.js";
 import type {
   ExecutorSubmitRequest,
+  EipRunRequestV1,
   WorkflowDefinition
 } from "../src/index.js";
 
@@ -26,27 +27,27 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
       cliPath,
       [
         "#!/usr/bin/env node",
-        "const chunks = [];",
-        "for await (const chunk of process.stdin) chunks.push(chunk);",
-        "const envelope = JSON.parse(Buffer.concat(chunks).toString('utf8'));",
-        "const requestId = envelope.request?.id ?? envelope.requestId;",
-        "const correlationId = envelope.request?.correlationId ?? `corr_${requestId.slice(4)}`;",
-        "switch (envelope.operation) {",
-        "  case 'submit':",
-        "    process.stdout.write(JSON.stringify({ requestId, acceptedAt: '2026-04-30T04:00:00.000Z' }));",
-        "    break;",
-        "  case 'status':",
-        "    process.stdout.write(JSON.stringify({",
+        "import { readFileSync } from 'node:fs';",
+        "const command = process.argv[2];",
+        "const requestPath = process.argv[3];",
+        "if (command !== 'x-gate2-smoke' || requestPath === undefined) {",
+        "  process.stderr.write('expected x-gate2-smoke <run-request-json-file>');",
+        "  process.exitCode = 2;",
+        "} else {",
+        "  const request = JSON.parse(readFileSync(requestPath, 'utf8'));",
+        "  const requestId = request.id;",
+        "  const correlationId = request.correlationId;",
+        "  process.stdout.write(JSON.stringify({",
+        "    schemaVersion: 'ensen-loop.x-gate2-smoke.v1',",
+        "    statusSnapshot: {",
         "      schemaVersion: 'eip.run-status.v1',",
         "      id: 'sts_cli_loop_smoke',",
         "      requestId,",
         "      correlationId,",
         "      status: 'completed',",
         "      observedAt: '2026-04-30T04:00:02.000Z'",
-        "    }));",
-        "    break;",
-        "  case 'result':",
-        "    process.stdout.write(JSON.stringify({",
+        "    },",
+        "    runResult: {",
         "      schemaVersion: 'eip.run-result.v1',",
         "      id: 'run_cli_loop_smoke',",
         "      requestId,",
@@ -55,10 +56,8 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
         "      completedAt: '2026-04-30T04:00:03.000Z',",
         "      verification: { status: 'passed', summary: 'CLI dry-run smoke completed.' },",
         "      evidenceBundles: [{ evidenceBundleId: 'evb_cli_loop_smoke', digest: 'sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef' }]",
-        "    }));",
-        "    break;",
-        "  case 'evidence':",
-        "    process.stdout.write(JSON.stringify({",
+        "    },",
+        "    evidenceBundleRef: {",
         "      schemaVersion: 'eip.evidence-bundle-ref.v1',",
         "      id: 'evb_cli_loop_smoke',",
         "      correlationId,",
@@ -66,11 +65,8 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
         "      uri: 'artifacts/evidence/cli-loop-smoke/bundle.json',",
         "      createdAt: '2026-04-30T04:00:03.000Z',",
         "      contentType: 'application/json'",
-        "    }));",
-        "    break;",
-        "  default:",
-        "    process.stderr.write(`unsupported operation ${envelope.operation}`);",
-        "    process.exitCode = 2;",
+        "    }",
+        "  }));",
         "}",
         ""
       ].join("\n"),
@@ -82,7 +78,7 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
       const connector = createEnsenLoopEipExecutorConnector({
         transport: createCliEnsenLoopEipExecutorTransport({
           command: process.execPath,
-          args: [cliPath]
+          args: [cliPath, "x-gate2-smoke"]
         }),
         now: () => "2026-04-30T04:00:00.000Z"
       });
@@ -244,13 +240,13 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
     try {
       const transport = createCliEnsenLoopEipExecutorTransport({
         command: process.execPath,
-        args: [cliPath]
+        args: [cliPath, "x-gate2-smoke"]
       });
 
-      await expect(transport.getRunStatusSnapshot({ requestId: "req_cli_loop_smoke" }))
+      await expect(transport.submitRunRequest(createSmokeRunRequest()))
         .rejects.toMatchObject({
           failureClass: expectedClass,
-          operation: "status"
+          operation: "submit"
         });
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
@@ -279,14 +275,14 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
     try {
       const transport = createCliEnsenLoopEipExecutorTransport({
         command: process.execPath,
-        args: [cliPath],
+        args: [cliPath, "x-gate2-smoke"],
         timeoutMs: 100
       });
 
-      await expect(transport.getRunStatusSnapshot({ requestId: "req_cli_loop_smoke" }))
+      await expect(transport.submitRunRequest(createSmokeRunRequest()))
         .rejects.toMatchObject({
           failureClass: "loop-gap",
-          operation: "status",
+          operation: "submit",
           stderr: "ignored SIGTERM"
         });
     } finally {
@@ -304,12 +300,23 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
         "#!/usr/bin/env node",
         "process.on('SIGTERM', () => {",
         "  process.stdout.write(JSON.stringify({",
-        "    schemaVersion: 'eip.run-status.v1',",
-        "    id: 'sts_cli_loop_timeout_grace',",
-        "    requestId: 'req_cli_loop_smoke',",
-        "    correlationId: 'corr_cli_loop_timeout_grace',",
-        "    status: 'completed',",
-        "    observedAt: '2026-04-30T04:00:02.000Z'",
+        "    schemaVersion: 'ensen-loop.x-gate2-smoke.v1',",
+        "    statusSnapshot: {",
+        "      schemaVersion: 'eip.run-status.v1',",
+        "      id: 'sts_cli_loop_timeout_grace',",
+        "      requestId: 'req_cli_loop_smoke',",
+        "      correlationId: 'corr_cli_loop_smoke',",
+        "      status: 'completed',",
+        "      observedAt: '2026-04-30T04:00:02.000Z'",
+        "    },",
+        "    runResult: {",
+        "      schemaVersion: 'eip.run-result.v1',",
+        "      id: 'run_cli_loop_timeout_grace',",
+        "      requestId: 'req_cli_loop_smoke',",
+        "      correlationId: 'corr_cli_loop_smoke',",
+        "      status: 'succeeded',",
+        "      completedAt: '2026-04-30T04:00:03.000Z'",
+        "    }",
         "  }));",
         "  process.exit(0);",
         "});",
@@ -324,12 +331,15 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
     try {
       const transport = createCliEnsenLoopEipExecutorTransport({
         command: process.execPath,
-        args: [cliPath],
+        args: [cliPath, "x-gate2-smoke"],
         timeoutMs: 100
       });
 
-      await expect(transport.getRunStatusSnapshot({ requestId: "req_cli_loop_smoke" }))
-        .resolves.toMatchObject({
+      await expect(transport.submitRunRequest(createSmokeRunRequest())).resolves.toMatchObject({
+        requestId: "req_cli_loop_smoke"
+      });
+      expect(transport.getRunStatusSnapshot({ requestId: "req_cli_loop_smoke" }))
+        .toMatchObject({
           schemaVersion: "eip.run-status.v1",
           requestId: "req_cli_loop_smoke",
           status: "completed"
@@ -344,12 +354,36 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
       command: "ensen-flow-missing-loop-cli-command"
     });
 
-    await expect(transport.getRunStatusSnapshot({ requestId: "req_cli_loop_smoke" }))
+    await expect(transport.submitRunRequest(createSmokeRunRequest()))
       .rejects.toBeInstanceOf(EnsenLoopCliTransportError);
-    await expect(transport.getRunStatusSnapshot({ requestId: "req_cli_loop_smoke" }))
+    await expect(transport.submitRunRequest(createSmokeRunRequest()))
       .rejects.toMatchObject({
         failureClass: "flow-gap",
-        operation: "status"
+        operation: "submit"
       });
   });
+});
+
+const createSmokeRunRequest = (): EipRunRequestV1 => ({
+  schemaVersion: "eip.run-request.v1",
+  id: "req_cli_loop_smoke",
+  correlationId: "corr_cli_loop_smoke",
+  idempotencyKey: "cli-loop-smoke-0001",
+  source: {
+    sourceId: "source_ensen_flow",
+    sourceType: "manual",
+    externalRef: "cli-smoke"
+  },
+  requestedBy: {
+    actorId: "actor_ensen_flow",
+    actorType: "system",
+    displayName: "Ensen-flow"
+  },
+  workItem: {
+    workItemId: "workitem_cli_loop_smoke",
+    externalId: "cli-loop-smoke",
+    title: "CLI Loop dry-run smoke"
+  },
+  mode: "validate",
+  createdAt: "2026-04-30T04:00:00.000Z"
 });

--- a/test/cli-loop-executor-smoke.test.ts
+++ b/test/cli-loop-executor-smoke.test.ts
@@ -253,6 +253,111 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
     }
   });
 
+  it.each([
+    {
+      operation: "status",
+      call: (transport: ReturnType<typeof createCliEnsenLoopEipExecutorTransport>) =>
+        transport.getRunStatusSnapshot({ requestId: "req_missing_cli_loop_smoke" })
+    },
+    {
+      operation: "result",
+      call: (transport: ReturnType<typeof createCliEnsenLoopEipExecutorTransport>) =>
+        transport.getRunResult({ requestId: "req_missing_cli_loop_smoke" })
+    },
+    {
+      operation: "evidence",
+      call: (transport: ReturnType<typeof createCliEnsenLoopEipExecutorTransport>) =>
+        transport.getEvidenceBundleRef({ requestId: "req_missing_cli_loop_smoke" })
+    }
+  ])("labels missing cached aggregate errors as $operation", ({ operation, call }) => {
+    const transport = createCliEnsenLoopEipExecutorTransport({
+      command: "unused-loop-cli"
+    });
+
+    expect(() => call(transport)).toThrow(EnsenLoopCliTransportError);
+
+    try {
+      call(transport);
+    } catch (error) {
+      expect(error).toMatchObject({
+        failureClass: "flow-gap",
+        operation
+      });
+    }
+  });
+
+  it.each([
+    {
+      name: "status snapshot requestId",
+      aggregate: {
+        ...createSmokeAggregate(),
+        statusSnapshot: {
+          ...createSmokeAggregate().statusSnapshot,
+          requestId: "req_wrong_cli_loop_smoke"
+        }
+      },
+      expectedMessage: "EIP RunStatusSnapshot requestId does not match the submitted request"
+    },
+    {
+      name: "run result schemaVersion",
+      aggregate: {
+        ...createSmokeAggregate(),
+        runResult: {
+          ...createSmokeAggregate().runResult,
+          schemaVersion: "eip.run-result.v2"
+        }
+      },
+      expectedMessage: "unsupported EIP RunResult schemaVersion eip.run-result.v2"
+    },
+    {
+      name: "evidence bundle local path",
+      aggregate: {
+        ...createSmokeAggregate(),
+        evidenceBundleRef: {
+          ...createSmokeAggregate().evidenceBundleRef,
+          uri: "../evidence/cli-loop-smoke/bundle.json"
+        }
+      },
+      expectedMessage: "EIP EvidenceBundleRef local_path uri is malformed"
+    }
+  ])("rejects malformed nested aggregate $name before caching", async ({
+    aggregate,
+    expectedMessage
+  }) => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-cli-loop-invalid-"));
+    const cliPath = join(tempRoot, "loop-dry-run-cli.mjs");
+
+    await writeFile(
+      cliPath,
+      [
+        "#!/usr/bin/env node",
+        `process.stdout.write(${JSON.stringify(JSON.stringify(aggregate))});`,
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+    await chmod(cliPath, 0o755);
+
+    try {
+      const transport = createCliEnsenLoopEipExecutorTransport({
+        command: process.execPath,
+        args: [cliPath, "x-gate2-smoke"]
+      });
+
+      await expect(transport.submitRunRequest(createSmokeRunRequest()))
+        .rejects.toMatchObject({
+          failureClass: "protocol-gap",
+          operation: "submit",
+          message: expectedMessage
+        });
+      expect(() =>
+        transport.getRunStatusSnapshot({ requestId: "req_cli_loop_smoke" })
+      ).toThrow(EnsenLoopCliTransportError);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("times out a CLI process that ignores SIGTERM", async () => {
     const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-cli-loop-timeout-"));
     const cliPath = join(tempRoot, "loop-dry-run-cli.mjs");
@@ -386,4 +491,37 @@ const createSmokeRunRequest = (): EipRunRequestV1 => ({
   },
   mode: "validate",
   createdAt: "2026-04-30T04:00:00.000Z"
+});
+
+const createSmokeAggregate = () => ({
+  schemaVersion: "ensen-loop.x-gate2-smoke.v1",
+  statusSnapshot: {
+    schemaVersion: "eip.run-status.v1",
+    id: "sts_cli_loop_smoke",
+    requestId: "req_cli_loop_smoke",
+    correlationId: "corr_cli_loop_smoke",
+    status: "completed",
+    observedAt: "2026-04-30T04:00:02.000Z"
+  },
+  runResult: {
+    schemaVersion: "eip.run-result.v1",
+    id: "run_cli_loop_smoke",
+    requestId: "req_cli_loop_smoke",
+    correlationId: "corr_cli_loop_smoke",
+    status: "succeeded",
+    completedAt: "2026-04-30T04:00:03.000Z",
+    verification: {
+      status: "passed",
+      summary: "CLI dry-run smoke completed."
+    }
+  },
+  evidenceBundleRef: {
+    schemaVersion: "eip.evidence-bundle-ref.v1",
+    id: "evb_cli_loop_smoke",
+    correlationId: "corr_cli_loop_smoke",
+    type: "local_path",
+    uri: "artifacts/evidence/cli-loop-smoke/bundle.json",
+    createdAt: "2026-04-30T04:00:03.000Z",
+    contentType: "application/json"
+  }
 });


### PR DESCRIPTION
## Summary
- switch the CLI-backed Loop smoke transport to invoke x-gate2-smoke with a run-request JSON file and consume the aggregate stdout contract
- split cached aggregate statusSnapshot, runResult, and optional evidenceBundleRef into the existing Flow connector status/evidence paths
- preserve the old per-operation stdin CLI helper separately and cover the aggregate smoke shape in the CLI smoke test

## Verification
- npm run build
- npm test -- test/cli-loop-executor-smoke.test.ts
- npm test

Refs #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added an alternative transport option for per-operation CLI execution mode.

* **Changes**
  - Default CLI executor now performs a single submit, caches the combined run aggregate per request, and serves subsequent status/result/evidence from that cache.

* **Tests**
  - Smoke tests updated to use submit-based flow and to validate caching, error classification, and early protocol/schema validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->