### PR TITLE
FLOW-034: Add final Flow X-Gate 3 smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ authority, and no premature compliance claims.
   boundaries.
 - `docs/x-gate3-flow-caller-boundary-runbook.md`: Flow-owned X-Gate 3 caller
   boundary, Loop local fake lane command shape, stdout contract, failure
-  routing, and non-production limits.
+  routing, focused Flow smoke coverage, local cleanup limits, and
+  non-production limits.
 
 ## Workflow Definition Schema
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Start here:
 - [Workflow Definition Schema](./workflow-definition.md): the Phase 1 standalone workflow definition boundary and validation shape.
 - [X-Gate 2 Loop-Flow Smoke Runbook](./x-gate2-loop-flow-smoke-runbook.md): local smoke commands, artifacts, failure routing, and non-production boundaries.
 - [X-Gate 3 Flow Caller Boundary Runbook](./x-gate3-flow-caller-boundary-runbook.md): Flow-owned caller boundary for Loop local fake lane smoke input, stdout output, artifacts, and failure routing.
+- Focused Flow X-Gate 3 smoke coverage: `npm test -- test/x-gate3-flow-smoke.test.ts`.
 - [Ensen-protocol v0.1.0 Snapshot](../protocol-snapshots/ensen-protocol/v0.1.0/README.md): copied protocol schemas and conformance fixtures for later connector tests.
 
 Ensen-flow documentation should preserve the product boundary: lightweight explainable workflow orchestration, no shared runtime dependency with Ensen-loop, and no premature Pharma/GxP compliance claims.

--- a/docs/x-gate3-flow-caller-boundary-runbook.md
+++ b/docs/x-gate3-flow-caller-boundary-runbook.md
@@ -45,6 +45,23 @@ Docs, tests, fixtures, and issue output must keep these as placeholders or
 repo-relative paths; they must not publish workstation-local absolute paths,
 secrets, customer data, or production evidence locations.
 
+For a real sibling Loop checkout, use environment variables or placeholders
+rather than durable host paths in published notes:
+
+```sh
+LOOP_ROOT=<codex-supervisor-root-or-loop-checkout>
+FLOW_SMOKE_ROOT=<temporary-flow-x-gate3-smoke-root>
+node "$LOOP_ROOT/dist/index.js" x-gate3-smoke <run-request-json-file> --workspace-root "$FLOW_SMOKE_ROOT/workspace" --state-root "$FLOW_SMOKE_ROOT/state"
+```
+
+The Flow-owned local smoke test creates its own temporary RunRequest input and
+invokes an X-Gate 3-shaped local fake lane process. It is the required focused
+test for this repository:
+
+```sh
+npm test -- test/x-gate3-flow-smoke.test.ts
+```
+
 ## Stdout Contract
 
 The command should write one JSON aggregate to process stdout. Flow may consume
@@ -80,6 +97,13 @@ Flow must not publish raw secrets, access tokens, customer records, provider
 payloads, real repository data, real review text, ERPNext records, or Pharma/GxP
 evidence as part of X-Gate 3 smoke output.
 
+Cleanup is limited to the temporary smoke root created for a single local run,
+for example `<temporary-flow-x-gate3-smoke-root>/workspace`,
+`<temporary-flow-x-gate3-smoke-root>/state`, and temporary RunRequest files.
+Do not delete repository checkouts, supervisor state, customer data,
+production evidence paths, shared caches, or any path that was not created for
+the current smoke run.
+
 ## Failure Routing
 
 | Failure class | Route follow-up to | Use when |
@@ -99,12 +123,13 @@ assumption.
 Run the repo-owned documentation contract test:
 
 ```sh
+npm test -- test/x-gate3-flow-smoke.test.ts
 npm test -- test/x-gate3-flow-runbook.test.ts
 ```
 
-Before marking the runbook complete, also inspect the docs diff for boundary
-wording and placeholder-only paths. Full local verification should continue to
-use the repo-owned commands:
+Before marking the runbook complete, inspect the docs diff for boundary wording,
+placeholder-only paths, cleanup limits, and Protocol #28 routing language. Full
+local verification should continue to use the repo-owned commands:
 
 ```sh
 npm run build
@@ -115,14 +140,17 @@ npm test
 
 X-Gate 3 documentation can be marked ready when all of the following are true:
 
+- `npm test -- test/x-gate3-flow-smoke.test.ts` passes and proves the Flow
+  runner plus connector can exercise the Loop-shaped local fake lane boundary;
 - the Flow runbook describes protocol-shaped input and process stdout output;
 - README or docs navigation links to this runbook;
-- the command shape uses placeholders only;
+- the command shape uses placeholders or documented environment variables only;
 - expected stdout fields include aggregate schema version, boundary flags,
   RunStatusSnapshot, RunResult, and local artifact references;
 - failure routing covers `protocol-gap`, `loop-gap`, and `flow-gap`;
 - concrete protocol contract ambiguity routes to TommyKammy/Ensen-protocol#28;
 - the wording preserves the Ensen-flow repository boundary and forbids shared
   Ensen-loop implementation imports;
+- cleanup is limited to the temporary smoke root created for the current run;
 - the smoke remains local development evidence only, with no production
-  automation or compliance evidence claim.
+  automation, external mutation, or compliance evidence claim.

--- a/docs/x-gate3-flow-caller-boundary-runbook.md
+++ b/docs/x-gate3-flow-caller-boundary-runbook.md
@@ -55,7 +55,7 @@ node "$LOOP_ROOT/dist/index.js" x-gate3-smoke <run-request-json-file> --workspac
 ```
 
 The Flow-owned local smoke test creates its own temporary RunRequest input and
-invokes an X-Gate 3-shaped local fake lane process. It is the required focused
+invokes an X-Gate 3-shaped local fake lane process. It is the required smoke
 test for this repository:
 
 ```sh

--- a/docs/x-gate3-flow-caller-boundary-runbook.md
+++ b/docs/x-gate3-flow-caller-boundary-runbook.md
@@ -50,7 +50,9 @@ rather than durable host paths in published notes:
 
 ```sh
 LOOP_ROOT=<codex-supervisor-root-or-loop-checkout>
-FLOW_SMOKE_ROOT=<temporary-flow-x-gate3-smoke-root>
+FLOW_SMOKE_ROOT=<absolute-temporary-flow-x-gate3-smoke-root>
+: "${LOOP_ROOT:?Set LOOP_ROOT to a local Ensen-loop checkout root}"
+: "${FLOW_SMOKE_ROOT:?Set FLOW_SMOKE_ROOT to a per-run temporary absolute root}"
 node "$LOOP_ROOT/dist/index.js" x-gate3-smoke <run-request-json-file> --workspace-root "$FLOW_SMOKE_ROOT/workspace" --state-root "$FLOW_SMOKE_ROOT/state"
 ```
 

--- a/test/x-gate3-flow-runbook.test.ts
+++ b/test/x-gate3-flow-runbook.test.ts
@@ -17,7 +17,13 @@ describe("X-Gate 3 Flow caller boundary runbook", () => {
       "x-gate3-smoke <run-request-json-file> --workspace-root <workspace-root> --state-root <state-root>",
     );
     expect(runbook).toContain("LOOP_ROOT=<codex-supervisor-root-or-loop-checkout>");
-    expect(runbook).toContain("FLOW_SMOKE_ROOT=<temporary-flow-x-gate3-smoke-root>");
+    expect(runbook).toContain("FLOW_SMOKE_ROOT=<absolute-temporary-flow-x-gate3-smoke-root>");
+    expect(runbook).toContain(
+      ': "${LOOP_ROOT:?Set LOOP_ROOT to a local Ensen-loop checkout root}"',
+    );
+    expect(runbook).toContain(
+      ': "${FLOW_SMOKE_ROOT:?Set FLOW_SMOKE_ROOT to a per-run temporary absolute root}"',
+    );
     expect(runbook).toContain("npm test -- test/x-gate3-flow-smoke.test.ts");
     expect(runbook).toContain("protocol-shaped input");
     expect(runbook).toContain("process stdout");

--- a/test/x-gate3-flow-runbook.test.ts
+++ b/test/x-gate3-flow-runbook.test.ts
@@ -16,6 +16,9 @@ describe("X-Gate 3 Flow caller boundary runbook", () => {
     expect(runbook).toContain(
       "x-gate3-smoke <run-request-json-file> --workspace-root <workspace-root> --state-root <state-root>",
     );
+    expect(runbook).toContain("LOOP_ROOT=<codex-supervisor-root-or-loop-checkout>");
+    expect(runbook).toContain("FLOW_SMOKE_ROOT=<temporary-flow-x-gate3-smoke-root>");
+    expect(runbook).toContain("npm test -- test/x-gate3-flow-smoke.test.ts");
     expect(runbook).toContain("protocol-shaped input");
     expect(runbook).toContain("process stdout");
     expect(runbook).toContain("aggregate schema version");
@@ -35,6 +38,8 @@ describe("X-Gate 3 Flow caller boundary runbook", () => {
     expect(runbook).toContain("no real pull request");
     expect(runbook).toContain("no ERPNext");
     expect(runbook).toContain("no Pharma/GxP");
+    expect(runbook).toContain("Cleanup is limited to the temporary smoke root");
+    expect(runbook).toContain("Do not delete repository checkouts, supervisor state");
     expect(runbook).not.toMatch(posixHomeRootPattern);
     expect(runbook).not.toMatch(linuxHomeRootPattern);
     expect(runbook).not.toMatch(windowsHomeRootPattern);

--- a/test/x-gate3-flow-smoke.test.ts
+++ b/test/x-gate3-flow-smoke.test.ts
@@ -1,0 +1,423 @@
+import { constants } from "node:fs";
+import { access, chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createCliEnsenLoopEipExecutorTransport,
+  createEnsenLoopEipExecutorConnector,
+  runWorkflow
+} from "../src/index.js";
+import type {
+  ExecutorConnector,
+  ExecutorConnectorStatusSnapshot,
+  WorkflowDefinition,
+  WorkflowStepHandler
+} from "../src/index.js";
+
+const tempRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
+  );
+});
+
+describe("Flow X-Gate 3 caller smoke", () => {
+  it.each([
+    {
+      laneStatus: "succeeded",
+      loopStatus: "completed",
+      expectedRunStatus: "succeeded",
+      expectedAttemptStatus: "succeeded",
+      summary: "Loop X-Gate 3 local fake lane succeeded."
+    },
+    {
+      laneStatus: "failed",
+      loopStatus: "failed",
+      expectedRunStatus: "failed",
+      expectedAttemptStatus: "failed",
+      summary: "Loop X-Gate 3 local fake lane failed."
+    },
+    {
+      laneStatus: "blocked",
+      loopStatus: "blocked",
+      expectedRunStatus: "failed",
+      expectedAttemptStatus: "failed",
+      summary: "Loop X-Gate 3 local fake lane blocked."
+    }
+  ] as const)(
+    "exercises the Loop-shaped X-Gate 3 boundary end to end for $laneStatus",
+    async ({
+      laneStatus,
+      loopStatus,
+      expectedRunStatus,
+      expectedAttemptStatus,
+      summary
+    }) => {
+      const tempRoot = await createTempRoot("ensen-flow-xgate3-smoke-");
+      const cliPath = await writeLoopXGate3SmokeCli(tempRoot, {
+        laneStatus,
+        loopStatus,
+        summary
+      });
+      const statePath = join(tempRoot, "flow-state", `${laneStatus}.jsonl`);
+      const connector = createEnsenLoopEipExecutorConnector({
+        transport: createCliEnsenLoopEipExecutorTransport({
+          command: process.execPath,
+          args: [cliPath],
+          xGate3Smoke: {
+            workspaceRoot: join(tempRoot, "workspace-root"),
+            stateRoot: join(tempRoot, "state-root")
+          }
+        }),
+        now: () => "2026-05-01T05:00:00.000Z"
+      });
+
+      const result = await runWorkflow({
+        definition: createXGate3SmokeDefinition(laneStatus),
+        statePath,
+        triggerContext: {
+          requestId: `xgate3-${laneStatus}`
+        },
+        now: fixedClock(),
+        stepHandler: createLoopConnectorStepHandler(connector)
+      });
+
+      expect(result.run.status).toBe(expectedRunStatus);
+      expect(result.stepAttempts["xgate3-local-lane"]).toMatchObject([
+        {
+          attempt: 1,
+          status: expectedAttemptStatus,
+          result: {
+            executor: {
+              requestId: `req_flow_xgate3_${laneStatus}_xgate3_${laneStatus}_xgate3_local_lane_1`,
+              status: laneStatus,
+              result: {
+                status: laneStatus,
+                summary,
+                evidence: {
+                  verification: {
+                    status: laneStatus === "succeeded" ? "passed" : laneStatus,
+                    summary
+                  },
+                  localArtifacts: [
+                    {
+                      kind: "aggregate-json",
+                      path: "state/x-gate3/aggregate.json"
+                    },
+                    {
+                      kind: "log",
+                      path: "state/x-gate3/loop.log"
+                    }
+                  ],
+                  localArtifactSemantics: "local-development-references-only",
+                  productionEvidence: false
+                }
+              }
+            }
+          }
+        }
+      ]);
+      expect(JSON.stringify(result)).not.toContain("production evidence archive");
+      expect(JSON.stringify(result)).not.toContain(tempRoot);
+    }
+  );
+
+  it("fails closed before invoking Loop when Flow builds invalid protocol input", async () => {
+    const tempRoot = await createTempRoot("ensen-flow-xgate3-invalid-input-");
+    const invokedPath = join(tempRoot, "loop-invoked.txt");
+    const cliPath = await writeLoopXGate3SmokeCli(tempRoot, {
+      laneStatus: "succeeded",
+      loopStatus: "completed",
+      summary: "Loop X-Gate 3 local fake lane succeeded.",
+      invokedPath
+    });
+    const connector = createEnsenLoopEipExecutorConnector({
+      transport: createCliEnsenLoopEipExecutorTransport({
+        command: process.execPath,
+        args: [cliPath],
+        xGate3Smoke: {
+          workspaceRoot: join(tempRoot, "workspace-root"),
+          stateRoot: join(tempRoot, "state-root")
+        }
+      }),
+      now: () => "2026-05-01T05:00:00.000Z"
+    });
+
+    const result = await runWorkflow({
+      definition: createXGate3SmokeDefinition("invalid-input"),
+      statePath: join(tempRoot, "flow-state", "invalid-input.jsonl"),
+      triggerContext: {
+        requestId: "xgate3-invalid-input"
+      },
+      now: fixedClock(),
+      stepHandler: createLoopConnectorStepHandler(connector, {
+        idempotencyKey: "bad"
+      })
+    });
+
+    expect(result.run.status).toBe("failed");
+    expect(result.stepAttempts["xgate3-local-lane"]).toMatchObject([
+      {
+        attempt: 1,
+        status: "failed",
+        retry: {
+          retryable: false,
+          reason: "EIP RunRequest idempotencyKey is malformed"
+        }
+      }
+    ]);
+    await expect(access(invokedPath, constants.F_OK)).rejects.toMatchObject({
+      code: "ENOENT"
+    });
+  });
+
+  it("fails closed when X-Gate 3 local roots are unsafe", async () => {
+    const tempRoot = await createTempRoot("ensen-flow-xgate3-unsafe-root-");
+    const connector = createEnsenLoopEipExecutorConnector({
+      transport: createCliEnsenLoopEipExecutorTransport({
+        command: "unused-loop-cli",
+        xGate3Smoke: {
+          workspaceRoot: "workspace-root",
+          stateRoot: join(tempRoot, "state-root")
+        }
+      }),
+      now: () => "2026-05-01T05:00:00.000Z"
+    });
+
+    const result = await runWorkflow({
+      definition: createXGate3SmokeDefinition("unsafe-root"),
+      statePath: join(tempRoot, "flow-state", "unsafe-root.jsonl"),
+      triggerContext: {
+        requestId: "xgate3-unsafe-root"
+      },
+      now: fixedClock(),
+      stepHandler: createLoopConnectorStepHandler(connector)
+    });
+
+    expect(result.run.status).toBe("failed");
+    expect(result.stepAttempts["xgate3-local-lane"]).toMatchObject([
+      {
+        attempt: 1,
+        status: "failed",
+        retry: {
+          retryable: false,
+          reason:
+            "Ensen-loop X-Gate 3 smoke roots must be non-empty absolute local path strings without traversal or credential-shaped values"
+        }
+      }
+    ]);
+  });
+
+  it("fails closed when Loop returns an invalid X-Gate 3 aggregate", async () => {
+    const tempRoot = await createTempRoot("ensen-flow-xgate3-invalid-aggregate-");
+    const cliPath = join(tempRoot, "loop-x-gate3-invalid-cli.mjs");
+    await writeFile(
+      cliPath,
+      [
+        "#!/usr/bin/env node",
+        "process.stdout.write(JSON.stringify({ schemaVersion: 'ensen-loop.x-gate3-local-lane-smoke.v2' }));",
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+    await chmod(cliPath, 0o755);
+    const connector = createEnsenLoopEipExecutorConnector({
+      transport: createCliEnsenLoopEipExecutorTransport({
+        command: process.execPath,
+        args: [cliPath],
+        xGate3Smoke: {
+          workspaceRoot: join(tempRoot, "workspace-root"),
+          stateRoot: join(tempRoot, "state-root")
+        }
+      }),
+      now: () => "2026-05-01T05:00:00.000Z"
+    });
+
+    const result = await runWorkflow({
+      definition: createXGate3SmokeDefinition("invalid-aggregate"),
+      statePath: join(tempRoot, "flow-state", "invalid-aggregate.jsonl"),
+      triggerContext: {
+        requestId: "xgate3-invalid-aggregate"
+      },
+      now: fixedClock(),
+      stepHandler: createLoopConnectorStepHandler(connector)
+    });
+
+    expect(result.run.status).toBe("failed");
+    expect(result.stepAttempts["xgate3-local-lane"]).toMatchObject([
+      {
+        attempt: 1,
+        status: "failed",
+        retry: {
+          retryable: false,
+          reason:
+            "unsupported EIP XGateSmokeAggregate schemaVersion ensen-loop.x-gate3-local-lane-smoke.v2"
+        }
+      }
+    ]);
+    expect(JSON.stringify(result)).not.toContain("localArtifacts");
+  });
+});
+
+const createTempRoot = async (prefix: string): Promise<string> => {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  tempRoots.push(root);
+  return root;
+};
+
+const createXGate3SmokeDefinition = (name: string): WorkflowDefinition => ({
+  schemaVersion: "flow.workflow.v1",
+  id: `flow-xgate3-${name}`,
+  name: `Flow X-Gate 3 ${name}`,
+  trigger: {
+    type: "manual",
+    idempotencyKey: {
+      source: "input",
+      field: "requestId"
+    }
+  },
+  steps: [
+    {
+      id: "xgate3-local-lane",
+      action: {
+        type: "local",
+        name: "loop_xgate3_local_lane"
+      }
+    }
+  ]
+});
+
+const createLoopConnectorStepHandler = (
+  connector: ExecutorConnector,
+  overrides: { idempotencyKey?: string } = {}
+): WorkflowStepHandler => async ({ definition, step, attempt, triggerContext, runState }) => {
+  const submitted = await connector.submit({
+    workflow: {
+      id: definition.id,
+      version: definition.schemaVersion
+    },
+    run: {
+      id: runState.run.runId
+    },
+    step: {
+      id: step.id,
+      attempt
+    },
+    idempotencyKey:
+      overrides.idempotencyKey ?? `${definition.id}:${runState.run.runId}:${step.id}:${attempt}`,
+    policyDecision: { decision: "allow" },
+    source: {
+      sourceId: "source_flow_xgate3_smoke",
+      sourceType: "manual",
+      externalRef: String(triggerContext.requestId ?? "xgate3-smoke")
+    },
+    requestedBy: {
+      actorId: "actor_ensen_flow_smoke",
+      actorType: "system",
+      displayName: "Ensen-flow X-Gate 3 smoke"
+    },
+    workItem: {
+      workItemId: `workitem_${definition.id.replaceAll("-", "_")}`,
+      externalId: step.id,
+      title: "Flow X-Gate 3 local fake lane smoke"
+    },
+    mode: "validate"
+  });
+
+  if (!submitted.ok) {
+    throw new Error(submitted.error.reason ?? submitted.error.message);
+  }
+
+  const status = await connector.status({ requestId: submitted.value.requestId });
+  if (!status.ok) {
+    throw new Error(status.error.reason ?? status.error.message);
+  }
+
+  return status.value satisfies ExecutorConnectorStatusSnapshot;
+};
+
+const fixedClock = (): (() => string) => {
+  let index = 0;
+  const timestamps = [
+    "2026-05-01T05:00:00.000Z",
+    "2026-05-01T05:00:01.000Z",
+    "2026-05-01T05:00:02.000Z",
+    "2026-05-01T05:00:03.000Z",
+    "2026-05-01T05:00:04.000Z"
+  ];
+  return () => timestamps[index++] ?? "2026-05-01T05:00:05.000Z";
+};
+
+const writeLoopXGate3SmokeCli = async (
+  root: string,
+  input: {
+    laneStatus: "succeeded" | "failed" | "blocked";
+    loopStatus: "completed" | "failed" | "blocked";
+    summary: string;
+    invokedPath?: string;
+  }
+): Promise<string> => {
+  const cliPath = join(root, "loop-x-gate3-cli.mjs");
+  await writeFile(
+    cliPath,
+    [
+      "#!/usr/bin/env node",
+      "import { readFileSync, writeFileSync } from 'node:fs';",
+      `const invokedPath = ${JSON.stringify(input.invokedPath)};`,
+      "if (invokedPath !== undefined) writeFileSync(invokedPath, 'invoked\\n');",
+      "const [command, requestPath, workspaceFlag, workspaceRoot, stateFlag, stateRoot] = process.argv.slice(2);",
+      "if (command !== 'x-gate3-smoke' || requestPath === undefined || workspaceFlag !== '--workspace-root' || stateFlag !== '--state-root') {",
+      "  process.stderr.write('expected x-gate3-smoke <run-request-json-file> --workspace-root <workspace-root> --state-root <state-root>');",
+      "  process.exitCode = 2;",
+      "} else {",
+      "  const request = JSON.parse(readFileSync(requestPath, 'utf8'));",
+      "  process.stdout.write(JSON.stringify({",
+      "    schemaVersion: 'ensen-loop.x-gate3-local-lane-smoke.v1',",
+      "    boundary: 'local-cli-bounded-fake-lane',",
+      "    requestId: request.id,",
+      "    correlationId: request.correlationId,",
+      "    mutatesRepository: false,",
+      "    invokesProvider: false,",
+      "    startsAgentProviderSession: false,",
+      "    writesProductionEvidenceArchive: false,",
+      "    statusSnapshot: {",
+      "      schemaVersion: 'eip.run-status.v1',",
+      "      id: 'sts_flow_xgate3_smoke',",
+      "      requestId: request.id,",
+      "      correlationId: request.correlationId,",
+      `      status: ${JSON.stringify(input.loopStatus)},`,
+      "      observedAt: '2026-05-01T05:00:02.000Z',",
+      `      message: ${JSON.stringify(input.summary)}`,
+      "    },",
+      "    runResult: {",
+      "      schemaVersion: 'eip.run-result.v1',",
+      "      id: 'run_flow_xgate3_smoke',",
+      "      requestId: request.id,",
+      "      correlationId: request.correlationId,",
+      `      status: ${JSON.stringify(input.laneStatus)},`,
+      "      completedAt: '2026-05-01T05:00:03.000Z',",
+      "      verification: {",
+      `        status: ${JSON.stringify(input.laneStatus === "succeeded" ? "passed" : input.laneStatus)},`,
+      `        summary: ${JSON.stringify(input.summary)}`,
+      "      },",
+      "      warnings: [{ code: 'local-lane-only', message: 'Local smoke reference only.' }]",
+      "    },",
+      "    localArtifacts: [",
+      "      { kind: 'aggregate-json', path: 'state/x-gate3/aggregate.json', contentType: 'application/json', description: 'Local X-Gate 3 smoke aggregate' },",
+      "      { kind: 'log', path: 'state/x-gate3/loop.log', contentType: 'text/plain' }",
+      "    ]",
+      "  }));",
+      "}",
+      "void workspaceRoot;",
+      "void stateRoot;",
+      ""
+    ].join("\n"),
+    "utf8"
+  );
+  await chmod(cliPath, 0o755);
+  return cliPath;
+};


### PR DESCRIPTION
## Summary
- add a focused Flow X-Gate 3 smoke that drives runWorkflow through the CLI-backed Loop connector boundary
- cover succeeded, failed, blocked, invalid Flow input, unsafe root, and invalid aggregate fail-closed paths
- update X-Gate 3 docs/navigation with focused verification, placeholder/env-var Loop command, cleanup limits, and Protocol #28 routing

## Verification
- npm test -- test/x-gate3-flow-smoke.test.ts test/x-gate3-flow-runbook.test.ts
- npm run build
- npm test

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the Flow X‑Gate 3 boundary runbook with example commands, environment variable guidance, tightened cleanup/safety constraints, and updated verification checklist to include smoke-test and routing checks.
  * Expanded docs navigation to reference the Flow smoke-test command.

* **Tests**
  * Added/updated tests to validate end-to-end smoke behavior, safety/cleanup constraints, failure modes, and privacy/sandbox outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->