### PR TITLE
FLOW-031: Validate Loop X-Gate 3 local lane aggregate

### DIFF
--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -151,7 +151,7 @@ interface JsonCliInvocationResult {
 export const createCliEnsenLoopEipExecutorTransport = (
   input: CreateCliEnsenLoopEipExecutorTransportInput
 ): EnsenLoopEipExecutorTransport => {
-  const smokeAggregates = new Map<string, EnsenLoopXGate2SmokeAggregateV1>();
+  const smokeAggregates = new Map<string, EnsenLoopSmokeAggregateV1>();
 
   return {
     async submitRunRequest(request: EipRunRequestV1) {
@@ -417,7 +417,7 @@ export const createEnsenLoopEipExecutorConnector = (
 const invokeEnsenLoopXGate2SmokeCli = async (
   input: CreateCliEnsenLoopEipExecutorTransportInput,
   request: EipRunRequestV1
-): Promise<EnsenLoopXGate2SmokeAggregateV1> => {
+): Promise<EnsenLoopSmokeAggregateV1> => {
   const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-x-gate2-smoke-"));
   const requestPath = join(tempRoot, "run-request.json");
 
@@ -441,31 +441,16 @@ const invokeEnsenLoopXGate2SmokeCli = async (
         : { exitCode: cliResult.exitCode }),
       ...(cliResult.stderr.length === 0 ? {} : { stderr: cliResult.stderr })
     };
-    const version = requireSchemaVersion(
-      aggregate,
-      "ensen-loop.x-gate2-smoke.v1",
-      "XGate2SmokeAggregate"
-    );
-
-    if (version !== undefined) {
-      throw new EnsenLoopCliTransportError({
-        message: version.message,
-        failureClass: invalidAggregateFailureClass,
-        operation: "submit",
-        ...invalidAggregateEvidence
-      });
-    }
-
     if (!isRecord(aggregate)) {
       throw new EnsenLoopCliTransportError({
-        message: "Ensen-loop X-Gate 2 smoke aggregate must be an object",
+        message: "Ensen-loop smoke aggregate must be an object",
         failureClass: invalidAggregateFailureClass,
         operation: "submit",
         ...invalidAggregateEvidence
       });
     }
 
-    const aggregateValidation = validateXGate2SmokeAggregate(aggregate, request.id);
+    const aggregateValidation = validateSmokeAggregate(aggregate, request.id);
 
     if (aggregateValidation !== undefined) {
       throw new EnsenLoopCliTransportError({
@@ -476,17 +461,17 @@ const invokeEnsenLoopXGate2SmokeCli = async (
       });
     }
 
-    return aggregate as unknown as EnsenLoopXGate2SmokeAggregateV1;
+    return aggregate as unknown as EnsenLoopSmokeAggregateV1;
   } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }
 };
 
 const requireSmokeAggregate = (
-  smokeAggregates: Map<string, EnsenLoopXGate2SmokeAggregateV1>,
+  smokeAggregates: Map<string, EnsenLoopSmokeAggregateV1>,
   requestId: string,
   operation: EnsenLoopCliOperation
-): EnsenLoopXGate2SmokeAggregateV1 => {
+): EnsenLoopSmokeAggregateV1 => {
   const aggregate = smokeAggregates.get(requestId);
 
   if (aggregate === undefined) {
@@ -837,6 +822,25 @@ interface EnsenLoopXGate2SmokeAggregateV1 {
   evidenceBundleRef?: Record<string, unknown>;
 }
 
+interface EnsenLoopXGate3LocalLaneSmokeAggregateV1 {
+  schemaVersion: "ensen-loop.x-gate3-local-lane-smoke.v1";
+  boundary: "local-cli-bounded-fake-lane";
+  requestId: string;
+  correlationId: string;
+  mutatesRepository: false;
+  invokesProvider: false;
+  startsAgentProviderSession: false;
+  writesProductionEvidenceArchive: false;
+  statusSnapshot: EipRunStatusSnapshotV1;
+  runResult: EipRunResultV1;
+  localArtifacts: Array<Record<string, unknown>>;
+  evidenceBundleRef?: Record<string, unknown>;
+}
+
+type EnsenLoopSmokeAggregateV1 =
+  | EnsenLoopXGate2SmokeAggregateV1
+  | EnsenLoopXGate3LocalLaneSmokeAggregateV1;
+
 const createRunRequestPayload = (
   request: ExecutorSubmitRequest,
   createdAt: string
@@ -990,6 +994,23 @@ const validateRunStatusSnapshot = (
   return undefined;
 };
 
+const validateSmokeAggregate = (
+  value: Record<string, unknown>,
+  expectedRequestId: string
+): { message: string; reason: string } | undefined => {
+  if (value.schemaVersion === "ensen-loop.x-gate2-smoke.v1") {
+    return validateXGate2SmokeAggregate(value, expectedRequestId);
+  }
+
+  if (value.schemaVersion === "ensen-loop.x-gate3-local-lane-smoke.v1") {
+    return validateXGate3LocalLaneSmokeAggregate(value, expectedRequestId);
+  }
+
+  const versionText =
+    typeof value.schemaVersion === "string" ? value.schemaVersion : "missing";
+  return failClosedReason(`unsupported EIP XGateSmokeAggregate schemaVersion ${versionText}`);
+};
+
 const validateXGate2SmokeAggregate = (
   value: Record<string, unknown>,
   expectedRequestId: string
@@ -1088,6 +1109,205 @@ const validateXGate2SmokeAggregate = (
     const evidenceValidation = validateEvidenceBundleRef(value.evidenceBundleRef);
     if (evidenceValidation !== undefined) {
       return evidenceValidation;
+    }
+  }
+
+  return undefined;
+};
+
+const validateXGate3LocalLaneSmokeAggregate = (
+  value: Record<string, unknown>,
+  expectedRequestId: string
+): { message: string; reason: string } | undefined => {
+  const shapeName = "EIP XGate3LocalLaneSmokeAggregate";
+  const unknownProperty = findUnknownProperty(value, [
+    "schemaVersion",
+    "boundary",
+    "requestId",
+    "correlationId",
+    "mutatesRepository",
+    "invokesProvider",
+    "startsAgentProviderSession",
+    "writesProductionEvidenceArchive",
+    "statusSnapshot",
+    "runResult",
+    "localArtifacts",
+    "evidenceBundleRef"
+  ]);
+
+  if (unknownProperty !== undefined) {
+    return failClosedReason(`${shapeName} has unsupported field ${unknownProperty}`);
+  }
+
+  if (value.boundary !== "local-cli-bounded-fake-lane") {
+    return failClosedReason(`${shapeName} boundary is unsupported or malformed`);
+  }
+
+  for (const field of [
+    "mutatesRepository",
+    "invokesProvider",
+    "startsAgentProviderSession",
+    "writesProductionEvidenceArchive"
+  ]) {
+    if (value[field] !== false) {
+      return failClosedReason(`${shapeName} ${field} must be false`);
+    }
+  }
+
+  if (typeof value.requestId !== "string" || value.requestId !== expectedRequestId) {
+    return failClosedReason(`${shapeName} requestId does not match the submitted request`);
+  }
+
+  if (!isRecord(value.statusSnapshot)) {
+    return failClosedReason(`${shapeName} statusSnapshot must be an object`);
+  }
+
+  if (!isRecord(value.runResult)) {
+    return failClosedReason(`${shapeName} runResult must be an object`);
+  }
+
+  const statusVersion = requireSchemaVersion(
+    value.statusSnapshot,
+    "eip.run-status.v1",
+    "RunStatusSnapshot"
+  );
+  if (statusVersion !== undefined) {
+    return statusVersion;
+  }
+
+  const statusValidation = validateRunStatusSnapshot(value.statusSnapshot, expectedRequestId);
+  if (statusValidation !== undefined) {
+    return statusValidation;
+  }
+
+  const resultVersion = requireSchemaVersion(value.runResult, "eip.run-result.v1", "RunResult");
+  if (resultVersion !== undefined) {
+    return resultVersion;
+  }
+
+  const resultValidation = validateRunResult(value.runResult, expectedRequestId);
+  if (resultValidation !== undefined) {
+    return resultValidation;
+  }
+
+  if (
+    value.statusSnapshot.correlationId !== value.runResult.correlationId ||
+    value.correlationId !== value.statusSnapshot.correlationId
+  ) {
+    return failClosedReason(`${shapeName} correlationId does not match nested payloads`);
+  }
+
+  if (!Array.isArray(value.localArtifacts) || value.localArtifacts.length === 0) {
+    return failClosedReason(`${shapeName} localArtifacts must be a non-empty array`);
+  }
+
+  for (const [index, artifact] of value.localArtifacts.entries()) {
+    const artifactValidation = validateXGate3LocalArtifact(
+      artifact,
+      `${shapeName} localArtifacts[${index}]`
+    );
+    if (artifactValidation !== undefined) {
+      return artifactValidation;
+    }
+  }
+
+  if (value.evidenceBundleRef !== undefined) {
+    if (!isRecord(value.evidenceBundleRef)) {
+      return failClosedReason(`${shapeName} evidenceBundleRef must be an object`);
+    }
+
+    const evidenceVersion = requireSchemaVersion(
+      value.evidenceBundleRef,
+      "eip.evidence-bundle-ref.v1",
+      "EvidenceBundleRef"
+    );
+    if (evidenceVersion !== undefined) {
+      return evidenceVersion;
+    }
+
+    const evidenceValidation = validateEvidenceBundleRef(value.evidenceBundleRef);
+    if (evidenceValidation !== undefined) {
+      return evidenceValidation;
+    }
+  }
+
+  return undefined;
+};
+
+const validateXGate3LocalArtifact = (
+  value: unknown,
+  shapeName: string
+): { message: string; reason: string } | undefined => {
+  if (!isRecord(value)) {
+    return failClosedReason(`${shapeName} must be an object`);
+  }
+
+  const unknownProperty = findUnknownProperty(value, [
+    "kind",
+    "path",
+    "contentType",
+    "description",
+    "checksum"
+  ]);
+
+  if (unknownProperty !== undefined) {
+    return failClosedReason(`${shapeName} has unsupported field ${unknownProperty}`);
+  }
+
+  if (
+    typeof value.kind !== "string" ||
+    !/^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/.test(value.kind)
+  ) {
+    return failClosedReason(`${shapeName}.kind is malformed`);
+  }
+
+  if (typeof value.path !== "string" || !isPortableLocalArtifactPath(value.path)) {
+    return failClosedReason(`${shapeName}.path is malformed`);
+  }
+
+  for (const field of ["kind", "path", "contentType", "description"]) {
+    const fieldValue = value[field];
+    if (typeof fieldValue === "string" && containsCredentialShapedValue(fieldValue)) {
+      return failClosedReason(`${shapeName}.${field} must not contain credential-shaped values`);
+    }
+  }
+
+  if (
+    value.contentType !== undefined &&
+    (typeof value.contentType !== "string" ||
+      !/^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*\/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*(?:; ?[A-Za-z0-9_.-]+=[A-Za-z0-9_.+-]+)*$/.test(
+        value.contentType
+      ))
+  ) {
+    return failClosedReason(`${shapeName}.contentType is malformed`);
+  }
+
+  if (value.description !== undefined && !isNonEmptyString(value.description, 240)) {
+    return failClosedReason(`${shapeName}.description is malformed`);
+  }
+
+  if (value.checksum !== undefined) {
+    if (!isRecord(value.checksum)) {
+      return failClosedReason(`${shapeName}.checksum must be an object`);
+    }
+
+    const checksumUnknownProperty = findUnknownProperty(value.checksum, ["algorithm", "value"]);
+    if (checksumUnknownProperty !== undefined) {
+      return failClosedReason(
+        `${shapeName}.checksum has unsupported field ${checksumUnknownProperty}`
+      );
+    }
+
+    if (value.checksum.algorithm !== "sha256") {
+      return failClosedReason(`${shapeName}.checksum algorithm is unsupported`);
+    }
+
+    if (
+      typeof value.checksum.value !== "string" ||
+      !/^[a-f0-9]{64}$/.test(value.checksum.value) ||
+      containsCredentialShapedValue(value.checksum.value)
+    ) {
+      return failClosedReason(`${shapeName}.checksum value is malformed`);
     }
   }
 
@@ -1740,6 +1960,20 @@ const isLocalEvidencePath = (value: string): boolean =>
     value
   );
 
+const isPortableLocalArtifactPath = (value: string): boolean =>
+  value.length > 0 &&
+  value.length <= 1000 &&
+  /^(?![A-Za-z][A-Za-z0-9+.-]*:\/\/)(?!\/)(?![A-Za-z]:\/)(?!.*(?:^|\/)\.\.(?:\/|$))[A-Za-z0-9._~@/-]+$/.test(
+    value
+  );
+
 const isFileEvidenceUri = (value: string): boolean =>
   /^file:\/\/\/(?!.*(?:^|\/)\.\.(?:\/|$))[^\s?#]+$/.test(value) &&
   !/^[A-Za-z][A-Za-z0-9+.-]*:\/\/[^/?#\s]*[^/?#\s:@]+:[^/?#\s:@]+@/.test(value);
+
+const containsCredentialShapedValue = (value: string): boolean =>
+  /(?:^|\b)(?:password|passwd|token|secret|api[_-]?key|access[_-]?key|private[_-]?key)\s*[:=]/i.test(
+    value
+  ) ||
+  /\b(?:ghp|github_pat|glpat|xox[abprs]|sk)-[A-Za-z0-9_-]{8,}\b/.test(value) ||
+  /-----BEGIN [A-Z ]*(?:PRIVATE KEY|TOKEN|SECRET)[A-Z ]*-----/.test(value);

--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -1963,7 +1963,7 @@ const isLocalEvidencePath = (value: string): boolean =>
 const isPortableLocalArtifactPath = (value: string): boolean =>
   value.length > 0 &&
   value.length <= 1000 &&
-  /^(?![A-Za-z][A-Za-z0-9+.-]*:\/\/)(?!\/)(?![A-Za-z]:\/)(?!.*(?:^|\/)\.\.(?:\/|$))[A-Za-z0-9._~@/-]+$/.test(
+  /^(?!~)(?![A-Za-z][A-Za-z0-9+.-]*:\/\/)(?!\/)(?![A-Za-z]:\/)(?!.*(?:^|\/)\.\.(?:\/|$))[A-Za-z0-9._~@/-]+$/.test(
     value
   );
 
@@ -1975,5 +1975,5 @@ const containsCredentialShapedValue = (value: string): boolean =>
   /(?:^|\b)(?:password|passwd|token|secret|api[_-]?key|access[_-]?key|private[_-]?key)\s*[:=]/i.test(
     value
   ) ||
-  /\b(?:ghp|github_pat|glpat|xox[abprs]|sk)-[A-Za-z0-9_-]{8,}\b/.test(value) ||
+  /\b(?:ghp|github_pat|glpat|xox[abprs]|sk)[-_][A-Za-z0-9_-]{8,}\b/.test(value) ||
   /-----BEGIN [A-Z ]*(?:PRIVATE KEY|TOKEN|SECRET)[A-Z ]*-----/.test(value);

--- a/test/cli-loop-executor-smoke.test.ts
+++ b/test/cli-loop-executor-smoke.test.ts
@@ -719,6 +719,32 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
       expectedMessage: "EIP XGate3LocalLaneSmokeAggregate localArtifacts[0].path is malformed"
     },
     {
+      name: "home-relative local artifact path",
+      aggregate: {
+        ...createXGate3Aggregate(),
+        localArtifacts: [
+          {
+            kind: "aggregate-json",
+            path: "~/state/x-gate3/aggregate.json"
+          }
+        ]
+      },
+      expectedMessage: "EIP XGate3LocalLaneSmokeAggregate localArtifacts[0].path is malformed"
+    },
+    {
+      name: "user-home-relative local artifact path",
+      aggregate: {
+        ...createXGate3Aggregate(),
+        localArtifacts: [
+          {
+            kind: "aggregate-json",
+            path: "~operator/state/x-gate3/aggregate.json"
+          }
+        ]
+      },
+      expectedMessage: "EIP XGate3LocalLaneSmokeAggregate localArtifacts[0].path is malformed"
+    },
+    {
       name: "credential-shaped local artifact value",
       aggregate: {
         ...createXGate3Aggregate(),
@@ -727,6 +753,36 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
             kind: "log",
             path: "state/x-gate3/log.txt",
             description: "token=sample-secret"
+          }
+        ]
+      },
+      expectedMessage:
+        "EIP XGate3LocalLaneSmokeAggregate localArtifacts[0].description must not contain credential-shaped values"
+    },
+    {
+      name: "underscore-delimited GitHub token artifact value",
+      aggregate: {
+        ...createXGate3Aggregate(),
+        localArtifacts: [
+          {
+            kind: "log",
+            path: "state/x-gate3/log.txt",
+            description: "ghp_sampletokenvalue"
+          }
+        ]
+      },
+      expectedMessage:
+        "EIP XGate3LocalLaneSmokeAggregate localArtifacts[0].description must not contain credential-shaped values"
+    },
+    {
+      name: "underscore-delimited GitHub fine-grained token artifact value",
+      aggregate: {
+        ...createXGate3Aggregate(),
+        localArtifacts: [
+          {
+            kind: "log",
+            path: "state/x-gate3/log.txt",
+            description: "github_pat_sampletokenvalue"
           }
         ]
       },

--- a/test/cli-loop-executor-smoke.test.ts
+++ b/test/cli-loop-executor-smoke.test.ts
@@ -492,6 +492,328 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
     }
   });
 
+  it.each([
+    {
+      status: "succeeded",
+      runStatus: "completed",
+      summary: "Loop X-Gate 3 local fake lane succeeded."
+    },
+    {
+      status: "failed",
+      runStatus: "failed",
+      summary: "Loop X-Gate 3 local fake lane failed."
+    },
+    {
+      status: "blocked",
+      runStatus: "blocked",
+      summary: "Loop X-Gate 3 local fake lane blocked."
+    }
+  ])("consumes a valid X-Gate 3 local lane aggregate with $status result", async ({
+    status,
+    runStatus,
+    summary
+  }) => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-cli-loop-xgate3-"));
+    const cliPath = join(tempRoot, "loop-x-gate3-cli.mjs");
+
+    await writeFile(
+      cliPath,
+      [
+        "#!/usr/bin/env node",
+        "import { readFileSync } from 'node:fs';",
+        "const requestPath = process.argv[3];",
+        "const request = JSON.parse(readFileSync(requestPath, 'utf8'));",
+        "process.stdout.write(JSON.stringify({",
+        "  ...createXGate3Aggregate(request.id, request.correlationId),",
+        `  statusSnapshot: { ...createXGate3Aggregate(request.id, request.correlationId).statusSnapshot, status: ${JSON.stringify(runStatus)}, message: ${JSON.stringify(summary)} },`,
+        `  runResult: { ...createXGate3Aggregate(request.id, request.correlationId).runResult, status: ${JSON.stringify(status)}, verification: { status: ${JSON.stringify(status)}, summary: ${JSON.stringify(summary)} } }`,
+        "}));",
+        `if (${JSON.stringify(status)} === 'blocked') process.exitCode = 1;`,
+        `if (${JSON.stringify(status)} === 'failed') process.exitCode = 2;`,
+        "function createXGate3Aggregate(requestId, correlationId) { return {",
+        "  schemaVersion: 'ensen-loop.x-gate3-local-lane-smoke.v1',",
+        "  boundary: 'local-cli-bounded-fake-lane',",
+        "  requestId,",
+        "  correlationId,",
+        "  mutatesRepository: false,",
+        "  invokesProvider: false,",
+        "  startsAgentProviderSession: false,",
+        "  writesProductionEvidenceArchive: false,",
+        "  statusSnapshot: {",
+        "    schemaVersion: 'eip.run-status.v1',",
+        "    id: 'sts_cli_loop_xgate3',",
+        "    requestId,",
+        "    correlationId,",
+        "    status: 'completed',",
+        "    observedAt: '2026-05-01T04:00:02.000Z'",
+        "  },",
+        "  runResult: {",
+        "    schemaVersion: 'eip.run-result.v1',",
+        "    id: 'run_cli_loop_xgate3',",
+        "    requestId,",
+        "    correlationId,",
+        "    status: 'succeeded',",
+        "    completedAt: '2026-05-01T04:00:03.000Z',",
+        "    verification: {",
+        "      status: 'passed',",
+        "      summary: 'Loop X-Gate 3 local fake lane succeeded.'",
+        "    }",
+        "  },",
+        "  localArtifacts: [",
+        "    {",
+        "      kind: 'aggregate-json',",
+        "      path: 'state/x-gate3/aggregate.json',",
+        "      contentType: 'application/json',",
+        "      description: 'Local X-Gate 3 smoke aggregate'",
+        "    },",
+        "    {",
+        "      kind: 'log',",
+        "      path: 'state/x-gate3/loop.log',",
+        "      contentType: 'text/plain'",
+        "    }",
+        "  ]",
+        "}; }",
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+    await chmod(cliPath, 0o755);
+
+    try {
+      const connector = createEnsenLoopEipExecutorConnector({
+        transport: createCliEnsenLoopEipExecutorTransport({
+          command: process.execPath,
+          args: [cliPath, "x-gate3-smoke"]
+        })
+      });
+
+      const submitted = await connector.submit({
+        workflow: {
+          id: "cli-loop-smoke",
+          version: "flow.workflow.v1"
+        },
+        run: {
+          id: "cli-loop-smoke"
+        },
+        step: {
+          id: "loop-dry-run",
+          attempt: 1
+        },
+        idempotencyKey: "cli-loop-smoke-0001",
+        policyDecision: { decision: "allow" },
+        source: createSmokeRunRequest().source,
+        requestedBy: createSmokeRunRequest().requestedBy,
+        workItem: createSmokeRunRequest().workItem
+      });
+
+      expect(submitted).toMatchObject({
+        ok: true,
+        value: {
+          requestId: "req_cli_loop_smoke_loop_dry_run_1"
+        }
+      });
+
+      const result = await connector.status({ requestId: "req_cli_loop_smoke_loop_dry_run_1" });
+
+      expect(result).toMatchObject({
+        ok: true,
+        value: {
+          requestId: "req_cli_loop_smoke_loop_dry_run_1",
+          status: status === "succeeded" ? "succeeded" : status,
+          result: {
+            status,
+            summary
+          }
+        }
+      });
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    {
+      name: "unknown top-level field",
+      aggregate: {
+        ...createXGate3Aggregate(),
+        providerRan: false
+      },
+      expectedMessage: "EIP XGate3LocalLaneSmokeAggregate has unsupported field providerRan"
+    },
+    {
+      name: "mismatched requestId",
+      aggregate: {
+        ...createXGate3Aggregate(),
+        requestId: "req_wrong_cli_loop_smoke"
+      },
+      expectedMessage:
+        "EIP XGate3LocalLaneSmokeAggregate requestId does not match the submitted request"
+    },
+    {
+      name: "mismatched correlationId",
+      aggregate: {
+        ...createXGate3Aggregate(),
+        correlationId: "corr_wrong_cli_loop_smoke"
+      },
+      expectedMessage:
+        "EIP XGate3LocalLaneSmokeAggregate correlationId does not match nested payloads"
+    },
+    {
+      name: "unexpected repository mutation flag",
+      aggregate: {
+        ...createXGate3Aggregate(),
+        mutatesRepository: true
+      },
+      expectedMessage: "EIP XGate3LocalLaneSmokeAggregate mutatesRepository must be false"
+    },
+    {
+      name: "unexpected provider invocation flag",
+      aggregate: {
+        ...createXGate3Aggregate(),
+        invokesProvider: true
+      },
+      expectedMessage: "EIP XGate3LocalLaneSmokeAggregate invokesProvider must be false"
+    },
+    {
+      name: "unexpected agent-provider session flag",
+      aggregate: {
+        ...createXGate3Aggregate(),
+        startsAgentProviderSession: true
+      },
+      expectedMessage:
+        "EIP XGate3LocalLaneSmokeAggregate startsAgentProviderSession must be false"
+    },
+    {
+      name: "unexpected production evidence archive flag",
+      aggregate: {
+        ...createXGate3Aggregate(),
+        writesProductionEvidenceArchive: true
+      },
+      expectedMessage:
+        "EIP XGate3LocalLaneSmokeAggregate writesProductionEvidenceArchive must be false"
+    },
+    {
+      name: "traversing local artifact path",
+      aggregate: {
+        ...createXGate3Aggregate(),
+        localArtifacts: [
+          {
+            kind: "aggregate-json",
+            path: "../state/x-gate3/aggregate.json"
+          }
+        ]
+      },
+      expectedMessage: "EIP XGate3LocalLaneSmokeAggregate localArtifacts[0].path is malformed"
+    },
+    {
+      name: "absolute local artifact path",
+      aggregate: {
+        ...createXGate3Aggregate(),
+        localArtifacts: [
+          {
+            kind: "aggregate-json",
+            path: "/tmp/x-gate3/aggregate.json"
+          }
+        ]
+      },
+      expectedMessage: "EIP XGate3LocalLaneSmokeAggregate localArtifacts[0].path is malformed"
+    },
+    {
+      name: "credential-shaped local artifact value",
+      aggregate: {
+        ...createXGate3Aggregate(),
+        localArtifacts: [
+          {
+            kind: "log",
+            path: "state/x-gate3/log.txt",
+            description: "token=sample-secret"
+          }
+        ]
+      },
+      expectedMessage:
+        "EIP XGate3LocalLaneSmokeAggregate localArtifacts[0].description must not contain credential-shaped values"
+    }
+  ])("rejects malformed X-Gate 3 local lane aggregate $name", async ({
+    aggregate,
+    expectedMessage
+  }) => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-cli-loop-xgate3-invalid-"));
+    const cliPath = join(tempRoot, "loop-x-gate3-cli.mjs");
+
+    await writeFile(
+      cliPath,
+      [
+        "#!/usr/bin/env node",
+        `process.stdout.write(${JSON.stringify(JSON.stringify(aggregate))});`,
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+    await chmod(cliPath, 0o755);
+
+    try {
+      const transport = createCliEnsenLoopEipExecutorTransport({
+        command: process.execPath,
+        args: [cliPath, "x-gate3-smoke"]
+      });
+
+      await expect(transport.submitRunRequest(createSmokeRunRequest()))
+        .rejects.toMatchObject({
+          failureClass: "protocol-gap",
+          operation: "submit",
+          message: expectedMessage
+        });
+      expect(() =>
+        transport.getRunResult({ requestId: "req_cli_loop_smoke" })
+      ).toThrow(EnsenLoopCliTransportError);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    {
+      name: "protocol gap for unsupported successful aggregate shape",
+      scriptBody:
+        "process.stdout.write(JSON.stringify({ schemaVersion: 'ensen-loop.x-gate3-local-lane-smoke.v2' }));",
+      expectedClass: "protocol-gap"
+    },
+    {
+      name: "loop gap for non-zero invalid aggregate shape",
+      scriptBody:
+        "process.stdout.write(JSON.stringify({ schemaVersion: 'ensen-loop.x-gate3-local-lane-smoke.v2' })); process.exitCode = 3;",
+      expectedClass: "loop-gap"
+    }
+  ])("classifies X-Gate 3 invalid aggregate output as $name", async ({
+    scriptBody,
+    expectedClass
+  }) => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-cli-loop-xgate3-class-"));
+    const cliPath = join(tempRoot, "loop-x-gate3-cli.mjs");
+
+    await writeFile(
+      cliPath,
+      ["#!/usr/bin/env node", scriptBody, ""].join("\n"),
+      "utf8"
+    );
+    await chmod(cliPath, 0o755);
+
+    try {
+      const transport = createCliEnsenLoopEipExecutorTransport({
+        command: process.execPath,
+        args: [cliPath, "x-gate3-smoke"]
+      });
+
+      await expect(transport.submitRunRequest(createSmokeRunRequest()))
+        .rejects.toMatchObject({
+          failureClass: expectedClass,
+          operation: "submit"
+        });
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("times out a CLI process that ignores SIGTERM", async () => {
     const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-cli-loop-timeout-"));
     const cliPath = join(tempRoot, "loop-dry-run-cli.mjs");
@@ -664,4 +986,48 @@ const createSmokeAggregate = () => ({
     createdAt: "2026-04-30T04:00:03.000Z",
     contentType: "application/json"
   }
+});
+
+const createXGate3Aggregate = () => ({
+  schemaVersion: "ensen-loop.x-gate3-local-lane-smoke.v1",
+  boundary: "local-cli-bounded-fake-lane",
+  requestId: "req_cli_loop_smoke",
+  correlationId: "corr_cli_loop_smoke",
+  mutatesRepository: false,
+  invokesProvider: false,
+  startsAgentProviderSession: false,
+  writesProductionEvidenceArchive: false,
+  statusSnapshot: {
+    schemaVersion: "eip.run-status.v1",
+    id: "sts_cli_loop_xgate3",
+    requestId: "req_cli_loop_smoke",
+    correlationId: "corr_cli_loop_smoke",
+    status: "completed",
+    observedAt: "2026-05-01T04:00:02.000Z"
+  },
+  runResult: {
+    schemaVersion: "eip.run-result.v1",
+    id: "run_cli_loop_xgate3",
+    requestId: "req_cli_loop_smoke",
+    correlationId: "corr_cli_loop_smoke",
+    status: "succeeded",
+    completedAt: "2026-05-01T04:00:03.000Z",
+    verification: {
+      status: "passed",
+      summary: "Loop X-Gate 3 local fake lane succeeded."
+    }
+  },
+  localArtifacts: [
+    {
+      kind: "aggregate-json",
+      path: "state/x-gate3/aggregate.json",
+      contentType: "application/json",
+      description: "Local X-Gate 3 smoke aggregate"
+    },
+    {
+      kind: "log",
+      path: "state/x-gate3/loop.log",
+      contentType: "text/plain"
+    }
+  ]
 });


### PR DESCRIPTION
## Summary
- add Flow-side validation for the Loop X-Gate 3 local lane aggregate schema
- require the local bounded fake lane boundary and fail closed on mutation/provider/session/archive flags
- validate nested EIP status/result payloads and portable local artifact metadata

## Verification
- npm run build
- npm test -- test/cli-loop-executor-smoke.test.ts
- npm test -- test/executor-connector.test.ts
- npm test

Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for X-Gate 3 local-lane aggregates in the connector and CLI flow.

* **Bug Fixes**
  * Enforced stricter aggregate validation (structure, fields, checksums, paths, and consistency) with clearer protocol-gap vs loop-gap classification.
  * Rejected malformed or credential-shaped artifact values to prevent incorrect submissions.

* **Tests**
  * Expanded smoke tests to cover X-Gate 3 scenarios, success/boundary cases, and protocol/error classifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->