### PR TITLE
Accept Loop X-Gate 3 local artifacts object

### DIFF
--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -869,12 +869,18 @@ interface EnsenLoopXGate3LocalLaneSmokeAggregateV1 {
   writesProductionEvidenceArchive: false;
   statusSnapshot: EipRunStatusSnapshotV1;
   runResult: EipRunResultV1;
-  localArtifacts: Array<Record<string, unknown>>;
+  localArtifacts: EnsenLoopXGate3LocalArtifactsV1;
   evidenceBundleRef?: Record<string, unknown>;
 }
 
+interface EnsenLoopXGate3LocalArtifactsV1 {
+  laneRunId: string;
+  stateFile: string;
+  evidenceMetadata: string[];
+}
+
 interface XGate3LocalLaneEvidence {
-  localArtifacts: Array<Record<string, unknown>>;
+  localArtifacts: EnsenLoopXGate3LocalArtifactsV1;
   localArtifactSemantics: "local-development-references-only";
   productionEvidence: false;
 }
@@ -1082,23 +1088,24 @@ const extractXGate3LocalLaneEvidence = (
 
   if (
     localLane.localArtifactSemantics !== "local-development-references-only" ||
-    localLane.productionEvidence !== false ||
-    !Array.isArray(localLane.localArtifacts) ||
-    localLane.localArtifacts.length === 0
+    localLane.productionEvidence !== false
   ) {
     return undefined;
   }
 
-  const localArtifacts: Array<Record<string, unknown>> = [];
-  for (const artifact of localLane.localArtifacts) {
-    if (validateXGate3LocalArtifact(artifact, "x-ensen-flow-local-lane.localArtifacts[]")) {
-      return undefined;
-    }
-    localArtifacts.push(sanitizeXGate3LocalArtifact(artifact));
+  if (
+    validateXGate3LocalArtifacts(
+      localLane.localArtifacts,
+      "x-ensen-flow-local-lane.localArtifacts"
+    )
+  ) {
+    return undefined;
   }
 
   return {
-    localArtifacts,
+    localArtifacts: sanitizeXGate3LocalArtifacts(
+      localLane.localArtifacts as Record<string, unknown>
+    ),
     localArtifactSemantics: "local-development-references-only",
     productionEvidence: false
   };
@@ -1307,18 +1314,12 @@ const validateXGate3LocalLaneSmokeAggregate = (
     return failClosedReason(`${shapeName} correlationId does not match nested payloads`);
   }
 
-  if (!Array.isArray(value.localArtifacts) || value.localArtifacts.length === 0) {
-    return failClosedReason(`${shapeName} localArtifacts must be a non-empty array`);
-  }
-
-  for (const [index, artifact] of value.localArtifacts.entries()) {
-    const artifactValidation = validateXGate3LocalArtifact(
-      artifact,
-      `${shapeName} localArtifacts[${index}]`
-    );
-    if (artifactValidation !== undefined) {
-      return artifactValidation;
-    }
+  const artifactsValidation = validateXGate3LocalArtifacts(
+    value.localArtifacts,
+    `${shapeName} localArtifacts`
+  );
+  if (artifactsValidation !== undefined) {
+    return artifactsValidation;
   }
 
   if (value.evidenceBundleRef !== undefined) {
@@ -1344,7 +1345,7 @@ const validateXGate3LocalLaneSmokeAggregate = (
   return undefined;
 };
 
-const validateXGate3LocalArtifact = (
+const validateXGate3LocalArtifacts = (
   value: unknown,
   shapeName: string
 ): { message: string; reason: string } | undefined => {
@@ -1353,83 +1354,53 @@ const validateXGate3LocalArtifact = (
   }
 
   const unknownProperty = findUnknownProperty(value, [
-    "kind",
-    "path",
-    "contentType",
-    "description",
-    "checksum"
+    "laneRunId",
+    "stateFile",
+    "evidenceMetadata"
   ]);
-
   if (unknownProperty !== undefined) {
     return failClosedReason(`${shapeName} has unsupported field ${unknownProperty}`);
   }
 
   if (
-    typeof value.kind !== "string" ||
-    !/^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/.test(value.kind)
+    typeof value.laneRunId !== "string" ||
+    !/^[A-Za-z0-9][A-Za-z0-9._:-]{2,127}$/.test(value.laneRunId) ||
+    containsCredentialShapedValue(value.laneRunId)
   ) {
-    return failClosedReason(`${shapeName}.kind is malformed`);
-  }
-
-  if (typeof value.path !== "string" || !isPortableLocalArtifactPath(value.path)) {
-    return failClosedReason(`${shapeName}.path is malformed`);
-  }
-
-  for (const field of ["kind", "path", "contentType", "description"]) {
-    const fieldValue = value[field];
-    if (typeof fieldValue === "string" && containsCredentialShapedValue(fieldValue)) {
-      return failClosedReason(`${shapeName}.${field} must not contain credential-shaped values`);
-    }
+    return failClosedReason(`${shapeName}.laneRunId is malformed`);
   }
 
   if (
-    value.contentType !== undefined &&
-    (typeof value.contentType !== "string" ||
-      !/^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*\/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*(?:; ?[A-Za-z0-9_.-]+=[A-Za-z0-9_.+-]+)*$/.test(
-        value.contentType
-      ))
+    typeof value.stateFile !== "string" ||
+    !isPortableLocalArtifactPath(value.stateFile) ||
+    containsCredentialShapedValue(value.stateFile)
   ) {
-    return failClosedReason(`${shapeName}.contentType is malformed`);
+    return failClosedReason(`${shapeName}.stateFile is malformed`);
   }
 
-  if (value.description !== undefined && !isNonEmptyString(value.description, 240)) {
-    return failClosedReason(`${shapeName}.description is malformed`);
+  if (!Array.isArray(value.evidenceMetadata) || value.evidenceMetadata.length === 0) {
+    return failClosedReason(`${shapeName}.evidenceMetadata must be a non-empty array`);
   }
 
-  if (value.checksum !== undefined) {
-    if (!isRecord(value.checksum)) {
-      return failClosedReason(`${shapeName}.checksum must be an object`);
-    }
-
-    const checksumUnknownProperty = findUnknownProperty(value.checksum, ["algorithm", "value"]);
-    if (checksumUnknownProperty !== undefined) {
-      return failClosedReason(
-        `${shapeName}.checksum has unsupported field ${checksumUnknownProperty}`
-      );
-    }
-
-    if (value.checksum.algorithm !== "sha256") {
-      return failClosedReason(`${shapeName}.checksum algorithm is unsupported`);
-    }
-
+  for (const [index, metadataPath] of value.evidenceMetadata.entries()) {
     if (
-      typeof value.checksum.value !== "string" ||
-      !/^[a-f0-9]{64}$/.test(value.checksum.value) ||
-      containsCredentialShapedValue(value.checksum.value)
+      typeof metadataPath !== "string" ||
+      !isPortableLocalArtifactPath(metadataPath) ||
+      containsCredentialShapedValue(metadataPath)
     ) {
-      return failClosedReason(`${shapeName}.checksum value is malformed`);
+      return failClosedReason(`${shapeName}.evidenceMetadata[${index}] is malformed`);
     }
   }
 
   return undefined;
 };
 
-const sanitizeXGate3LocalArtifact = (value: Record<string, unknown>): Record<string, unknown> => ({
-  kind: value.kind,
-  path: value.path,
-  ...(value.contentType === undefined ? {} : { contentType: value.contentType }),
-  ...(value.description === undefined ? {} : { description: value.description }),
-  ...(value.checksum === undefined ? {} : { checksum: value.checksum })
+const sanitizeXGate3LocalArtifacts = (
+  value: Record<string, unknown>
+): EnsenLoopXGate3LocalArtifactsV1 => ({
+  laneRunId: value.laneRunId as string,
+  stateFile: value.stateFile as string,
+  evidenceMetadata: [...(value.evidenceMetadata as string[])]
 });
 
 const validateRunRequest = (value: unknown): { message: string; reason: string } | undefined => {

--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -869,8 +869,14 @@ interface EnsenLoopXGate3LocalLaneSmokeAggregateV1 {
   writesProductionEvidenceArchive: false;
   statusSnapshot: EipRunStatusSnapshotV1;
   runResult: EipRunResultV1;
-  localArtifacts: EnsenLoopXGate3LocalArtifactsV1;
+  localArtifacts: EnsenLoopXGate3RawLocalArtifactsV1;
   evidenceBundleRef?: Record<string, unknown>;
+}
+
+interface EnsenLoopXGate3RawLocalArtifactsV1 {
+  laneRunId: string;
+  stateFile: string;
+  evidenceMetadata?: string[];
 }
 
 interface EnsenLoopXGate3LocalArtifactsV1 {
@@ -1061,9 +1067,7 @@ const enrichSmokeRunResult = (aggregate: EnsenLoopSmokeAggregateV1): EipRunResul
     extensions: {
       ...(aggregate.runResult.extensions ?? {}),
       "x-ensen-flow-local-lane": {
-        localArtifacts: sanitizeXGate3LocalArtifacts(
-          aggregate.localArtifacts as unknown as Record<string, unknown>
-        ),
+        localArtifacts: sanitizeXGate3LocalArtifacts(aggregate.localArtifacts),
         localArtifactSemantics: "local-development-references-only",
         productionEvidence: false
       }
@@ -1104,10 +1108,9 @@ const extractXGate3LocalLaneEvidence = (
     return undefined;
   }
 
+  const localArtifacts = localLane.localArtifacts as EnsenLoopXGate3RawLocalArtifactsV1;
   return {
-    localArtifacts: sanitizeXGate3LocalArtifacts(
-      localLane.localArtifacts as Record<string, unknown>
-    ),
+    localArtifacts: sanitizeXGate3LocalArtifacts(localArtifacts),
     localArtifactSemantics: "local-development-references-only",
     productionEvidence: false
   };
@@ -1399,11 +1402,11 @@ const validateXGate3LocalArtifacts = (
 };
 
 const sanitizeXGate3LocalArtifacts = (
-  value: Record<string, unknown>
+  value: EnsenLoopXGate3RawLocalArtifactsV1
 ): EnsenLoopXGate3LocalArtifactsV1 => ({
-  laneRunId: value.laneRunId as string,
-  stateFile: value.stateFile as string,
-  evidenceMetadata: [...((value.evidenceMetadata as string[] | undefined) ?? [])]
+  laneRunId: value.laneRunId,
+  stateFile: value.stateFile,
+  evidenceMetadata: [...(value.evidenceMetadata ?? [])]
 });
 
 const validateRunRequest = (value: unknown): { message: string; reason: string } | undefined => {

--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -1061,7 +1061,9 @@ const enrichSmokeRunResult = (aggregate: EnsenLoopSmokeAggregateV1): EipRunResul
     extensions: {
       ...(aggregate.runResult.extensions ?? {}),
       "x-ensen-flow-local-lane": {
-        localArtifacts: aggregate.localArtifacts,
+        localArtifacts: sanitizeXGate3LocalArtifacts(
+          aggregate.localArtifacts as unknown as Record<string, unknown>
+        ),
         localArtifactSemantics: "local-development-references-only",
         productionEvidence: false
       }
@@ -1378,11 +1380,12 @@ const validateXGate3LocalArtifacts = (
     return failClosedReason(`${shapeName}.stateFile is malformed`);
   }
 
-  if (!Array.isArray(value.evidenceMetadata) || value.evidenceMetadata.length === 0) {
-    return failClosedReason(`${shapeName}.evidenceMetadata must be a non-empty array`);
+  if (value.evidenceMetadata !== undefined && !Array.isArray(value.evidenceMetadata)) {
+    return failClosedReason(`${shapeName}.evidenceMetadata must be an array`);
   }
 
-  for (const [index, metadataPath] of value.evidenceMetadata.entries()) {
+  const evidenceMetadata = value.evidenceMetadata ?? [];
+  for (const [index, metadataPath] of evidenceMetadata.entries()) {
     if (
       typeof metadataPath !== "string" ||
       !isPortableLocalArtifactPath(metadataPath) ||
@@ -1400,7 +1403,7 @@ const sanitizeXGate3LocalArtifacts = (
 ): EnsenLoopXGate3LocalArtifactsV1 => ({
   laneRunId: value.laneRunId as string,
   stateFile: value.stateFile as string,
-  evidenceMetadata: [...(value.evidenceMetadata as string[])]
+  evidenceMetadata: [...((value.evidenceMetadata as string[] | undefined) ?? [])]
 });
 
 const validateRunRequest = (value: unknown): { message: string; reason: string } | undefined => {

--- a/test/cli-loop-executor-smoke.test.ts
+++ b/test/cli-loop-executor-smoke.test.ts
@@ -640,6 +640,87 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
 
   it.each([
     {
+      name: "empty evidenceMetadata",
+      localArtifacts: {
+        ...createXGate3Aggregate().localArtifacts,
+        evidenceMetadata: []
+      }
+    },
+    {
+      name: "omitted evidenceMetadata",
+      localArtifacts: {
+        laneRunId: createXGate3Aggregate().localArtifacts.laneRunId,
+        stateFile: createXGate3Aggregate().localArtifacts.stateFile
+      }
+    }
+  ])("accepts X-Gate 3 local artifacts with $name", async ({ localArtifacts }) => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-cli-loop-xgate3-metadata-"));
+    const cliPath = join(tempRoot, "loop-x-gate3-cli.mjs");
+    const aggregate = {
+      ...createXGate3Aggregate(),
+      localArtifacts
+    };
+
+    await writeFile(
+      cliPath,
+      [
+        "#!/usr/bin/env node",
+        "import { readFileSync } from 'node:fs';",
+        "const request = JSON.parse(readFileSync(process.argv[3], 'utf8'));",
+        `const aggregate = ${JSON.stringify(aggregate)};`,
+        "aggregate.requestId = request.id;",
+        "aggregate.correlationId = request.correlationId;",
+        "aggregate.statusSnapshot.requestId = request.id;",
+        "aggregate.statusSnapshot.correlationId = request.correlationId;",
+        "aggregate.runResult.requestId = request.id;",
+        "aggregate.runResult.correlationId = request.correlationId;",
+        "process.stdout.write(JSON.stringify(aggregate));",
+        ""
+      ].join("\n"),
+      "utf8"
+    );
+    await chmod(cliPath, 0o755);
+
+    try {
+      const connector = createEnsenLoopEipExecutorConnector({
+        transport: createCliEnsenLoopEipExecutorTransport({
+          command: process.execPath,
+          args: [cliPath, "x-gate3-smoke"]
+        })
+      });
+
+      const submitted = await connector.submit(createSmokeSubmitRequest());
+      expect(submitted).toMatchObject({
+        ok: true,
+        value: {
+          requestId: "req_cli_loop_smoke_loop_dry_run_1"
+        }
+      });
+
+      const result = await connector.status({ requestId: "req_cli_loop_smoke_loop_dry_run_1" });
+      expect(result).toMatchObject({
+        ok: true,
+        value: {
+          result: {
+            evidence: {
+              localArtifacts: {
+                laneRunId: "lane_xgate3_smoke",
+                stateFile: "state/x-gate3/lane-run.jsonl",
+                evidenceMetadata: []
+              },
+              localArtifactSemantics: "local-development-references-only",
+              productionEvidence: false
+            }
+          }
+        }
+      });
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    {
       name: "unknown top-level field",
       aggregate: {
         ...createXGate3Aggregate(),
@@ -698,6 +779,18 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
       },
       expectedMessage:
         "EIP XGate3LocalLaneSmokeAggregate writesProductionEvidenceArchive must be false"
+    },
+    {
+      name: "non-array evidence metadata",
+      aggregate: {
+        ...createXGate3Aggregate(),
+        localArtifacts: {
+          ...createXGate3Aggregate().localArtifacts,
+          evidenceMetadata: "evidence/run_01HV7Y8M8F2KQ5W3P9R6T4N2AB-bundle.json"
+        }
+      },
+      expectedMessage:
+        "EIP XGate3LocalLaneSmokeAggregate localArtifacts.evidenceMetadata must be an array"
     },
     {
       name: "traversing local artifact path",

--- a/test/cli-loop-executor-smoke.test.ts
+++ b/test/cli-loop-executor-smoke.test.ts
@@ -559,19 +559,14 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
         "      summary: 'Loop X-Gate 3 local fake lane succeeded.'",
         "    }",
         "  },",
-        "  localArtifacts: [",
-        "    {",
-        "      kind: 'aggregate-json',",
-        "      path: 'state/x-gate3/aggregate.json',",
-        "      contentType: 'application/json',",
-        "      description: 'Local X-Gate 3 smoke aggregate'",
-        "    },",
-        "    {",
-        "      kind: 'log',",
-        "      path: 'state/x-gate3/loop.log',",
-        "      contentType: 'text/plain'",
-        "    }",
-        "  ]",
+        "  localArtifacts: {",
+        "    laneRunId: 'lane_xgate3_smoke',",
+        "    stateFile: 'state/x-gate3/lane-run.jsonl',",
+        "    evidenceMetadata: [",
+        "      'evidence/run_01HV7Y8M8F2KQ5W3P9R6T4N2AB-bundle.json',",
+        "      'evidence/run_01HV7Y8M8F2KQ5W3P9R6T4N2AB-lane.json'",
+        "    ]",
+        "  }",
         "}; }",
         ""
       ].join("\n"),
@@ -624,16 +619,14 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
             status,
             summary,
             evidence: {
-              localArtifacts: [
-                {
-                  kind: "aggregate-json",
-                  path: "state/x-gate3/aggregate.json"
-                },
-                {
-                  kind: "log",
-                  path: "state/x-gate3/loop.log"
-                }
-              ],
+              localArtifacts: {
+                laneRunId: "lane_xgate3_smoke",
+                stateFile: "state/x-gate3/lane-run.jsonl",
+                evidenceMetadata: [
+                  "evidence/run_01HV7Y8M8F2KQ5W3P9R6T4N2AB-bundle.json",
+                  "evidence/run_01HV7Y8M8F2KQ5W3P9R6T4N2AB-lane.json"
+                ]
+              },
               localArtifactSemantics: "local-development-references-only",
               productionEvidence: false
             }
@@ -710,98 +703,96 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
       name: "traversing local artifact path",
       aggregate: {
         ...createXGate3Aggregate(),
-        localArtifacts: [
-          {
-            kind: "aggregate-json",
-            path: "../state/x-gate3/aggregate.json"
-          }
-        ]
+        localArtifacts: {
+          ...createXGate3Aggregate().localArtifacts,
+          evidenceMetadata: ["../state/x-gate3/aggregate.json"]
+        }
       },
-      expectedMessage: "EIP XGate3LocalLaneSmokeAggregate localArtifacts[0].path is malformed"
+      expectedMessage:
+        "EIP XGate3LocalLaneSmokeAggregate localArtifacts.evidenceMetadata[0] is malformed"
     },
     {
       name: "absolute local artifact path",
       aggregate: {
         ...createXGate3Aggregate(),
-        localArtifacts: [
-          {
-            kind: "aggregate-json",
-            path: "/tmp/x-gate3/aggregate.json"
-          }
-        ]
+        localArtifacts: {
+          ...createXGate3Aggregate().localArtifacts,
+          evidenceMetadata: ["/tmp/x-gate3/aggregate.json"]
+        }
       },
-      expectedMessage: "EIP XGate3LocalLaneSmokeAggregate localArtifacts[0].path is malformed"
+      expectedMessage:
+        "EIP XGate3LocalLaneSmokeAggregate localArtifacts.evidenceMetadata[0] is malformed"
     },
     {
       name: "home-relative local artifact path",
       aggregate: {
         ...createXGate3Aggregate(),
-        localArtifacts: [
-          {
-            kind: "aggregate-json",
-            path: "~/state/x-gate3/aggregate.json"
-          }
-        ]
+        localArtifacts: {
+          ...createXGate3Aggregate().localArtifacts,
+          evidenceMetadata: ["~/state/x-gate3/aggregate.json"]
+        }
       },
-      expectedMessage: "EIP XGate3LocalLaneSmokeAggregate localArtifacts[0].path is malformed"
+      expectedMessage:
+        "EIP XGate3LocalLaneSmokeAggregate localArtifacts.evidenceMetadata[0] is malformed"
     },
     {
       name: "user-home-relative local artifact path",
       aggregate: {
         ...createXGate3Aggregate(),
-        localArtifacts: [
-          {
-            kind: "aggregate-json",
-            path: "~operator/state/x-gate3/aggregate.json"
-          }
-        ]
-      },
-      expectedMessage: "EIP XGate3LocalLaneSmokeAggregate localArtifacts[0].path is malformed"
-    },
-    {
-      name: "credential-shaped local artifact value",
-      aggregate: {
-        ...createXGate3Aggregate(),
-        localArtifacts: [
-          {
-            kind: "log",
-            path: "state/x-gate3/log.txt",
-            description: "token=sample-secret"
-          }
-        ]
+        localArtifacts: {
+          ...createXGate3Aggregate().localArtifacts,
+          evidenceMetadata: ["~operator/state/x-gate3/aggregate.json"]
+        }
       },
       expectedMessage:
-        "EIP XGate3LocalLaneSmokeAggregate localArtifacts[0].description must not contain credential-shaped values"
+        "EIP XGate3LocalLaneSmokeAggregate localArtifacts.evidenceMetadata[0] is malformed"
+    },
+    {
+      name: "unsafe state file path",
+      aggregate: {
+        ...createXGate3Aggregate(),
+        localArtifacts: {
+          ...createXGate3Aggregate().localArtifacts,
+          stateFile: "../state/x-gate3/lane-run.jsonl"
+        }
+      },
+      expectedMessage: "EIP XGate3LocalLaneSmokeAggregate localArtifacts.stateFile is malformed"
+    },
+    {
+      name: "credential-shaped local artifact metadata path",
+      aggregate: {
+        ...createXGate3Aggregate(),
+        localArtifacts: {
+          ...createXGate3Aggregate().localArtifacts,
+          evidenceMetadata: ["state/x-gate3/token=sample-secret/log.txt"]
+        }
+      },
+      expectedMessage:
+        "EIP XGate3LocalLaneSmokeAggregate localArtifacts.evidenceMetadata[0] is malformed"
     },
     {
       name: "underscore-delimited GitHub token artifact value",
       aggregate: {
         ...createXGate3Aggregate(),
-        localArtifacts: [
-          {
-            kind: "log",
-            path: "state/x-gate3/log.txt",
-            description: "ghp_sampletokenvalue"
-          }
-        ]
+        localArtifacts: {
+          ...createXGate3Aggregate().localArtifacts,
+          evidenceMetadata: ["state/x-gate3/ghp_sampletokenvalue/log.txt"]
+        }
       },
       expectedMessage:
-        "EIP XGate3LocalLaneSmokeAggregate localArtifacts[0].description must not contain credential-shaped values"
+        "EIP XGate3LocalLaneSmokeAggregate localArtifacts.evidenceMetadata[0] is malformed"
     },
     {
       name: "underscore-delimited GitHub fine-grained token artifact value",
       aggregate: {
         ...createXGate3Aggregate(),
-        localArtifacts: [
-          {
-            kind: "log",
-            path: "state/x-gate3/log.txt",
-            description: "github_pat_sampletokenvalue"
-          }
-        ]
+        localArtifacts: {
+          ...createXGate3Aggregate().localArtifacts,
+          evidenceMetadata: ["state/x-gate3/github_pat_sampletokenvalue/log.txt"]
+        }
       },
       expectedMessage:
-        "EIP XGate3LocalLaneSmokeAggregate localArtifacts[0].description must not contain credential-shaped values"
+        "EIP XGate3LocalLaneSmokeAggregate localArtifacts.evidenceMetadata[0] is malformed"
     }
   ])("rejects malformed X-Gate 3 local lane aggregate $name", async ({
     aggregate,
@@ -853,13 +844,16 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
     {
       name: "unsupported local artifact field",
       extension: {
-        localArtifacts: [
-          {
-            kind: "aggregate-json",
-            path: "state/x-gate3/aggregate.json",
-            durableEvidenceArchive: true
-          }
-        ],
+        localArtifacts: {
+          ...createXGate3Aggregate().localArtifacts,
+          evidenceMetadata: [
+            {
+              kind: "aggregate-json",
+              path: "state/x-gate3/aggregate.json",
+              durableEvidenceArchive: true
+            }
+          ]
+        },
         localArtifactSemantics: "local-development-references-only",
         productionEvidence: false
       }
@@ -995,10 +989,14 @@ describe("CLI-backed Ensen-loop executor smoke", () => {
         "      completedAt: '2026-05-01T04:00:03.000Z',",
         "      verification: { status: 'passed', summary: 'Loop X-Gate 3 local fake lane succeeded.' }",
         "    },",
-        "    localArtifacts: [",
-        "      { kind: 'aggregate-json', path: 'state/x-gate3/aggregate.json' },",
-        "      { kind: 'log', path: 'state/x-gate3/loop.log' }",
-        "    ]",
+        "    localArtifacts: {",
+        "      laneRunId: 'lane_xgate3_roots',",
+        "      stateFile: 'state/x-gate3/lane-run.jsonl',",
+        "      evidenceMetadata: [",
+        "        'evidence/run_01HV7Y8M8F2KQ5W3P9R6T4N2AB-bundle.json',",
+        "        'evidence/run_01HV7Y8M8F2KQ5W3P9R6T4N2AB-lane.json'",
+        "      ]",
+        "    }",
         "  }));",
         "}",
         ""
@@ -1304,19 +1302,14 @@ const createXGate3Aggregate = () => ({
       summary: "Loop X-Gate 3 local fake lane succeeded."
     }
   },
-  localArtifacts: [
-    {
-      kind: "aggregate-json",
-      path: "state/x-gate3/aggregate.json",
-      contentType: "application/json",
-      description: "Local X-Gate 3 smoke aggregate"
-    },
-    {
-      kind: "log",
-      path: "state/x-gate3/loop.log",
-      contentType: "text/plain"
-    }
-  ]
+  localArtifacts: {
+    laneRunId: "lane_xgate3_smoke",
+    stateFile: "state/x-gate3/lane-run.jsonl",
+    evidenceMetadata: [
+      "evidence/run_01HV7Y8M8F2KQ5W3P9R6T4N2AB-bundle.json",
+      "evidence/run_01HV7Y8M8F2KQ5W3P9R6T4N2AB-lane.json"
+    ]
+  }
 });
 
 const createSmokeSubmitRequest = (): ExecutorSubmitRequest => ({

--- a/test/workflow-runner.test.ts
+++ b/test/workflow-runner.test.ts
@@ -498,14 +498,11 @@ describe("sequential workflow runner", () => {
                 ...(resultStatus === "succeeded"
                   ? {}
                   : { errors: [{ code: resultStatus, message: summary }] }),
-                localArtifacts: [
-                  {
-                    kind: "aggregate-json",
-                    path: "state/x-gate3/aggregate.json",
-                    contentType: "application/json",
-                    description: "Local X-Gate 3 smoke aggregate"
-                  }
-                ],
+                localArtifacts: {
+                  laneRunId: `lane_xgate3_${executorStatus}`,
+                  stateFile: "state/x-gate3/lane-run.jsonl",
+                  evidenceMetadata: ["evidence/run_01HV7Y8M8F2KQ5W3P9R6T4N2AB-bundle.json"]
+                },
                 localArtifactSemantics: "local-development-references-only",
                 productionEvidence: false
               }
@@ -530,12 +527,13 @@ describe("sequential workflow runner", () => {
                     status: resultStatus === "succeeded" ? "passed" : resultStatus,
                     summary
                   },
-                  localArtifacts: [
-                    {
-                      kind: "aggregate-json",
-                      path: "state/x-gate3/aggregate.json"
-                    }
-                  ],
+                  localArtifacts: {
+                    laneRunId: `lane_xgate3_${executorStatus}`,
+                    stateFile: "state/x-gate3/lane-run.jsonl",
+                    evidenceMetadata: [
+                      "evidence/run_01HV7Y8M8F2KQ5W3P9R6T4N2AB-bundle.json"
+                    ]
+                  },
                   localArtifactSemantics: "local-development-references-only",
                   productionEvidence: false
                 }

--- a/test/x-gate3-flow-smoke.test.ts
+++ b/test/x-gate3-flow-smoke.test.ts
@@ -103,16 +103,14 @@ describe("Flow X-Gate 3 caller smoke", () => {
                     status: laneStatus === "succeeded" ? "passed" : laneStatus,
                     summary
                   },
-                  localArtifacts: [
-                    {
-                      kind: "aggregate-json",
-                      path: "state/x-gate3/aggregate.json"
-                    },
-                    {
-                      kind: "log",
-                      path: "state/x-gate3/loop.log"
-                    }
-                  ],
+                  localArtifacts: {
+                    laneRunId: `lane_flow_xgate3_${laneStatus}`,
+                    stateFile: "state/x-gate3/lane-run.jsonl",
+                    evidenceMetadata: [
+                      "evidence/run_01HV7Y8M8F2KQ5W3P9R6T4N2AB-bundle.json",
+                      "evidence/run_01HV7Y8M8F2KQ5W3P9R6T4N2AB-lane.json"
+                    ]
+                  },
                   localArtifactSemantics: "local-development-references-only",
                   productionEvidence: false
                 }
@@ -406,10 +404,14 @@ const writeLoopXGate3SmokeCli = async (
       "      },",
       "      warnings: [{ code: 'local-lane-only', message: 'Local smoke reference only.' }]",
       "    },",
-      "    localArtifacts: [",
-      "      { kind: 'aggregate-json', path: 'state/x-gate3/aggregate.json', contentType: 'application/json', description: 'Local X-Gate 3 smoke aggregate' },",
-      "      { kind: 'log', path: 'state/x-gate3/loop.log', contentType: 'text/plain' }",
-      "    ]",
+      "    localArtifacts: {",
+      `      laneRunId: ${JSON.stringify(`lane_flow_xgate3_${input.laneStatus}`)},`,
+      "      stateFile: 'state/x-gate3/lane-run.jsonl',",
+      "      evidenceMetadata: [",
+      "        'evidence/run_01HV7Y8M8F2KQ5W3P9R6T4N2AB-bundle.json',",
+      "        'evidence/run_01HV7Y8M8F2KQ5W3P9R6T4N2AB-lane.json'",
+      "      ]",
+      "    }",
       "  }));",
       "}",
       "void workspaceRoot;",


### PR DESCRIPTION
## Summary
- accept the real Loop X-Gate 3 localArtifacts object with laneRunId, stateFile, and evidenceMetadata path entries
- preserve local artifact references only as local development metadata with productionEvidence false
- update X-Gate 3 smoke regressions and fail-closed path checks for unsafe state/evidence paths

## Verification
- npm ci
- npm run build
- npm test -- test/cli-loop-executor-smoke.test.ts
- npm test -- test/x-gate3-flow-smoke.test.ts
- focused local check invoking sibling Ensen-loop x-gate3-smoke through Flow connector
- npm test

Closes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated local artifact references into a single structured object (includes laneRunId and state file) and updated CLI payloads to use this shape.
* **Bug Fixes**
  * Strengthened validation/sanitization of the new local-artifacts object, removed array-length assumptions, and reject credential-shaped values.
* **Tests**
  * Updated tests/fixtures and added cases for empty/omitted evidenceMetadata and new evidence flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->