### PR TITLE
FLOW-033: Persist X-Gate 3 local lane outcomes

### DIFF
--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -171,7 +171,9 @@ export const createCliEnsenLoopEipExecutorTransport = (
       return requireSmokeAggregate(smokeAggregates, request.requestId, "status").statusSnapshot;
     },
     getRunResult(request: { requestId: string }) {
-      return requireSmokeAggregate(smokeAggregates, request.requestId, "result").runResult;
+      return enrichSmokeRunResult(
+        requireSmokeAggregate(smokeAggregates, request.requestId, "result")
+      );
     },
     getEvidenceBundleRef(request: { requestId: string }) {
       return requireSmokeAggregate(smokeAggregates, request.requestId, "evidence").evidenceBundleRef;
@@ -290,7 +292,7 @@ export const createEnsenLoopEipExecutorConnector = (
       const status = snapshot as EipRunStatusSnapshotV1;
       const mappedStatus = mapRunStatus(status.status);
 
-      if (status.status === "completed") {
+      if (hasTerminalRunResult(status.status)) {
         const result = await input.transport.getRunResult(request);
         const resultVersion = requireSchemaVersion(result, "eip.run-result.v1", "RunResult");
 
@@ -840,6 +842,7 @@ interface EipRunResultV1 {
   errors?: unknown[];
   warnings?: unknown[];
   metrics?: Record<string, unknown>;
+  extensions?: Record<string, unknown>;
 }
 
 interface EnsenLoopXGate2SmokeAggregateV1 {
@@ -943,17 +946,26 @@ const mapRunStatus = (status: EipRunStatusSnapshotV1["status"]): ExecutorConnect
   }
 };
 
+const hasTerminalRunResult = (status: EipRunStatusSnapshotV1["status"]): boolean =>
+  status === "completed" ||
+  status === "failed" ||
+  status === "blocked" ||
+  status === "cancelled";
+
 const mapRunResultToStatusSnapshot = (
   result: EipRunResultV1,
   observedAt?: string
 ): ExecutorConnectorStatusSnapshot => {
   const resultStatus = mapRunResultStatus(result.status);
   const summary = result.verification?.summary;
+  const localLaneEvidence = extractXGate3LocalLaneEvidence(result.extensions);
   const evidence = {
+    ...(result.verification === undefined ? {} : { verification: result.verification }),
     ...(result.evidenceBundles === undefined ? {} : { evidenceBundles: result.evidenceBundles }),
     ...(result.errors === undefined ? {} : { errors: result.errors }),
     ...(result.warnings === undefined ? {} : { warnings: result.warnings }),
-    ...(result.metrics === undefined ? {} : { metrics: result.metrics })
+    ...(result.metrics === undefined ? {} : { metrics: result.metrics }),
+    ...(localLaneEvidence === undefined ? {} : localLaneEvidence)
   };
 
   return {
@@ -1025,6 +1037,39 @@ const validateRunStatusSnapshot = (
   }
 
   return undefined;
+};
+
+const enrichSmokeRunResult = (aggregate: EnsenLoopSmokeAggregateV1): EipRunResultV1 => {
+  if (aggregate.schemaVersion !== "ensen-loop.x-gate3-local-lane-smoke.v1") {
+    return aggregate.runResult;
+  }
+
+  return {
+    ...aggregate.runResult,
+    extensions: {
+      ...(aggregate.runResult.extensions ?? {}),
+      "x-ensen-flow-local-lane": {
+        localArtifacts: aggregate.localArtifacts,
+        localArtifactSemantics: "local-development-references-only",
+        productionEvidence: false
+      }
+    }
+  };
+};
+
+const extractXGate3LocalLaneEvidence = (
+  extensions: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined => {
+  const localLane = extensions?.["x-ensen-flow-local-lane"];
+  if (!isRecord(localLane)) {
+    return undefined;
+  }
+
+  return {
+    localArtifacts: localLane.localArtifacts,
+    localArtifactSemantics: localLane.localArtifactSemantics,
+    productionEvidence: localLane.productionEvidence
+  };
 };
 
 const validateSmokeAggregate = (
@@ -1544,7 +1589,7 @@ const validateRunResult = (
     return failClosedReason("EIP RunResult metrics must be an object");
   }
 
-  return undefined;
+  return validateExtensionMap(value.extensions, "EIP RunResult extensions");
 };
 
 const validateEvidenceBundleRef = (

--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -873,6 +873,12 @@ interface EnsenLoopXGate3LocalLaneSmokeAggregateV1 {
   evidenceBundleRef?: Record<string, unknown>;
 }
 
+interface XGate3LocalLaneEvidence {
+  localArtifacts: Array<Record<string, unknown>>;
+  localArtifactSemantics: "local-development-references-only";
+  productionEvidence: false;
+}
+
 type EnsenLoopSmokeAggregateV1 =
   | EnsenLoopXGate2SmokeAggregateV1
   | EnsenLoopXGate3LocalLaneSmokeAggregateV1;
@@ -1059,16 +1065,42 @@ const enrichSmokeRunResult = (aggregate: EnsenLoopSmokeAggregateV1): EipRunResul
 
 const extractXGate3LocalLaneEvidence = (
   extensions: Record<string, unknown> | undefined
-): Record<string, unknown> | undefined => {
+): XGate3LocalLaneEvidence | undefined => {
   const localLane = extensions?.["x-ensen-flow-local-lane"];
   if (!isRecord(localLane)) {
     return undefined;
   }
 
+  const unknownProperty = findUnknownProperty(localLane, [
+    "localArtifacts",
+    "localArtifactSemantics",
+    "productionEvidence"
+  ]);
+  if (unknownProperty !== undefined) {
+    return undefined;
+  }
+
+  if (
+    localLane.localArtifactSemantics !== "local-development-references-only" ||
+    localLane.productionEvidence !== false ||
+    !Array.isArray(localLane.localArtifacts) ||
+    localLane.localArtifacts.length === 0
+  ) {
+    return undefined;
+  }
+
+  const localArtifacts: Array<Record<string, unknown>> = [];
+  for (const artifact of localLane.localArtifacts) {
+    if (validateXGate3LocalArtifact(artifact, "x-ensen-flow-local-lane.localArtifacts[]")) {
+      return undefined;
+    }
+    localArtifacts.push(sanitizeXGate3LocalArtifact(artifact));
+  }
+
   return {
-    localArtifacts: localLane.localArtifacts,
-    localArtifactSemantics: localLane.localArtifactSemantics,
-    productionEvidence: localLane.productionEvidence
+    localArtifacts,
+    localArtifactSemantics: "local-development-references-only",
+    productionEvidence: false
   };
 };
 
@@ -1391,6 +1423,14 @@ const validateXGate3LocalArtifact = (
 
   return undefined;
 };
+
+const sanitizeXGate3LocalArtifact = (value: Record<string, unknown>): Record<string, unknown> => ({
+  kind: value.kind,
+  path: value.path,
+  ...(value.contentType === undefined ? {} : { contentType: value.contentType }),
+  ...(value.description === undefined ? {} : { description: value.description }),
+  ...(value.checksum === undefined ? {} : { checksum: value.checksum })
+});
 
 const validateRunRequest = (value: unknown): { message: string; reason: string } | undefined => {
   if (!isRecord(value)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,7 @@ export type {
   WorkflowRunTerminalState,
   WorkflowRunTriggerContext,
   WorkflowStepAttemptEvent,
+  WorkflowStepAttemptResultMetadata,
   WorkflowStepAttemptState
 } from "./workflow-run-state.js";
 
@@ -155,7 +156,8 @@ export type {
 export type {
   RunWorkflowInput,
   WorkflowStepHandler,
-  WorkflowStepHandlerInput
+  WorkflowStepHandlerInput,
+  WorkflowStepHandlerResult
 } from "./workflow-runner.js";
 
 export type {

--- a/src/workflow-run-state.ts
+++ b/src/workflow-run-state.ts
@@ -36,7 +36,8 @@ const STEP_ATTEMPT_ALLOWED_KEYS = new Set([
   "stepId",
   "attempt",
   "occurredAt",
-  "retry"
+  "retry",
+  "result"
 ]);
 const RUN_COMPLETED_ALLOWED_KEYS = new Set([
   "type",
@@ -111,6 +112,7 @@ export interface WorkflowStepAttemptEvent {
   attempt: number;
   occurredAt: string;
   retry?: WorkflowRunRetryMetadata;
+  result?: WorkflowStepAttemptResultMetadata;
 }
 
 export interface WorkflowRunCompletedEvent {
@@ -146,6 +148,7 @@ export interface WorkflowStepAttemptState {
   completedAt?: string;
   failedAt?: string;
   retry?: WorkflowRunRetryMetadata;
+  result?: WorkflowStepAttemptResultMetadata;
   status: "running" | "succeeded" | "failed" | "retryable-failed";
 }
 
@@ -154,6 +157,8 @@ export interface WorkflowRunState {
   events: WorkflowRunEvent[];
   stepAttempts: Record<string, WorkflowStepAttemptState[]>;
 }
+
+export type WorkflowStepAttemptResultMetadata = Record<string, unknown>;
 
 export const createWorkflowRun = async (
   statePath: string,
@@ -373,10 +378,12 @@ const applyStepAttemptEvent = (
     attempt.completedAt = event.occurredAt;
     attempt.status = "succeeded";
     attempt.retry = event.retry;
+    attempt.result = event.result;
   } else {
     attempt.failedAt = event.occurredAt;
     attempt.status = event.retry?.retryable === true ? "retryable-failed" : "failed";
     attempt.retry = event.retry;
+    attempt.result = event.result;
   }
 };
 
@@ -429,6 +436,10 @@ const validateWorkflowRunEvent = (
 
   if ("retry" in value) {
     validateRetryMetadata(value.retry, lineNumber);
+  }
+
+  if ("result" in value) {
+    validateResultMetadata(value.result, lineNumber);
   }
 
   return value as unknown as WorkflowStepAttemptEvent;
@@ -491,6 +502,15 @@ const validateRetryMetadata = (value: unknown, lineNumber: number): void => {
   if ("reason" in value && (typeof value.reason !== "string" || value.reason.trim() === "")) {
     throw stateError(lineNumber, "retry.reason must be a non-empty string");
   }
+};
+
+const validateResultMetadata = (value: unknown, lineNumber: number): void => {
+  if (!isRecord(value)) {
+    throw stateError(lineNumber, "result must be an object");
+  }
+
+  validateJsonSerializableValue(value, lineNumber, "result");
+  rejectCredentialShapedStrings(value, lineNumber, "result");
 };
 
 const rejectUnknownKeys = (
@@ -614,6 +634,32 @@ const validateJsonSerializableValue = (
   throw stateError(lineNumber, `${path} must contain only JSON-serializable values`);
 };
 
+const rejectCredentialShapedStrings = (
+  value: unknown,
+  lineNumber: number,
+  path: string
+): void => {
+  if (typeof value === "string") {
+    if (containsCredentialShapedValue(value)) {
+      throw stateError(lineNumber, `${path} must not contain credential-shaped values`);
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      rejectCredentialShapedStrings(item, lineNumber, `${path}[${index}]`);
+    });
+    return;
+  }
+
+  if (isRecord(value)) {
+    Object.entries(value).forEach(([key, item]) => {
+      rejectCredentialShapedStrings(item, lineNumber, `${path}.${key}`);
+    });
+  }
+};
+
 const validateJsonContainer = (
   value: object,
   lineNumber: number,
@@ -665,3 +711,10 @@ const isStrictIsoTimestamp = (value: string): boolean => {
 
 const isNodeError = (error: unknown): error is NodeJS.ErrnoException =>
   error instanceof Error && "code" in error;
+
+const containsCredentialShapedValue = (value: string): boolean =>
+  /(?:^|\b)(?:password|passwd|token|secret|api[_-]?key|access[_-]?key|private[_-]?key)\s*[:=]/i.test(
+    value
+  ) ||
+  /\b(?:ghp|github_pat|glpat|xox[abprs]|sk)[-_][A-Za-z0-9_-]{8,}\b/.test(value) ||
+  /-----BEGIN [A-Z ]*(?:PRIVATE KEY|TOKEN|SECRET)[A-Z ]*-----/.test(value);

--- a/src/workflow-run-state.ts
+++ b/src/workflow-run-state.ts
@@ -439,6 +439,9 @@ const validateWorkflowRunEvent = (
   }
 
   if ("result" in value) {
+    if (eventType === "step.attempt.started") {
+      throw stateError(lineNumber, "result is only allowed on terminal step attempt events");
+    }
     validateResultMetadata(value.result, lineNumber);
   }
 

--- a/src/workflow-runner.ts
+++ b/src/workflow-runner.ts
@@ -53,7 +53,7 @@ export type WorkflowStepHandlerResult =
   | void
   | ExecutorConnectorStatusSnapshot
   | {
-      executor?: ExecutorConnectorStatusSnapshot;
+      executor: ExecutorConnectorStatusSnapshot;
     };
 
 export type WorkflowStepHandler = (
@@ -290,7 +290,7 @@ const normalizeStepHandlerResult = (
     return { executor: result.executor };
   }
 
-  return undefined;
+  throw new Error("stepHandler must return an ExecutorConnectorStatusSnapshot or { executor }");
 };
 
 const errorStepResult = (error: unknown): WorkflowStepAttemptResultMetadata | undefined =>

--- a/src/workflow-runner.ts
+++ b/src/workflow-runner.ts
@@ -8,7 +8,12 @@ import {
 import { createLocalAuditEventWriter } from "./audit-event-writer.js";
 import type { NeutralAuditEventWriter } from "./audit-event-writer.js";
 import type {
+  ExecutorConnectorStatusSnapshot,
+  ExecutorConnectorExecutionStatus
+} from "./executor-connector.js";
+import type {
   WorkflowRunIdempotencyMetadata,
+  WorkflowStepAttemptResultMetadata,
   WorkflowRunState
 } from "./workflow-run-state.js";
 import {
@@ -44,7 +49,20 @@ export interface WorkflowStepHandlerInput {
   runState: WorkflowRunState;
 }
 
-export type WorkflowStepHandler = (input: WorkflowStepHandlerInput) => Promise<void> | void;
+export type WorkflowStepHandlerResult =
+  | void
+  | ExecutorConnectorStatusSnapshot
+  | {
+      executor?: ExecutorConnectorStatusSnapshot;
+    };
+
+export type WorkflowStepHandler = (
+  input: WorkflowStepHandlerInput
+) => Promise<WorkflowStepHandlerResult> | WorkflowStepHandlerResult;
+
+interface NormalizedWorkflowStepHandlerResult extends WorkflowStepAttemptResultMetadata {
+  executor: ExecutorConnectorStatusSnapshot;
+}
 
 export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunState> => {
   assertSupportedWorkflowEipProtocolVersion(input.definition);
@@ -130,13 +148,25 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
       });
 
       try {
-        await stepHandler({
-          definition: input.definition,
-          step,
-          attempt,
-          triggerContext,
-          runState: await readWorkflowRunState(input.statePath)
-        });
+        const stepResult = normalizeStepHandlerResult(
+          await stepHandler({
+            definition: input.definition,
+            step,
+            attempt,
+            triggerContext,
+            runState: await readWorkflowRunState(input.statePath)
+          })
+        );
+
+        if (
+          stepResult?.executor !== undefined &&
+          stepResult.executor.status !== "succeeded"
+        ) {
+          throw new WorkflowStepOutcomeError(
+            executorFailureReason(stepResult.executor),
+            stepResult
+          );
+        }
 
         const completedAt = now();
         await appendWorkflowRunEvent(input.statePath, {
@@ -144,7 +174,8 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
           runId,
           stepId: step.id,
           attempt,
-          occurredAt: completedAt
+          occurredAt: completedAt,
+          ...(stepResult === undefined ? {} : { result: stepResult })
         });
         await writeStepAuditEvent(auditWriter, {
           type: "step.completed",
@@ -155,6 +186,7 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
         });
         break;
       } catch (error) {
+        const stepResult = errorStepResult(error);
         const retryable = attempt < retryPolicy.maxAttempts;
         const failedAt = now();
         const nextAttemptAt = retryable
@@ -170,7 +202,8 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
             retryable,
             ...(nextAttemptAt === undefined ? {} : { nextAttemptAt }),
             reason: errorReason(error)
-          }
+          },
+          ...(stepResult === undefined ? {} : { result: stepResult })
         });
         await writeStepAuditEvent(auditWriter, {
           type: "step.failed",
@@ -231,6 +264,72 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
 
   return readWorkflowRunState(input.statePath);
 };
+
+class WorkflowStepOutcomeError extends Error {
+  readonly result: WorkflowStepAttemptResultMetadata;
+
+  constructor(message: string, result: WorkflowStepAttemptResultMetadata) {
+    super(message);
+    this.name = "WorkflowStepOutcomeError";
+    this.result = result;
+  }
+}
+
+const normalizeStepHandlerResult = (
+  result: WorkflowStepHandlerResult
+): NormalizedWorkflowStepHandlerResult | undefined => {
+  if (result === undefined) {
+    return undefined;
+  }
+
+  if (isExecutorStatusSnapshot(result)) {
+    return { executor: result };
+  }
+
+  if (isRecord(result) && isExecutorStatusSnapshot(result.executor)) {
+    return { executor: result.executor };
+  }
+
+  return undefined;
+};
+
+const errorStepResult = (error: unknown): WorkflowStepAttemptResultMetadata | undefined =>
+  error instanceof WorkflowStepOutcomeError ? error.result : undefined;
+
+const executorFailureReason = (executor: ExecutorConnectorStatusSnapshot): string => {
+  const resultSummary = executor.result?.summary;
+  if (resultSummary !== undefined && resultSummary.trim() !== "") {
+    return resultSummary;
+  }
+
+  return `executor status ${executor.status} did not complete successfully`;
+};
+
+const isExecutorStatusSnapshot = (
+  value: unknown
+): value is ExecutorConnectorStatusSnapshot => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    typeof value.requestId === "string" &&
+    typeof value.status === "string" &&
+    isExecutorTerminalOrProgressStatus(value.status)
+  );
+};
+
+const isExecutorTerminalOrProgressStatus = (
+  value: string
+): value is ExecutorConnectorExecutionStatus =>
+  value === "accepted" ||
+  value === "running" ||
+  value === "succeeded" ||
+  value === "failed" ||
+  value === "cancelled" ||
+  value === "approval-required" ||
+  value === "blocked" ||
+  value === "needs-review";
 
 export const loadWorkflowDefinitionFile = async (
   definitionPath: string

--- a/test/cli-loop-executor-smoke.test.ts
+++ b/test/cli-loop-executor-smoke.test.ts
@@ -622,7 +622,21 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
           status: status === "succeeded" ? "succeeded" : status,
           result: {
             status,
-            summary
+            summary,
+            evidence: {
+              localArtifacts: [
+                {
+                  kind: "aggregate-json",
+                  path: "state/x-gate3/aggregate.json"
+                },
+                {
+                  kind: "log",
+                  path: "state/x-gate3/loop.log"
+                }
+              ],
+              localArtifactSemantics: "local-development-references-only",
+              productionEvidence: false
+            }
           }
         }
       });

--- a/test/cli-loop-executor-smoke.test.ts
+++ b/test/cli-loop-executor-smoke.test.ts
@@ -843,6 +843,67 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
 
   it.each([
     {
+      name: "production evidence claim",
+      extension: {
+        localArtifacts: createXGate3Aggregate().localArtifacts,
+        localArtifactSemantics: "local-development-references-only",
+        productionEvidence: true
+      }
+    },
+    {
+      name: "unsupported local artifact field",
+      extension: {
+        localArtifacts: [
+          {
+            kind: "aggregate-json",
+            path: "state/x-gate3/aggregate.json",
+            durableEvidenceArchive: true
+          }
+        ],
+        localArtifactSemantics: "local-development-references-only",
+        productionEvidence: false
+      }
+    },
+    {
+      name: "unsupported local lane field",
+      extension: {
+        localArtifacts: createXGate3Aggregate().localArtifacts,
+        localArtifactSemantics: "local-development-references-only",
+        productionEvidence: false,
+        providerRan: true
+      }
+    }
+  ])("does not surface unsafe X-Gate 3 local lane evidence from $name", async ({
+    extension
+  }) => {
+    const transport = createFakeTransportWithResultExtension(extension);
+    const connector = createEnsenLoopEipExecutorConnector({ transport });
+    const submitted = await connector.submit(createSmokeSubmitRequest());
+    if (!submitted.ok) {
+      throw new Error(submitted.error.reason ?? submitted.error.message);
+    }
+
+    const result = await connector.status({ requestId: submitted.value.requestId });
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        result: {
+          evidence: {
+            verification: {
+              summary: "Loop X-Gate 3 local fake lane succeeded."
+            }
+          }
+        }
+      }
+    });
+    expect(JSON.stringify(result)).not.toContain("localArtifacts");
+    expect(JSON.stringify(result)).not.toContain("productionEvidence");
+    expect(JSON.stringify(result)).not.toContain("providerRan");
+  });
+
+  it.each([
+    {
       name: "protocol gap for unsupported successful aggregate shape",
       scriptBody:
         "process.stdout.write(JSON.stringify({ schemaVersion: 'ensen-loop.x-gate3-local-lane-smoke.v2' }));",
@@ -1257,3 +1318,74 @@ const createXGate3Aggregate = () => ({
     }
   ]
 });
+
+const createSmokeSubmitRequest = (): ExecutorSubmitRequest => ({
+  workflow: {
+    id: "cli-loop-smoke",
+    version: "flow.workflow.v1"
+  },
+  run: {
+    id: "cli-loop-smoke"
+  },
+  step: {
+    id: "loop-dry-run",
+    attempt: 1
+  },
+  idempotencyKey: "cli-loop-smoke-0001",
+  policyDecision: { decision: "allow" },
+  source: createSmokeRunRequest().source,
+  requestedBy: createSmokeRunRequest().requestedBy,
+  workItem: createSmokeRunRequest().workItem
+});
+
+const createFakeTransportWithResultExtension = (extension: Record<string, unknown>) => {
+  const requestIds: string[] = [];
+  const submittedRunRequests: EipRunRequestV1[] = [];
+  return {
+    submittedRunRequests,
+    submitRunRequest(request: EipRunRequestV1) {
+      requestIds.push(request.id);
+      submittedRunRequests.push(request);
+      return {
+        requestId: request.id,
+        acceptedAt: "2026-05-01T04:00:01.000Z"
+      };
+    },
+    getRunStatusSnapshot({ requestId }: { requestId: string }) {
+      if (!requestIds.includes(requestId)) {
+        throw new Error("unknown request");
+      }
+      return {
+        schemaVersion: "eip.run-status.v1",
+        id: "sts_cli_loop_xgate3_extension",
+        requestId,
+        correlationId: "corr_cli_loop_smoke",
+        status: "completed",
+        observedAt: "2026-05-01T04:00:02.000Z"
+      };
+    },
+    getRunResult({ requestId }: { requestId: string }) {
+      if (!requestIds.includes(requestId)) {
+        throw new Error("unknown request");
+      }
+      return {
+        schemaVersion: "eip.run-result.v1",
+        id: "run_cli_loop_xgate3_extension",
+        requestId,
+        correlationId: "corr_cli_loop_smoke",
+        status: "succeeded",
+        completedAt: "2026-05-01T04:00:03.000Z",
+        verification: {
+          status: "passed",
+          summary: "Loop X-Gate 3 local fake lane succeeded."
+        },
+        extensions: {
+          "x-ensen-flow-local-lane": extension
+        }
+      };
+    },
+    getEvidenceBundleRef() {
+      throw new Error("evidence should not be fetched");
+    }
+  };
+};

--- a/test/workflow-run-state.test.ts
+++ b/test/workflow-run-state.test.ts
@@ -596,6 +596,37 @@ describe("workflow run JSONL state", () => {
     );
   });
 
+  it("rejects result metadata on started step attempts before appending", async () => {
+    const statePath = await createTempStatePath();
+
+    await createWorkflowRun(statePath, {
+      runId: "run-started-result",
+      workflowId: "operator-review",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z"
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+
+    await expect(
+      appendWorkflowRunEvent(statePath, {
+        type: "step.attempt.started",
+        runId: "run-started-result",
+        stepId: "collect-input",
+        attempt: 1,
+        occurredAt: "2026-04-29T00:00:02.000Z",
+        result: { ignored: true }
+      })
+    ).rejects.toThrow(
+      "workflow run state line 1: result is only allowed on terminal step attempt events"
+    );
+
+    const persisted = await readWorkflowRunState(statePath);
+    expect(persisted.events.map((event) => event.type)).toEqual(["run.created"]);
+  });
+
   it("fails closed on duplicate terminal step attempt transitions", async () => {
     const statePath = await createTempStatePath();
     await writeFile(

--- a/test/workflow-runner.test.ts
+++ b/test/workflow-runner.test.ts
@@ -383,6 +383,44 @@ describe("sequential workflow runner", () => {
     });
   });
 
+  it("fails the step when a handler returns a malformed non-void result", async () => {
+    const definition = readWorkflowFixture("simple-manual.valid.json");
+    definition.steps = [definition.steps[0]];
+    const statePath = await createTempStatePath();
+
+    const result = await runWorkflow({
+      definition,
+      statePath,
+      triggerContext: {
+        requestId: "manual-malformed-handler"
+      },
+      now: (() => {
+        let index = 0;
+        const timestamps = [
+          "2026-04-29T00:05:00.000Z",
+          "2026-04-29T00:05:01.000Z",
+          "2026-04-29T00:05:02.000Z",
+          "2026-04-29T00:05:03.000Z",
+          "2026-04-29T00:05:04.000Z"
+        ];
+        return () => timestamps[index++] ?? "2026-04-29T00:05:05.000Z";
+      })(),
+      stepHandler: () => ({}) as never
+    });
+
+    expect(result.run.status).toBe("failed");
+    expect(result.stepAttempts["collect-input"]).toMatchObject([
+      {
+        attempt: 1,
+        status: "failed",
+        retry: {
+          retryable: false,
+          reason: "stepHandler must return an ExecutorConnectorStatusSnapshot or { executor }"
+        }
+      }
+    ]);
+  });
+
   it.each([
     {
       executorStatus: "succeeded",

--- a/test/workflow-runner.test.ts
+++ b/test/workflow-runner.test.ts
@@ -6,7 +6,10 @@ import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { readWorkflowRunState, runWorkflow } from "../src/index.js";
-import type { WorkflowDefinition } from "../src/index.js";
+import type {
+  ExecutorConnectorStatusSnapshot,
+  WorkflowDefinition
+} from "../src/index.js";
 
 const tempRoots: string[] = [];
 
@@ -379,6 +382,139 @@ describe("sequential workflow runner", () => {
       }
     });
   });
+
+  it.each([
+    {
+      executorStatus: "succeeded",
+      resultStatus: "succeeded",
+      expectedRunStatus: "succeeded",
+      expectedAttemptStatus: "succeeded",
+      summary: "Loop X-Gate 3 local fake lane succeeded."
+    },
+    {
+      executorStatus: "failed",
+      resultStatus: "failed",
+      expectedRunStatus: "failed",
+      expectedAttemptStatus: "failed",
+      summary: "Loop X-Gate 3 local fake lane failed."
+    },
+    {
+      executorStatus: "blocked",
+      resultStatus: "blocked",
+      expectedRunStatus: "failed",
+      expectedAttemptStatus: "failed",
+      summary: "Loop X-Gate 3 local fake lane blocked."
+    }
+  ] as const)(
+    "persists X-Gate 3 local lane $executorStatus outcome in Flow run state",
+    async ({
+      executorStatus,
+      resultStatus,
+      expectedRunStatus,
+      expectedAttemptStatus,
+      summary
+    }) => {
+      const definition = readWorkflowFixture("simple-manual.valid.json");
+      definition.id = `xgate3-local-lane-${executorStatus}`;
+      definition.steps = [
+        {
+          id: "xgate3-local-lane",
+          action: {
+            type: "local",
+            name: "loop_xgate3_local_lane"
+          }
+        }
+      ];
+      const statePath = await createTempStatePath();
+
+      const result = await runWorkflow({
+        definition,
+        statePath,
+        triggerContext: {
+          requestId: `xgate3-${executorStatus}`
+        },
+        now: (() => {
+          let index = 0;
+          const timestamps = [
+            "2026-05-01T04:00:00.000Z",
+            "2026-05-01T04:00:01.000Z",
+            "2026-05-01T04:00:02.000Z",
+            "2026-05-01T04:00:03.000Z"
+          ];
+          return () => timestamps[index++] ?? "2026-05-01T04:00:04.000Z";
+        })(),
+        stepHandler: () =>
+          ({
+            requestId: `req_xgate3_${executorStatus}_local_lane`,
+            status: executorStatus,
+            observedAt: "2026-05-01T04:00:03.000Z",
+            result: {
+              status: resultStatus,
+              summary,
+              evidence: {
+                verification: {
+                  status: resultStatus === "succeeded" ? "passed" : resultStatus,
+                  summary
+                },
+                warnings: [{ code: "local-lane-only", message: "Local smoke reference only." }],
+                ...(resultStatus === "succeeded"
+                  ? {}
+                  : { errors: [{ code: resultStatus, message: summary }] }),
+                localArtifacts: [
+                  {
+                    kind: "aggregate-json",
+                    path: "state/x-gate3/aggregate.json",
+                    contentType: "application/json",
+                    description: "Local X-Gate 3 smoke aggregate"
+                  }
+                ],
+                localArtifactSemantics: "local-development-references-only",
+                productionEvidence: false
+              }
+            }
+          }) satisfies ExecutorConnectorStatusSnapshot
+      });
+
+      expect(result.run.status).toBe(expectedRunStatus);
+      expect(result.stepAttempts["xgate3-local-lane"]).toMatchObject([
+        {
+          attempt: 1,
+          status: expectedAttemptStatus,
+          result: {
+            executor: {
+              requestId: `req_xgate3_${executorStatus}_local_lane`,
+              status: executorStatus,
+              result: {
+                status: resultStatus,
+                summary,
+                evidence: {
+                  verification: {
+                    status: resultStatus === "succeeded" ? "passed" : resultStatus,
+                    summary
+                  },
+                  localArtifacts: [
+                    {
+                      kind: "aggregate-json",
+                      path: "state/x-gate3/aggregate.json"
+                    }
+                  ],
+                  localArtifactSemantics: "local-development-references-only",
+                  productionEvidence: false
+                }
+              }
+            }
+          }
+        }
+      ]);
+
+      const persisted = await readWorkflowRunState(statePath);
+      expect(JSON.stringify(persisted)).not.toContain("compliance evidence");
+      expect(JSON.stringify(persisted)).not.toContain("production evidence archive");
+      expect(persisted.stepAttempts["xgate3-local-lane"][0].result).toEqual(
+        result.stepAttempts["xgate3-local-lane"][0].result
+      );
+    }
+  );
 
   it("returns the existing terminal run when the idempotency key matches", async () => {
     const definition = readWorkflowFixture("simple-manual.valid.json");


### PR DESCRIPTION
## Summary
- persist executor status/result metadata on Flow step attempts returned by local lane handlers
- map failed and blocked X-Gate 3 outcomes to failed Flow attempts/runs instead of success
- expose X-Gate 3 local artifact references as local-development metadata, not production evidence

## Verification
- npm run build
- npm test -- test/workflow-runner.test.ts
- npm test -- test/cli-loop-executor-smoke.test.ts
- npm test

Closes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow step handlers can now return and persist result metadata, including execution evidence and local artifact references across all terminal states (completed, failed, blocked, cancelled).
  * Enhanced status tracking with structured outcome information.

* **Tests**
  * Added validation tests for result metadata persistence across different executor outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->