### PR TITLE
Preserve loop-gap for invalid smoke JSON

### DIFF
--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -142,6 +142,12 @@ interface FakeEnsenLoopEipRecord {
   statusIndex: number;
 }
 
+interface JsonCliInvocationResult {
+  payload: unknown;
+  exitCode: number | null;
+  stderr: string;
+}
+
 export const createCliEnsenLoopEipExecutorTransport = (
   input: CreateCliEnsenLoopEipExecutorTransportInput
 ): EnsenLoopEipExecutorTransport => {
@@ -417,14 +423,24 @@ const invokeEnsenLoopXGate2SmokeCli = async (
 
   try {
     await writeFile(requestPath, `${JSON.stringify(request, null, 2)}\n`, "utf8");
-    const aggregate = await invokeJsonCli({
+    const cliResult = await invokeJsonCli({
       input: {
         ...input,
         args: [...(input.args ?? []), requestPath]
       },
       operation: "submit",
-      allowNonZeroJsonStdout: true
-    });
+      allowNonZeroJsonStdout: true,
+      returnResultMetadata: true
+    }) as JsonCliInvocationResult;
+    const aggregate = cliResult.payload;
+    const invalidAggregateFailureClass =
+      cliResult.exitCode === 0 ? "protocol-gap" : "loop-gap";
+    const invalidAggregateEvidence = {
+      ...(cliResult.exitCode === null || cliResult.exitCode === 0
+        ? {}
+        : { exitCode: cliResult.exitCode }),
+      ...(cliResult.stderr.length === 0 ? {} : { stderr: cliResult.stderr })
+    };
     const version = requireSchemaVersion(
       aggregate,
       "ensen-loop.x-gate2-smoke.v1",
@@ -434,16 +450,18 @@ const invokeEnsenLoopXGate2SmokeCli = async (
     if (version !== undefined) {
       throw new EnsenLoopCliTransportError({
         message: version.message,
-        failureClass: "protocol-gap",
-        operation: "submit"
+        failureClass: invalidAggregateFailureClass,
+        operation: "submit",
+        ...invalidAggregateEvidence
       });
     }
 
     if (!isRecord(aggregate)) {
       throw new EnsenLoopCliTransportError({
         message: "Ensen-loop X-Gate 2 smoke aggregate must be an object",
-        failureClass: "protocol-gap",
-        operation: "submit"
+        failureClass: invalidAggregateFailureClass,
+        operation: "submit",
+        ...invalidAggregateEvidence
       });
     }
 
@@ -452,8 +470,9 @@ const invokeEnsenLoopXGate2SmokeCli = async (
     if (aggregateValidation !== undefined) {
       throw new EnsenLoopCliTransportError({
         message: aggregateValidation.message,
-        failureClass: "protocol-gap",
-        operation: "submit"
+        failureClass: invalidAggregateFailureClass,
+        operation: "submit",
+        ...invalidAggregateEvidence
       });
     }
 
@@ -501,6 +520,7 @@ const invokeJsonCli = async (run: {
   operation: EnsenLoopCliOperation;
   stdin?: string;
   allowNonZeroJsonStdout?: boolean;
+  returnResultMetadata?: boolean;
 }): Promise<unknown> => {
   const { input, operation } = run;
   const child = spawn(input.command, input.args ?? [], {
@@ -612,7 +632,15 @@ const invokeJsonCli = async (run: {
   }
 
   try {
-    return JSON.parse(stdout) as unknown;
+    const payload = JSON.parse(stdout) as unknown;
+    if (run.returnResultMetadata === true) {
+      return {
+        payload,
+        exitCode: code,
+        stderr
+      } satisfies JsonCliInvocationResult;
+    }
+    return payload;
   } catch (error) {
     throw new EnsenLoopCliTransportError({
       message:

--- a/test/cli-loop-executor-smoke.test.ts
+++ b/test/cli-loop-executor-smoke.test.ts
@@ -223,10 +223,20 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
       name: "loop gap for non-zero CLI exit",
       scriptBody: "process.stderr.write('dry-run CLI failed'); process.exitCode = 3;",
       expectedClass: "loop-gap"
+    },
+    {
+      name: "loop gap for non-zero invalid smoke JSON",
+      scriptBody:
+        "process.stdout.write(JSON.stringify({ error: 'loop failed before aggregate' })); process.stderr.write('dry-run CLI failed'); process.exitCode = 3;",
+      expectedClass: "loop-gap",
+      expectedExitCode: 3,
+      expectedStderr: "dry-run CLI failed"
     }
   ])("classifies CLI smoke failures as $name", async ({
     scriptBody,
-    expectedClass
+    expectedClass,
+    expectedExitCode,
+    expectedStderr
   }) => {
     const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-cli-loop-failure-"));
     const cliPath = join(tempRoot, "loop-dry-run-cli.mjs");
@@ -252,7 +262,9 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
       await expect(transport.submitRunRequest(createSmokeRunRequest()))
         .rejects.toMatchObject({
           failureClass: expectedClass,
-          operation: "submit"
+          operation: "submit",
+          ...(expectedExitCode === undefined ? {} : { exitCode: expectedExitCode }),
+          ...(expectedStderr === undefined ? {} : { stderr: expectedStderr })
         });
     } finally {
       await rm(tempRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- classify non-zero X-Gate smoke CLI exits with JSON stdout that is not a valid smoke aggregate as loop-gap
- preserve valid blocked aggregate handling on non-zero exits
- keep zero-exit malformed aggregate stdout as protocol-gap
- include exit code and stderr evidence on invalid non-zero smoke JSON errors

Fixes #45

## Verification
- npm run build
- npm test -- test/cli-loop-executor-smoke.test.ts
- npm test
- local built smoke check for non-zero CLI command emitting invalid smoke JSON

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced execution metadata handling with improved error classification and diagnostic information for CLI connectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->