### PR TITLE
FLOW-040: Add schedule trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ A lightweight workflow orchestration engine.
 This repository is in the Phase 1 baseline stage. The current package exposes a
 minimal TypeScript scaffold plus the initial standalone workflow definition
 schema, append-only JSONL workflow run state helpers, a local sequential runner,
-and neutral audit JSONL events. It does not implement executor connectors,
-Ensen-loop integration, ERPNext behavior, or Pharma/GxP workflow packs yet.
+neutral audit JSONL events, and a bounded local schedule trigger evaluator. It
+does not implement executor connectors, Ensen-loop integration, ERPNext
+behavior, or Pharma/GxP workflow packs yet.
 
 Use the same commands locally that CI runs:
 
@@ -50,6 +51,16 @@ The initial standalone workflow definition schema is documented in
 It validates versioned workflow definitions, stable workflow and step IDs,
 trigger shape, dependencies, retry policy, neutral actions, and idempotency key
 semantics without contacting Ensen-loop or external executor connectors.
+
+Schedule triggers are a local definition and test helper boundary only. A
+workflow may declare `trigger.type: "schedule"` with a five-field UTC cron shape
+using `*` or numeric values, and callers may deterministically evaluate one
+candidate scheduled instant with `evaluateScheduleTrigger`. The helper derives a
+stable run ID and JSONL state path from the scheduled instant, so repeating the
+same evaluation returns the existing terminal run instead of creating an
+unexpected duplicate. Ensen-flow does not run a background scheduler daemon, cron
+service integration, cloud scheduler, external calendar integration, or
+production time-zone policy.
 
 ## Workflow Run JSONL State
 

--- a/docs/workflow-definition.md
+++ b/docs/workflow-definition.md
@@ -27,6 +27,15 @@ persistence behavior, executor connector configuration, or real Slack, Teams,
 ERPNext, GitHub, or other connector behavior. Those concerns are deferred to
 later Phase 1 issues.
 
+Schedule triggers are intentionally small. The schema accepts only a local
+`schedule` trigger with a `cron` string containing five UTC minute fields. Each
+field must be either `*` or a numeric value in the field range. The runtime
+helper `evaluateScheduleTrigger` can evaluate one supplied `scheduledFor`
+timestamp against that cron expression in local tests, derive a deterministic
+run ID and JSONL state path, and preserve trigger idempotency. This is not a
+long-running scheduler daemon, cron service integration, cloud scheduler,
+external calendar integration, or production time-zone policy.
+
 Runner audit output is intentionally separate from the workflow definition
 schema. The Phase 1 runner writes an internal neutral JSONL audit shape for
 local lifecycle activity only; a formal mapping to EIP AuditEvent is deferred to
@@ -72,6 +81,32 @@ runtime dispatch implementation.
         "backoff": {
           "strategy": "none"
         }
+      }
+    }
+  ]
+}
+```
+
+A bounded schedule trigger uses the same workflow shape with a schedule trigger:
+
+```json
+{
+  "schemaVersion": "flow.workflow.v1",
+  "id": "local-schedule-demo",
+  "trigger": {
+    "type": "schedule",
+    "cron": "0 9 * * *",
+    "idempotencyKey": {
+      "source": "workflow",
+      "template": "{workflow.id}:{trigger.type}:{trigger.scheduledFor}"
+    }
+  },
+  "steps": [
+    {
+      "id": "scheduled-step",
+      "action": {
+        "type": "local",
+        "name": "scheduled_noop"
       }
     }
   ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,11 @@ export {
   runWorkflow
 } from "./workflow-runner.js";
 
+export {
+  evaluateScheduleTrigger,
+  isDueForSchedule
+} from "./schedule-trigger.js";
+
 export type {
   IdempotencyKeyDefinition,
   RetryBackoffPolicy,
@@ -159,6 +164,12 @@ export type {
   WorkflowStepHandlerInput,
   WorkflowStepHandlerResult
 } from "./workflow-runner.js";
+
+export type {
+  EvaluateScheduleTriggerInput,
+  ScheduleTriggerEvaluationResult,
+  ScheduleTriggerNotDueResult
+} from "./schedule-trigger.js";
 
 export type {
   CreateLocalAuditEventWriterInput,

--- a/src/schedule-trigger.ts
+++ b/src/schedule-trigger.ts
@@ -9,6 +9,9 @@ import type { WorkflowDefinition } from "./workflow-definition.js";
 import { runWorkflow } from "./workflow-runner.js";
 import type { WorkflowStepHandler } from "./workflow-runner.js";
 
+const SCHEDULED_FOR_UTC_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{3}))?Z$/;
+
 export interface EvaluateScheduleTriggerInput {
   definition: WorkflowDefinition;
   stateRoot: string;
@@ -30,6 +33,8 @@ export type ScheduleTriggerEvaluationResult =
 export const evaluateScheduleTrigger = async (
   input: EvaluateScheduleTriggerInput
 ): Promise<ScheduleTriggerEvaluationResult> => {
+  const scheduledFor = normalizeScheduledForUtc(input.scheduledFor);
+
   const validation = validateWorkflowDefinition(input.definition);
   if (!validation.valid) {
     const details = validation.errors
@@ -42,14 +47,14 @@ export const evaluateScheduleTrigger = async (
     throw new Error("evaluateScheduleTrigger requires a schedule trigger workflow");
   }
 
-  if (!isDueForSchedule(input.definition.trigger.cron, input.scheduledFor)) {
+  if (!isDueForSchedule(input.definition.trigger.cron, scheduledFor)) {
     return {
       status: "not-due",
       reason: "scheduledFor does not match trigger.cron"
     };
   }
 
-  const runId = createScheduleRunId(input.definition.id, input.scheduledFor);
+  const runId = createScheduleRunId(input.definition.id, scheduledFor);
   return runWorkflow({
     definition: input.definition,
     statePath: join(input.stateRoot, `${runId}.jsonl`),
@@ -58,7 +63,7 @@ export const evaluateScheduleTrigger = async (
     triggerContext: {
       schedule: {
         cron: input.definition.trigger.cron,
-        scheduledFor: input.scheduledFor
+        scheduledFor
       }
     },
     now: input.now,
@@ -71,8 +76,8 @@ export const isDueForSchedule = (cron: string, scheduledFor: string): boolean =>
     return false;
   }
 
-  const scheduledForDate = new Date(scheduledFor);
-  if (!Number.isFinite(scheduledForDate.getTime())) {
+  const scheduledForDate = parseScheduledForUtc(scheduledFor);
+  if (scheduledForDate === undefined) {
     return false;
   }
 
@@ -93,3 +98,29 @@ const createScheduleRunId = (workflowId: string, scheduledFor: string): string =
 
 const compactTimestamp = (value: string): string =>
   value.replaceAll("-", "").replaceAll(":", "").replace(".", "").replace("Z", "Z");
+
+const parseScheduledForUtc = (value: string): Date | undefined => {
+  const match = SCHEDULED_FOR_UTC_PATTERN.exec(value);
+  if (match === null) {
+    return undefined;
+  }
+
+  const parsed = new Date(value);
+  if (!Number.isFinite(parsed.getTime())) {
+    return undefined;
+  }
+
+  const canonicalInput = `${match[1]}-${match[2]}-${match[3]}T${match[4]}:${match[5]}:${match[6]}.${
+    match[7] ?? "000"
+  }Z`;
+  return parsed.toISOString() === canonicalInput ? parsed : undefined;
+};
+
+const normalizeScheduledForUtc = (value: string): string => {
+  const parsed = parseScheduledForUtc(value);
+  if (parsed === undefined) {
+    throw new Error("scheduledFor must be an ISO-8601 UTC timestamp");
+  }
+
+  return parsed.toISOString();
+};

--- a/src/schedule-trigger.ts
+++ b/src/schedule-trigger.ts
@@ -1,0 +1,95 @@
+import { join } from "node:path";
+
+import type { WorkflowRunState } from "./workflow-run-state.js";
+import {
+  isValidScheduleCronExpression,
+  validateWorkflowDefinition
+} from "./workflow-definition.js";
+import type { WorkflowDefinition } from "./workflow-definition.js";
+import { runWorkflow } from "./workflow-runner.js";
+import type { WorkflowStepHandler } from "./workflow-runner.js";
+
+export interface EvaluateScheduleTriggerInput {
+  definition: WorkflowDefinition;
+  stateRoot: string;
+  auditPath?: string;
+  scheduledFor: string;
+  now?: () => string;
+  stepHandler?: WorkflowStepHandler;
+}
+
+export interface ScheduleTriggerNotDueResult {
+  status: "not-due";
+  reason: "scheduledFor does not match trigger.cron";
+}
+
+export type ScheduleTriggerEvaluationResult =
+  | WorkflowRunState
+  | ScheduleTriggerNotDueResult;
+
+export const evaluateScheduleTrigger = async (
+  input: EvaluateScheduleTriggerInput
+): Promise<ScheduleTriggerEvaluationResult> => {
+  const validation = validateWorkflowDefinition(input.definition);
+  if (!validation.valid) {
+    const details = validation.errors
+      .map((error) => `${error.path}: ${error.message}`)
+      .join("; ");
+    throw new Error(`workflow definition is invalid: ${details}`);
+  }
+
+  if (input.definition.trigger.type !== "schedule") {
+    throw new Error("evaluateScheduleTrigger requires a schedule trigger workflow");
+  }
+
+  if (!isDueForSchedule(input.definition.trigger.cron, input.scheduledFor)) {
+    return {
+      status: "not-due",
+      reason: "scheduledFor does not match trigger.cron"
+    };
+  }
+
+  const runId = createScheduleRunId(input.definition.id, input.scheduledFor);
+  return runWorkflow({
+    definition: input.definition,
+    statePath: join(input.stateRoot, `${runId}.jsonl`),
+    auditPath: input.auditPath,
+    runId,
+    triggerContext: {
+      schedule: {
+        cron: input.definition.trigger.cron,
+        scheduledFor: input.scheduledFor
+      }
+    },
+    now: input.now,
+    stepHandler: input.stepHandler
+  });
+};
+
+export const isDueForSchedule = (cron: string, scheduledFor: string): boolean => {
+  if (!isValidScheduleCronExpression(cron)) {
+    return false;
+  }
+
+  const scheduledForDate = new Date(scheduledFor);
+  if (!Number.isFinite(scheduledForDate.getTime())) {
+    return false;
+  }
+
+  const fields = cron.trim().split(/\s+/);
+  const dateFields = [
+    scheduledForDate.getUTCMinutes(),
+    scheduledForDate.getUTCHours(),
+    scheduledForDate.getUTCDate(),
+    scheduledForDate.getUTCMonth() + 1,
+    scheduledForDate.getUTCDay()
+  ];
+
+  return fields.every((field, index) => field === "*" || Number(field) === dateFields[index]);
+};
+
+const createScheduleRunId = (workflowId: string, scheduledFor: string): string =>
+  `${workflowId}-scheduled-${compactTimestamp(scheduledFor)}`;
+
+const compactTimestamp = (value: string): string =>
+  value.replaceAll("-", "").replaceAll(":", "").replace(".", "").replace("Z", "Z");

--- a/src/workflow-definition.ts
+++ b/src/workflow-definition.ts
@@ -5,6 +5,13 @@ import {
 
 const WORKFLOW_SCHEMA_VERSION = "flow.workflow.v1";
 
+const CRON_FIELD_SPECS = [
+  { name: "minute", min: 0, max: 59 },
+  { name: "hour", min: 0, max: 23 },
+  { name: "day-of-month", min: 1, max: 31 },
+  { name: "month", min: 1, max: 12 },
+  { name: "day-of-week", min: 0, max: 6 }
+] as const;
 const TRIGGER_TYPES = new Set(["manual", "schedule", "webhook"]);
 const ACTION_TYPES = new Set(["local", "approval", "notification"]);
 const IDEMPOTENCY_KEY_SOURCES = new Set(["input", "workflow", "static"]);
@@ -150,6 +157,27 @@ export interface WorkflowDefinitionValidationResult {
 export const workflowDefinitionSchemaVersion: WorkflowSchemaVersion =
   WORKFLOW_SCHEMA_VERSION;
 
+export const isValidScheduleCronExpression = (value: string): boolean => {
+  const fields = value.trim().split(/\s+/);
+  if (fields.length !== CRON_FIELD_SPECS.length) {
+    return false;
+  }
+
+  return fields.every((field, index) => {
+    if (field === "*") {
+      return true;
+    }
+
+    if (!/^\d+$/.test(field)) {
+      return false;
+    }
+
+    const numericField = Number(field);
+    const spec = CRON_FIELD_SPECS[index];
+    return Number.isInteger(numericField) && numericField >= spec.min && numericField <= spec.max;
+  });
+};
+
 export const validateWorkflowDefinition = (
   value: unknown
 ): WorkflowDefinitionValidationResult => {
@@ -209,6 +237,16 @@ const validateTrigger = (
 
   if (triggerType === "schedule") {
     requireNonEmptyString(value, "cron", "trigger.cron", errors);
+    if (
+      typeof value.cron === "string" &&
+      value.cron.trim() !== "" &&
+      !isValidScheduleCronExpression(value.cron)
+    ) {
+      errors.push({
+        path: "trigger.cron",
+        message: "schedule cron must use five UTC minute fields with * or numeric values"
+      });
+    }
   }
 
   if (triggerType === "webhook") {

--- a/src/workflow-runner.ts
+++ b/src/workflow-runner.ts
@@ -460,8 +460,21 @@ const resolveIdempotencyKey = (
       .replaceAll("{workflow.id}", workflow.id)
       .replaceAll("{step.id}", step?.id ?? "")
       .replaceAll("{trigger.type}", workflow.trigger.type)
+      .replaceAll("{trigger.scheduledFor}", resolveScheduledFor(triggerContext))
       .replaceAll("{trigger.idempotencyKey}", resolveTriggerKey(triggerContext))
   };
+};
+
+const resolveScheduledFor = (triggerContext: Record<string, unknown>): string => {
+  const schedule = triggerContext.schedule;
+  if (!isRecord(schedule)) {
+    return "";
+  }
+
+  const scheduledFor = schedule.scheduledFor;
+  return typeof scheduledFor === "string" || typeof scheduledFor === "number"
+    ? String(scheduledFor)
+    : "";
 };
 
 const resolveTriggerKey = (triggerContext: Record<string, unknown>): string => {

--- a/test/schedule-trigger.test.ts
+++ b/test/schedule-trigger.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   evaluateScheduleTrigger,
+  isDueForSchedule,
   readWorkflowRunState,
   validateWorkflowDefinition
 } from "../src/index.js";
@@ -105,7 +106,7 @@ describe("schedule trigger", () => {
       definition,
       stateRoot,
       auditPath,
-      scheduledFor: "2026-05-02T09:00:00.000Z"
+      scheduledFor: "2026-05-02T09:00:00Z"
     });
 
     if (!("run" in first) || !("run" in second)) {
@@ -169,5 +170,22 @@ describe("schedule trigger", () => {
     await expect(
       readFile(join(stateRoot, "local-schedule-demo-scheduled-20260502T090100000Z.jsonl"), "utf8")
     ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects offset-less or malformed scheduledFor values before cron matching", async () => {
+    const root = await createTempRoot();
+    const stateRoot = join(root, "runs");
+
+    expect(isDueForSchedule("0 9 * * *", "2026-05-02T09:00:00")).toBe(false);
+    expect(isDueForSchedule("0 9 * * *", "2026/05/02 09:00:00Z")).toBe(false);
+    expect(isDueForSchedule("0 9 * * *", "2026-02-31T09:00:00Z")).toBe(false);
+
+    await expect(
+      evaluateScheduleTrigger({
+        definition: createScheduleWorkflow(),
+        stateRoot,
+        scheduledFor: "2026-05-02T09:00:00"
+      })
+    ).rejects.toThrow("scheduledFor must be an ISO-8601 UTC timestamp");
   });
 });

--- a/test/schedule-trigger.test.ts
+++ b/test/schedule-trigger.test.ts
@@ -1,0 +1,173 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  evaluateScheduleTrigger,
+  readWorkflowRunState,
+  validateWorkflowDefinition
+} from "../src/index.js";
+import type { WorkflowDefinition } from "../src/index.js";
+
+const tempRoots: string[] = [];
+
+const createScheduleWorkflow = (): WorkflowDefinition => ({
+  schemaVersion: "flow.workflow.v1",
+  id: "local-schedule-demo",
+  trigger: {
+    type: "schedule",
+    cron: "0 9 * * *",
+    idempotencyKey: {
+      source: "workflow",
+      template: "{workflow.id}:{trigger.type}:{trigger.scheduledFor}"
+    }
+  },
+  steps: [
+    {
+      id: "scheduled-step",
+      action: {
+        type: "local",
+        name: "scheduled_noop"
+      }
+    }
+  ]
+});
+
+const createTempRoot = async () => {
+  const root = await mkdtemp(join(tmpdir(), "ensen-flow-schedule-"));
+  tempRoots.push(root);
+  return root;
+};
+
+const readAuditEvents = async (auditPath: string): Promise<Array<Record<string, unknown>>> =>
+  (await readFile(auditPath, "utf8"))
+    .trimEnd()
+    .split("\n")
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
+  );
+});
+
+describe("schedule trigger", () => {
+  it("accepts the bounded local schedule trigger shape", () => {
+    const result = validateWorkflowDefinition(createScheduleWorkflow());
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("rejects malformed schedule trigger input", () => {
+    const definition = createScheduleWorkflow();
+    definition.trigger = {
+      type: "schedule",
+      cron: "every morning"
+    };
+
+    const result = validateWorkflowDefinition(definition);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual([
+      {
+        path: "trigger.cron",
+        message: "schedule cron must use five UTC minute fields with * or numeric values"
+      }
+    ]);
+  });
+
+  it("evaluates a due schedule once and returns the same terminal run on repeat", async () => {
+    const definition = createScheduleWorkflow();
+    const root = await createTempRoot();
+    const stateRoot = join(root, "runs");
+    const auditPath = join(root, "audit", "schedule.audit.jsonl");
+
+    const first = await evaluateScheduleTrigger({
+      definition,
+      stateRoot,
+      auditPath,
+      scheduledFor: "2026-05-02T09:00:00.000Z",
+      now: (() => {
+        let index = 0;
+        const timestamps = [
+          "2026-05-02T09:00:01.000Z",
+          "2026-05-02T09:00:02.000Z",
+          "2026-05-02T09:00:03.000Z",
+          "2026-05-02T09:00:04.000Z"
+        ];
+        return () => timestamps[index++] ?? "2026-05-02T09:00:05.000Z";
+      })()
+    });
+    const second = await evaluateScheduleTrigger({
+      definition,
+      stateRoot,
+      auditPath,
+      scheduledFor: "2026-05-02T09:00:00.000Z"
+    });
+
+    if (!("run" in first) || !("run" in second)) {
+      throw new Error("schedule should have produced a workflow run");
+    }
+
+    expect(second).toEqual(first);
+    expect(first.run.runId).toBe("local-schedule-demo-scheduled-20260502T090000000Z");
+    expect(first.run.trigger).toEqual({
+      type: "schedule",
+      receivedAt: "2026-05-02T09:00:01.000Z",
+      context: {
+        schedule: {
+          cron: "0 9 * * *",
+          scheduledFor: "2026-05-02T09:00:00.000Z"
+        }
+      },
+      idempotencyKey: {
+        source: "workflow",
+        key: "local-schedule-demo:schedule:2026-05-02T09:00:00.000Z"
+      }
+    });
+
+    const persisted = await readWorkflowRunState(
+      join(stateRoot, "local-schedule-demo-scheduled-20260502T090000000Z.jsonl")
+    );
+    expect(persisted.events.map((event) => event.type)).toEqual([
+      "run.created",
+      "step.attempt.started",
+      "step.attempt.completed",
+      "run.completed"
+    ]);
+
+    const auditEvents = await readAuditEvents(auditPath);
+    expect(auditEvents.map((event) => event.type)).toEqual([
+      "workflow.started",
+      "step.started",
+      "step.completed",
+      "workflow.completed"
+    ]);
+    expect(auditEvents[0]).toMatchObject({
+      id: "audit.local-schedule-demo-scheduled-20260502T090000000Z.000001",
+      run: { id: "local-schedule-demo-scheduled-20260502T090000000Z" }
+    });
+  });
+
+  it("does not create run state when the schedule is not due", async () => {
+    const root = await createTempRoot();
+    const stateRoot = join(root, "runs");
+
+    const result = await evaluateScheduleTrigger({
+      definition: createScheduleWorkflow(),
+      stateRoot,
+      scheduledFor: "2026-05-02T09:01:00.000Z"
+    });
+
+    expect(result).toEqual({
+      status: "not-due",
+      reason: "scheduledFor does not match trigger.cron"
+    });
+    await expect(
+      readFile(join(stateRoot, "local-schedule-demo-scheduled-20260502T090100000Z.jsonl"), "utf8")
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});


### PR DESCRIPTION
## Summary
- add strict bounded five-field UTC schedule trigger validation
- add deterministic local schedule evaluation with stable scheduled run IDs and idempotent repeat behavior
- document the local schedule trigger boundary and non-goals

## Verification
- npm run build
- npm test -- test/schedule-trigger.test.ts
- npm test

Closes #62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local-only schedule trigger support (UTC five-field cron) with deterministic, idempotent evaluations.
  * New public evaluation APIs: evaluateScheduleTrigger and isDueForSchedule.
* **Documentation**
  * Updated README and workflow-definition docs with usage, constraints, and examples.
* **Tests**
  * Added end-to-end tests covering due/not-due behavior, idempotency, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->