### PR TITLE
FLOW-030: Add X-Gate 3 Flow caller runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ authority, and no premature compliance claims.
 - `docs/x-gate2-loop-flow-smoke-runbook.md`: local X-Gate 2 loop-flow smoke
   runbook, expected artifacts, failure classification, and non-production
   boundaries.
+- `docs/x-gate3-flow-caller-boundary-runbook.md`: Flow-owned X-Gate 3 caller
+  boundary, Loop local fake lane command shape, stdout contract, failure
+  routing, and non-production limits.
 
 ## Workflow Definition Schema
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Start here:
 - [Mission](./mission.md): the Ensen-flow short-form development charter.
 - [Workflow Definition Schema](./workflow-definition.md): the Phase 1 standalone workflow definition boundary and validation shape.
 - [X-Gate 2 Loop-Flow Smoke Runbook](./x-gate2-loop-flow-smoke-runbook.md): local smoke commands, artifacts, failure routing, and non-production boundaries.
+- [X-Gate 3 Flow Caller Boundary Runbook](./x-gate3-flow-caller-boundary-runbook.md): Flow-owned caller boundary for Loop local fake lane smoke input, stdout output, artifacts, and failure routing.
 - [Ensen-protocol v0.1.0 Snapshot](../protocol-snapshots/ensen-protocol/v0.1.0/README.md): copied protocol schemas and conformance fixtures for later connector tests.
 
 Ensen-flow documentation should preserve the product boundary: lightweight explainable workflow orchestration, no shared runtime dependency with Ensen-loop, and no premature Pharma/GxP compliance claims.

--- a/docs/x-gate3-flow-caller-boundary-runbook.md
+++ b/docs/x-gate3-flow-caller-boundary-runbook.md
@@ -1,0 +1,128 @@
+# X-Gate 3 Flow Caller Boundary Runbook
+
+This runbook documents the Flow-owned Phase 3 / X-Gate 3 caller boundary for
+local development smoke evidence. It is not production automation, not
+compliance evidence, and not evidence of regulated workflow readiness.
+
+The boundary is intentionally process-shaped: Ensen-flow prepares
+protocol-shaped input, invokes a local Ensen-loop smoke command as a child
+process, reads one aggregate from process stdout, and routes findings to the
+owning repository. Ensen-flow must not import Ensen-loop implementation code,
+Ensen-loop internal packages, ERPNext adapters, Pharma/GxP packs, or runtime
+code from other Ensen repositories.
+
+## Scope
+
+The X-Gate 3 caller boundary proves that Flow can describe how it will call the
+Loop Phase 3 local fake lane without changing Flow runtime behavior yet. The
+smoke is a local development boundary, not a shared implementation contract and
+not a production executor integration.
+
+Out of scope:
+
+- no runtime connector implementation;
+- no shared Ensen-loop implementation imports;
+- no protocol schema changes;
+- no real provider invocation;
+- no real repository mutation;
+- no real pull request, review, or issue mutation;
+- no ERPNext behavior;
+- no Pharma/GxP workflow pack or compliance claim;
+- no customer data, production credentials, or durable production evidence.
+
+## Command Boundary
+
+Flow callers should treat the Loop smoke command as an external process with
+placeholder paths supplied by the operator or supervisor:
+
+```sh
+x-gate3-smoke <run-request-json-file> --workspace-root <workspace-root> --state-root <state-root>
+```
+
+The `<run-request-json-file>` input is a protocol-shaped RunRequest JSON file.
+The `<workspace-root>` and `<state-root>` values are local smoke roots only.
+Docs, tests, fixtures, and issue output must keep these as placeholders or
+repo-relative paths; they must not publish workstation-local absolute paths,
+secrets, customer data, or production evidence locations.
+
+## Stdout Contract
+
+The command should write one JSON aggregate to process stdout. Flow may consume
+only the boundary fields needed to classify the smoke result:
+
+- aggregate schema version, so Flow can fail closed on unsupported aggregate
+  shapes;
+- boundary flags, so local fake lane, dry-run, and no-production-mutation
+  claims remain explicit in the output;
+- RunStatusSnapshot, representing the observed status at the boundary;
+- RunResult, representing the terminal result when the smoke reaches one;
+- local artifact references, such as local evidence or log files created under
+  the supplied local state root.
+
+Flow must treat stderr, exit status, and stdout as boundary signals rather than
+trusted authority. Missing, malformed, mixed-version, or contradictory signals
+fail closed and must be routed as a finding.
+
+## Artifact Handling
+
+Flow may consume local artifact references only as local smoke pointers. They
+are not production evidence, not compliance evidence, not a customer archive,
+and not proof that an external executor or provider ran.
+
+Allowed local smoke references include:
+
+- a local aggregate JSON file under `<state-root>`;
+- a local log or transcript under `<state-root>`;
+- a local evidence-bundle reference whose URI is placeholder-based or
+  repo-relative.
+
+Flow must not publish raw secrets, access tokens, customer records, provider
+payloads, real repository data, real review text, ERPNext records, or Pharma/GxP
+evidence as part of X-Gate 3 smoke output.
+
+## Failure Routing
+
+| Failure class | Route follow-up to | Use when |
+| --- | --- | --- |
+| `protocol-gap` | TommyKammy/Ensen-protocol, using TommyKammy/Ensen-protocol#28 for concrete protocol contract ambiguity | The command boundary needs a protocol contract that is missing, ambiguous, contradictory, or not covered by the current protocol snapshot or fixtures. |
+| `loop-gap` | TommyKammy/Ensen-loop | The local fake lane command is unavailable, exits non-zero for a Loop-owned reason, omits the promised aggregate, mislabels boundary flags, or writes malformed local smoke artifacts. |
+| `flow-gap` | TommyKammy/Ensen-flow | Flow constructs invalid protocol-shaped input, invokes the process boundary incorrectly, trusts unsupported stdout, accepts unsafe artifact references, or documents a caller behavior it cannot later enforce. |
+
+Fail closed when the owner is unclear. Do not infer success from names, comments,
+placeholder credentials, forwarded identity headers, path shape, sibling
+records, or nearby metadata. Route concrete protocol contract ambiguity through
+TommyKammy/Ensen-protocol#28 rather than widening Flow or Loop behavior by
+assumption.
+
+## Verification
+
+Run the repo-owned documentation contract test:
+
+```sh
+npm test -- test/x-gate3-flow-runbook.test.ts
+```
+
+Before marking the runbook complete, also inspect the docs diff for boundary
+wording and placeholder-only paths. Full local verification should continue to
+use the repo-owned commands:
+
+```sh
+npm run build
+npm test
+```
+
+## X-Gate 3 Reached Criteria
+
+X-Gate 3 documentation can be marked ready when all of the following are true:
+
+- the Flow runbook describes protocol-shaped input and process stdout output;
+- README or docs navigation links to this runbook;
+- the command shape uses placeholders only;
+- expected stdout fields include aggregate schema version, boundary flags,
+  RunStatusSnapshot, RunResult, and local artifact references;
+- failure routing covers `protocol-gap`, `loop-gap`, and `flow-gap`;
+- concrete protocol contract ambiguity routes to TommyKammy/Ensen-protocol#28;
+- the wording preserves the Ensen-flow repository boundary and forbids shared
+  Ensen-loop implementation imports;
+- the smoke remains local development evidence only, with no production
+  automation or compliance evidence claim.

--- a/test/x-gate3-flow-runbook.test.ts
+++ b/test/x-gate3-flow-runbook.test.ts
@@ -1,0 +1,52 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+const runbookPath = "docs/x-gate3-flow-caller-boundary-runbook.md";
+const readmePath = "README.md";
+const docsIndexPath = "docs/README.md";
+const posixHomeRootPattern = new RegExp(["", "Users", "[A-Za-z0-9._-]+"].join("\\/"));
+const linuxHomeRootPattern = new RegExp(["", "home", "[A-Za-z0-9._-]+"].join("\\/"));
+const windowsHomeRootPattern = new RegExp(["[A-Za-z]:", "Users", ""].join("\\\\"));
+
+describe("X-Gate 3 Flow caller boundary runbook", () => {
+  it("documents the process boundary, stdout contract, routing, and non-production limits", async () => {
+    const runbook = await readFile(runbookPath, "utf8");
+
+    expect(runbook).toContain(
+      "x-gate3-smoke <run-request-json-file> --workspace-root <workspace-root> --state-root <state-root>",
+    );
+    expect(runbook).toContain("protocol-shaped input");
+    expect(runbook).toContain("process stdout");
+    expect(runbook).toContain("aggregate schema version");
+    expect(runbook).toContain("boundary flags");
+    expect(runbook).toContain("RunStatusSnapshot");
+    expect(runbook).toContain("RunResult");
+    expect(runbook).toContain("local artifact references");
+    expect(runbook).toContain("protocol-gap");
+    expect(runbook).toContain("loop-gap");
+    expect(runbook).toContain("flow-gap");
+    expect(runbook).toContain("TommyKammy/Ensen-protocol#28");
+    expect(runbook).toContain("must not import Ensen-loop implementation code");
+    expect(runbook).toContain("not production automation");
+    expect(runbook).toContain("not compliance evidence");
+    expect(runbook).toContain("no real provider");
+    expect(runbook).toContain("no real repository");
+    expect(runbook).toContain("no real pull request");
+    expect(runbook).toContain("no ERPNext");
+    expect(runbook).toContain("no Pharma/GxP");
+    expect(runbook).not.toMatch(posixHomeRootPattern);
+    expect(runbook).not.toMatch(linuxHomeRootPattern);
+    expect(runbook).not.toMatch(windowsHomeRootPattern);
+  });
+
+  it("links the runbook from public documentation navigation", async () => {
+    const [readme, docsIndex] = await Promise.all([
+      readFile(readmePath, "utf8"),
+      readFile(docsIndexPath, "utf8"),
+    ]);
+
+    expect(readme).toContain("docs/x-gate3-flow-caller-boundary-runbook.md");
+    expect(docsIndex).toContain("x-gate3-flow-caller-boundary-runbook.md");
+  });
+});


### PR DESCRIPTION
## Summary
- Add the Flow-owned X-Gate 3 caller boundary runbook for the Loop Phase 3 local fake lane smoke command.
- Document placeholder-only command shape, stdout fields, artifact handling, and protocol/loop/flow failure routing.
- Link the runbook from README and docs navigation, with a focused docs-contract test.

## Verification
- npm ci
- npm test -- test/x-gate3-flow-runbook.test.ts
- npm run build
- npm test

Closes #49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new runbook documenting the X-Gate 3 Phase 3 caller workflow process boundary and requirements.
  * Updated README with reference to the new runbook.
  * Added navigation link in documentation start guide.

* **Tests**
  * Added test suite validating runbook documentation completeness and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->