### PR TITLE
Handle Loop X-Gate 2 smoke aggregates

### DIFF
--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -422,7 +422,8 @@ const invokeEnsenLoopXGate2SmokeCli = async (
         ...input,
         args: [...(input.args ?? []), requestPath]
       },
-      operation: "submit"
+      operation: "submit",
+      allowNonZeroJsonStdout: true
     });
     const version = requireSchemaVersion(
       aggregate,
@@ -499,6 +500,7 @@ const invokeJsonCli = async (run: {
   input: CreateCliEnsenLoopEipExecutorTransportInput;
   operation: EnsenLoopCliOperation;
   stdin?: string;
+  allowNonZeroJsonStdout?: boolean;
 }): Promise<unknown> => {
   const { input, operation } = run;
   const child = spawn(input.command, input.args ?? [], {
@@ -584,7 +586,9 @@ const invokeJsonCli = async (run: {
 
   const { code, signal } = result;
 
-  if (code !== 0) {
+  const stdout = Buffer.concat(stdoutChunks).toString("utf8").trim();
+
+  if (code !== 0 && run.allowNonZeroJsonStdout !== true) {
     throw new EnsenLoopCliTransportError({
       message: `Ensen-loop CLI transport failed during ${operation} with exit code ${code ?? signal ?? "unknown"}`,
       failureClass: "loop-gap",
@@ -594,12 +598,15 @@ const invokeJsonCli = async (run: {
     });
   }
 
-  const stdout = Buffer.concat(stdoutChunks).toString("utf8").trim();
   if (stdout.length === 0) {
     throw new EnsenLoopCliTransportError({
-      message: `Ensen-loop CLI transport returned empty stdout during ${operation}`,
-      failureClass: "protocol-gap",
+      message:
+        code === 0
+          ? `Ensen-loop CLI transport returned empty stdout during ${operation}`
+          : `Ensen-loop CLI transport failed during ${operation} with exit code ${code ?? signal ?? "unknown"} and empty stdout`,
+      failureClass: code === 0 ? "protocol-gap" : "loop-gap",
       operation,
+      ...(code === null || code === 0 ? {} : { exitCode: code }),
       ...(stderr.length === 0 ? {} : { stderr })
     });
   }
@@ -608,9 +615,13 @@ const invokeJsonCli = async (run: {
     return JSON.parse(stdout) as unknown;
   } catch (error) {
     throw new EnsenLoopCliTransportError({
-      message: `Ensen-loop CLI transport returned non-JSON stdout during ${operation}`,
-      failureClass: "protocol-gap",
+      message:
+        code === 0
+          ? `Ensen-loop CLI transport returned non-JSON stdout during ${operation}`
+          : `Ensen-loop CLI transport failed during ${operation} with exit code ${code ?? signal ?? "unknown"} and non-JSON stdout`,
+      failureClass: code === 0 ? "protocol-gap" : "loop-gap",
       operation,
+      ...(code === null || code === 0 ? {} : { exitCode: code }),
       ...(stderr.length === 0 ? {} : { stderr })
     });
   }
@@ -787,6 +798,12 @@ interface EipRunResultV1 {
 
 interface EnsenLoopXGate2SmokeAggregateV1 {
   schemaVersion: "ensen-loop.x-gate2-smoke.v1";
+  boundary?: string;
+  requestId?: string;
+  correlationId?: string;
+  mutatesRepository?: boolean;
+  invokesProvider?: boolean;
+  writesDurableEvidence?: boolean;
   statusSnapshot: EipRunStatusSnapshotV1;
   runResult: EipRunResultV1;
   evidenceBundleRef?: Record<string, unknown>;
@@ -951,6 +968,12 @@ const validateXGate2SmokeAggregate = (
 ): { message: string; reason: string } | undefined => {
   const unknownProperty = findUnknownProperty(value, [
     "schemaVersion",
+    "boundary",
+    "requestId",
+    "correlationId",
+    "mutatesRepository",
+    "invokesProvider",
+    "writesDurableEvidence",
     "statusSnapshot",
     "runResult",
     "evidenceBundleRef"
@@ -970,6 +993,24 @@ const validateXGate2SmokeAggregate = (
 
   if (value.evidenceBundleRef !== undefined && !isRecord(value.evidenceBundleRef)) {
     return failClosedReason("EIP XGate2SmokeAggregate evidenceBundleRef must be an object");
+  }
+
+  if (value.boundary !== undefined && value.boundary !== "local-cli-stdout") {
+    return failClosedReason("EIP XGate2SmokeAggregate boundary is unsupported or malformed");
+  }
+
+  for (const field of ["mutatesRepository", "invokesProvider", "writesDurableEvidence"]) {
+    if (value[field] !== undefined && typeof value[field] !== "boolean") {
+      return failClosedReason(`EIP XGate2SmokeAggregate ${field} must be a boolean`);
+    }
+  }
+
+  if (value.requestId !== undefined) {
+    if (typeof value.requestId !== "string" || value.requestId !== expectedRequestId) {
+      return failClosedReason(
+        "EIP XGate2SmokeAggregate requestId does not match the submitted request"
+      );
+    }
   }
 
   const statusVersion = requireSchemaVersion(
@@ -994,6 +1035,16 @@ const validateXGate2SmokeAggregate = (
   const resultValidation = validateRunResult(value.runResult, expectedRequestId);
   if (resultValidation !== undefined) {
     return resultValidation;
+  }
+
+  if (
+    value.statusSnapshot.correlationId !== value.runResult.correlationId ||
+    (value.correlationId !== undefined &&
+      value.correlationId !== value.statusSnapshot.correlationId)
+  ) {
+    return failClosedReason(
+      "EIP XGate2SmokeAggregate correlationId does not match nested payloads"
+    );
   }
 
   if (value.evidenceBundleRef !== undefined) {

--- a/test/cli-loop-executor-smoke.test.ts
+++ b/test/cli-loop-executor-smoke.test.ts
@@ -39,6 +39,12 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
         "  const correlationId = request.correlationId;",
         "  process.stdout.write(JSON.stringify({",
         "    schemaVersion: 'ensen-loop.x-gate2-smoke.v1',",
+        "    boundary: 'local-cli-stdout',",
+        "    requestId,",
+        "    correlationId,",
+        "    mutatesRepository: false,",
+        "    invokesProvider: false,",
+        "    writesDurableEvidence: false,",
         "    statusSnapshot: {",
         "      schemaVersion: 'eip.run-status.v1',",
         "      id: 'sts_cli_loop_smoke',",
@@ -299,6 +305,14 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
       expectedMessage: "EIP RunStatusSnapshot requestId does not match the submitted request"
     },
     {
+      name: "top-level correlationId",
+      aggregate: {
+        ...createSmokeAggregate(),
+        correlationId: "corr_wrong_cli_loop_smoke"
+      },
+      expectedMessage: "EIP XGate2SmokeAggregate correlationId does not match nested payloads"
+    },
+    {
       name: "run result schemaVersion",
       aggregate: {
         ...createSmokeAggregate(),
@@ -353,6 +367,114 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
       expect(() =>
         transport.getRunStatusSnapshot({ requestId: "req_cli_loop_smoke" })
       ).toThrow(EnsenLoopCliTransportError);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("consumes a blocked smoke aggregate from non-zero CLI stdout", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-cli-loop-blocked-"));
+    const cliPath = join(tempRoot, "loop-dry-run-cli.mjs");
+
+    await writeFile(
+      cliPath,
+      [
+        "#!/usr/bin/env node",
+        "import { readFileSync } from 'node:fs';",
+        "const requestPath = process.argv[3];",
+        "const request = JSON.parse(readFileSync(requestPath, 'utf8'));",
+        "process.stdout.write(JSON.stringify(createBlockedAggregate(request.id, request.correlationId)));",
+        "process.stderr.write('blocked by Loop X-Gate 2 smoke prerequisites');",
+        "process.exitCode = 1;",
+        "function createBlockedAggregate(requestId, correlationId) {",
+        "  return {",
+        "    schemaVersion: 'ensen-loop.x-gate2-smoke.v1',",
+        "    boundary: 'local-cli-stdout',",
+        "    requestId,",
+        "    correlationId,",
+        "    mutatesRepository: false,",
+        "    invokesProvider: false,",
+        "    writesDurableEvidence: false,",
+        "    statusSnapshot: {",
+        "      schemaVersion: 'eip.run-status.v1',",
+        "      id: 'sts_cli_loop_blocked',",
+        "      requestId,",
+        "      correlationId,",
+        "      status: 'blocked',",
+        "      observedAt: '2026-04-30T04:00:02.000Z',",
+        "      message: 'Loop smoke blocked before external execution.'",
+        "    },",
+        "    runResult: {",
+        "      schemaVersion: 'eip.run-result.v1',",
+        "      id: 'run_cli_loop_blocked',",
+        "      requestId,",
+        "      correlationId,",
+        "      status: 'blocked',",
+        "      completedAt: '2026-04-30T04:00:03.000Z',",
+        "      verification: {",
+        "        status: 'blocked',",
+        "        summary: 'Loop smoke blocked before external execution.'",
+        "      },",
+        "      errors: [{ code: 'missing-prerequisite', message: 'Loop smoke prerequisites are unavailable.' }]",
+        "    }",
+        "  };",
+        "}",
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+    await chmod(cliPath, 0o755);
+
+    try {
+      const connector = createEnsenLoopEipExecutorConnector({
+        transport: createCliEnsenLoopEipExecutorTransport({
+          command: process.execPath,
+          args: [cliPath, "x-gate2-smoke"]
+        })
+      });
+
+      const submitted = await connector.submit({
+        workflow: {
+          id: "cli-loop-smoke",
+          version: "flow.workflow.v1"
+        },
+        run: {
+          id: "cli-loop-smoke"
+        },
+        step: {
+          id: "loop-dry-run",
+          attempt: 1
+        },
+        idempotencyKey: "cli-loop-smoke-0001",
+        policyDecision: { decision: "allow" },
+        source: createSmokeRunRequest().source,
+        requestedBy: createSmokeRunRequest().requestedBy,
+        workItem: createSmokeRunRequest().workItem
+      });
+
+      expect(submitted).toMatchObject({
+        ok: true,
+        value: {
+          requestId: "req_cli_loop_smoke_loop_dry_run_1"
+        }
+      });
+
+      const status = await connector.status({ requestId: "req_cli_loop_smoke_loop_dry_run_1" });
+
+      expect(status).toMatchObject({
+        ok: true,
+        value: {
+          requestId: "req_cli_loop_smoke_loop_dry_run_1",
+          status: "blocked",
+          flowControl: {
+            state: "blocked"
+          },
+          result: {
+            status: "blocked",
+            summary: "Loop smoke blocked before external execution."
+          }
+        }
+      });
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
     }
@@ -495,6 +617,12 @@ const createSmokeRunRequest = (): EipRunRequestV1 => ({
 
 const createSmokeAggregate = () => ({
   schemaVersion: "ensen-loop.x-gate2-smoke.v1",
+  boundary: "local-cli-stdout",
+  requestId: "req_cli_loop_smoke",
+  correlationId: "corr_cli_loop_smoke",
+  mutatesRepository: false,
+  invokesProvider: false,
+  writesDurableEvidence: false,
   statusSnapshot: {
     schemaVersion: "eip.run-status.v1",
     id: "sts_cli_loop_smoke",


### PR DESCRIPTION
## Summary
- accept real Ensen-loop X-Gate 2 smoke aggregate metadata at the Flow CLI boundary
- validate top-level request/correlation metadata against nested status and result payloads
- parse valid smoke aggregate stdout from non-zero CLI exits so blocked aggregates map to blocked connector results

## Verification
- npm run build
- npm test -- test/cli-loop-executor-smoke.test.ts
- npm test
- local cross-repo smoke check through Flow transport with <ensen-loop-root>/dist/src/cli/index.js x-gate2-smoke for ready and blocked fixtures

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI command results are now processed successfully even when commands exit with non-zero status codes, provided output is valid JSON
  * Added request and correlation ID tracking for improved traceability
  * Enhanced detection and reporting of blocked execution states

* **Bug Fixes**
  * Refined error reporting for CLI execution failures and malformed output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->