### PR TITLE
FLOW-032: Invoke Loop X-Gate 3 smoke with explicit local roots

### DIFF
--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -101,6 +101,10 @@ export interface CreateCliEnsenLoopEipExecutorTransportInput {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   timeoutMs?: number;
+  xGate3Smoke?: {
+    workspaceRoot: string;
+    stateRoot: string;
+  };
 }
 
 export interface CreateEnsenLoopEipExecutorConnectorInput {
@@ -155,7 +159,7 @@ export const createCliEnsenLoopEipExecutorTransport = (
 
   return {
     async submitRunRequest(request: EipRunRequestV1) {
-      const aggregate = await invokeEnsenLoopXGate2SmokeCli(input, request);
+      const aggregate = await invokeEnsenLoopSmokeCli(input, request);
       smokeAggregates.set(request.id, aggregate);
 
       return {
@@ -414,11 +418,11 @@ export const createEnsenLoopEipExecutorConnector = (
   };
 };
 
-const invokeEnsenLoopXGate2SmokeCli = async (
+const invokeEnsenLoopSmokeCli = async (
   input: CreateCliEnsenLoopEipExecutorTransportInput,
   request: EipRunRequestV1
 ): Promise<EnsenLoopSmokeAggregateV1> => {
-  const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-x-gate2-smoke-"));
+  const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-loop-smoke-"));
   const requestPath = join(tempRoot, "run-request.json");
 
   try {
@@ -426,7 +430,7 @@ const invokeEnsenLoopXGate2SmokeCli = async (
     const cliResult = await invokeJsonCli({
       input: {
         ...input,
-        args: [...(input.args ?? []), requestPath]
+        args: createSmokeCliArgs(input, requestPath)
       },
       operation: "submit",
       allowNonZeroJsonStdout: true,
@@ -465,6 +469,34 @@ const invokeEnsenLoopXGate2SmokeCli = async (
   } finally {
     await rm(tempRoot, { recursive: true, force: true });
   }
+};
+
+const createSmokeCliArgs = (
+  input: CreateCliEnsenLoopEipExecutorTransportInput,
+  requestPath: string
+): string[] => {
+  if (input.xGate3Smoke === undefined) {
+    return [...(input.args ?? []), requestPath];
+  }
+
+  const { workspaceRoot, stateRoot } = input.xGate3Smoke;
+  if (!isUsableLocalRoot(workspaceRoot) || !isUsableLocalRoot(stateRoot)) {
+    throw new EnsenLoopCliTransportError({
+      message: "Ensen-loop X-Gate 3 smoke roots must be non-empty local path strings",
+      failureClass: "flow-gap",
+      operation: "submit"
+    });
+  }
+
+  return [
+    ...(input.args ?? []),
+    "x-gate3-smoke",
+    requestPath,
+    "--workspace-root",
+    workspaceRoot,
+    "--state-root",
+    stateRoot
+  ];
 };
 
 const requireSmokeAggregate = (
@@ -1954,6 +1986,12 @@ const isIsoDateTimeUtc = (value: unknown): boolean =>
 
 const isNonEmptyString = (value: unknown, maxLength: number): boolean =>
   typeof value === "string" && value.length > 0 && value.length <= maxLength;
+
+const isUsableLocalRoot = (value: unknown): boolean =>
+  typeof value === "string" &&
+  value.length > 0 &&
+  !value.includes("\0") &&
+  !containsCredentialShapedValue(value);
 
 const isLocalEvidencePath = (value: string): boolean =>
   /^(?![A-Za-z][A-Za-z0-9+.-]*:\/\/)(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))[A-Za-z0-9._~@/-]+$/.test(

--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join, normalize } from "node:path";
 
 import {
   createExecutorConnectorCapabilities,
@@ -482,7 +482,8 @@ const createSmokeCliArgs = (
   const { workspaceRoot, stateRoot } = input.xGate3Smoke;
   if (!isUsableLocalRoot(workspaceRoot) || !isUsableLocalRoot(stateRoot)) {
     throw new EnsenLoopCliTransportError({
-      message: "Ensen-loop X-Gate 3 smoke roots must be non-empty local path strings",
+      message:
+        "Ensen-loop X-Gate 3 smoke roots must be non-empty absolute local path strings without traversal or credential-shaped values",
       failureClass: "flow-gap",
       operation: "submit"
     });
@@ -1987,11 +1988,29 @@ const isIsoDateTimeUtc = (value: unknown): boolean =>
 const isNonEmptyString = (value: unknown, maxLength: number): boolean =>
   typeof value === "string" && value.length > 0 && value.length <= maxLength;
 
-const isUsableLocalRoot = (value: unknown): boolean =>
-  typeof value === "string" &&
-  value.length > 0 &&
-  !value.includes("\0") &&
-  !containsCredentialShapedValue(value);
+const isUsableLocalRoot = (value: unknown): boolean => {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.includes("\0") ||
+    containsCredentialShapedValue(value) ||
+    /^[A-Za-z][A-Za-z0-9+.-]*:/.test(value) ||
+    value.includes("://") ||
+    !isAbsolute(value)
+  ) {
+    return false;
+  }
+
+  const normalized = normalize(value);
+  if (!isAbsolute(normalized) || normalized.includes("\0")) {
+    return false;
+  }
+
+  const hasTraversalSegment = (candidate: string): boolean =>
+    candidate.split(/[\\/]+/).includes("..");
+
+  return !hasTraversalSegment(value) && !hasTraversalSegment(normalized);
+};
 
 const isLocalEvidencePath = (value: string): boolean =>
   /^(?![A-Za-z][A-Za-z0-9+.-]*:\/\/)(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))[A-Za-z0-9._~@/-]+$/.test(

--- a/test/cli-loop-executor-smoke.test.ts
+++ b/test/cli-loop-executor-smoke.test.ts
@@ -973,32 +973,57 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
   it.each([
     {
       name: "empty workspace root",
-      workspaceRoot: "",
-      stateRoot: "state-root"
+      workspaceRoot: (_tempRoot: string) => "",
+      stateRoot: (tempRoot: string) => join(tempRoot, "state-root")
+    },
+    {
+      name: "relative workspace root",
+      workspaceRoot: (_tempRoot: string) => "workspace-root",
+      stateRoot: (tempRoot: string) => join(tempRoot, "state-root")
+    },
+    {
+      name: "URL-style workspace root",
+      workspaceRoot: (_tempRoot: string) => "https://example.test/workspace-root",
+      stateRoot: (tempRoot: string) => join(tempRoot, "state-root")
+    },
+    {
+      name: "scheme-like workspace root",
+      workspaceRoot: (_tempRoot: string) => "flow-root:workspace-root",
+      stateRoot: (tempRoot: string) => join(tempRoot, "state-root")
+    },
+    {
+      name: "traversal-style workspace root",
+      workspaceRoot: (tempRoot: string) => `${join(tempRoot, "workspace-root")}/../other-root`,
+      stateRoot: (tempRoot: string) => join(tempRoot, "state-root")
     },
     {
       name: "credential-shaped state root",
-      workspaceRoot: "workspace-root",
-      stateRoot: "state-root?token=sample-secret"
+      workspaceRoot: (tempRoot: string) => join(tempRoot, "workspace-root"),
+      stateRoot: (tempRoot: string) => `${join(tempRoot, "state-root")}?token=sample-secret`
     }
   ])("rejects unsafe X-Gate 3 local roots before invoking Loop: $name", async ({
     workspaceRoot,
     stateRoot
   }) => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-cli-loop-xgate3-root-guard-"));
     const transport = createCliEnsenLoopEipExecutorTransport({
       command: "unused-loop-cli",
       xGate3Smoke: {
-        workspaceRoot,
-        stateRoot
+        workspaceRoot: workspaceRoot(tempRoot),
+        stateRoot: stateRoot(tempRoot)
       }
     });
 
-    await expect(transport.submitRunRequest(createSmokeRunRequest()))
-      .rejects.toMatchObject({
+    try {
+      await expect(transport.submitRunRequest(createSmokeRunRequest())).rejects.toMatchObject({
         failureClass: "flow-gap",
         operation: "submit",
-        message: "Ensen-loop X-Gate 3 smoke roots must be non-empty local path strings"
+        message:
+          "Ensen-loop X-Gate 3 smoke roots must be non-empty absolute local path strings without traversal or credential-shaped values"
       });
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
   });
 
   it("times out a CLI process that ignores SIGTERM", async () => {

--- a/test/cli-loop-executor-smoke.test.ts
+++ b/test/cli-loop-executor-smoke.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -868,6 +868,137 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
     }
+  });
+
+  it("invokes X-Gate 3 smoke with explicit local roots and cleans the request file", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-cli-loop-xgate3-roots-"));
+    const cliPath = join(tempRoot, "loop-x-gate3-cli.mjs");
+    const observedArgsPath = join(tempRoot, "observed-args.json");
+    const workspaceRoot = join(tempRoot, "workspace-root");
+    const stateRoot = join(tempRoot, "state-root");
+
+    await writeFile(
+      cliPath,
+      [
+        "#!/usr/bin/env node",
+        "import { readFileSync, writeFileSync } from 'node:fs';",
+        "const observedArgsPath = process.env.OBSERVED_ARGS_PATH;",
+        "const command = process.argv[2];",
+        "const requestPath = process.argv[3];",
+        "const workspaceFlag = process.argv[4];",
+        "const stateFlag = process.argv[6];",
+        "if (observedArgsPath === undefined) throw new Error('missing observed args path');",
+        "writeFileSync(observedArgsPath, JSON.stringify({ args: process.argv.slice(2), requestPath }));",
+        "if (command !== 'x-gate3-smoke' || requestPath === undefined || workspaceFlag !== '--workspace-root' || stateFlag !== '--state-root') {",
+        "  process.stderr.write('expected x-gate3-smoke <run-request-json-file> --workspace-root <workspace-root> --state-root <state-root>');",
+        "  process.exitCode = 2;",
+        "} else {",
+        "  const request = JSON.parse(readFileSync(requestPath, 'utf8'));",
+        "  process.stdout.write(JSON.stringify({",
+        "    schemaVersion: 'ensen-loop.x-gate3-local-lane-smoke.v1',",
+        "    boundary: 'local-cli-bounded-fake-lane',",
+        "    requestId: request.id,",
+        "    correlationId: request.correlationId,",
+        "    mutatesRepository: false,",
+        "    invokesProvider: false,",
+        "    startsAgentProviderSession: false,",
+        "    writesProductionEvidenceArchive: false,",
+        "    statusSnapshot: {",
+        "      schemaVersion: 'eip.run-status.v1',",
+        "      id: 'sts_cli_loop_xgate3_roots',",
+        "      requestId: request.id,",
+        "      correlationId: request.correlationId,",
+        "      status: 'completed',",
+        "      observedAt: '2026-05-01T04:00:02.000Z'",
+        "    },",
+        "    runResult: {",
+        "      schemaVersion: 'eip.run-result.v1',",
+        "      id: 'run_cli_loop_xgate3_roots',",
+        "      requestId: request.id,",
+        "      correlationId: request.correlationId,",
+        "      status: 'succeeded',",
+        "      completedAt: '2026-05-01T04:00:03.000Z',",
+        "      verification: { status: 'passed', summary: 'Loop X-Gate 3 local fake lane succeeded.' }",
+        "    },",
+        "    localArtifacts: [",
+        "      { kind: 'aggregate-json', path: 'state/x-gate3/aggregate.json' },",
+        "      { kind: 'log', path: 'state/x-gate3/loop.log' }",
+        "    ]",
+        "  }));",
+        "}",
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+    await chmod(cliPath, 0o755);
+
+    try {
+      const transport = createCliEnsenLoopEipExecutorTransport({
+        command: process.execPath,
+        args: [cliPath],
+        env: {
+          ...process.env,
+          OBSERVED_ARGS_PATH: observedArgsPath
+        },
+        xGate3Smoke: {
+          workspaceRoot,
+          stateRoot
+        }
+      });
+
+      await expect(transport.submitRunRequest(createSmokeRunRequest())).resolves.toMatchObject({
+        requestId: "req_cli_loop_smoke"
+      });
+
+      const observed = JSON.parse(await readFile(observedArgsPath, "utf8")) as {
+        args: string[];
+        requestPath: string;
+      };
+      expect(observed.args).toEqual([
+        "x-gate3-smoke",
+        observed.requestPath,
+        "--workspace-root",
+        workspaceRoot,
+        "--state-root",
+        stateRoot
+      ]);
+      await expect(readFile(observed.requestPath, "utf8")).rejects.toMatchObject({
+        code: "ENOENT"
+      });
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    {
+      name: "empty workspace root",
+      workspaceRoot: "",
+      stateRoot: "state-root"
+    },
+    {
+      name: "credential-shaped state root",
+      workspaceRoot: "workspace-root",
+      stateRoot: "state-root?token=sample-secret"
+    }
+  ])("rejects unsafe X-Gate 3 local roots before invoking Loop: $name", async ({
+    workspaceRoot,
+    stateRoot
+  }) => {
+    const transport = createCliEnsenLoopEipExecutorTransport({
+      command: "unused-loop-cli",
+      xGate3Smoke: {
+        workspaceRoot,
+        stateRoot
+      }
+    });
+
+    await expect(transport.submitRunRequest(createSmokeRunRequest()))
+      .rejects.toMatchObject({
+        failureClass: "flow-gap",
+        operation: "submit",
+        message: "Ensen-loop X-Gate 3 smoke roots must be non-empty local path strings"
+      });
   });
 
   it("times out a CLI process that ignores SIGTERM", async () => {


### PR DESCRIPTION
## Summary
- add explicit X-Gate 3 smoke transport options for workspace and state roots
- invoke Loop as `x-gate3-smoke <run-request-json-file> --workspace-root <workspace-root> --state-root <state-root>` when configured
- keep X-Gate 2 CLI-backed smoke behavior and fail-closed aggregate handling intact

## Verification
- `npm run build`
- `npm test -- test/cli-loop-executor-smoke.test.ts`
- `npm test -- test/executor-connector.test.ts`
- `npm test`

Closes #51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added X-Gate 3 support for CLI transport with configurable workspace and state root parameters.

* **Improvements**
  * Enhanced validation to prevent empty or malformed root values.

* **Tests**
  * Added comprehensive test coverage for X-Gate 3 invocation and parameter validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->