### PR TITLE
FLOW-041: Add webhook intake boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A lightweight workflow orchestration engine.
 This repository is in the Phase 1 baseline stage. The current package exposes a
 minimal TypeScript scaffold plus the initial standalone workflow definition
 schema, append-only JSONL workflow run state helpers, a local sequential runner,
-neutral audit JSONL events, and a bounded local schedule trigger evaluator. It
+neutral audit JSONL events, a bounded local schedule trigger evaluator, and a
+bounded local webhook intake helper. It
 does not implement executor connectors, Ensen-loop integration, ERPNext
 behavior, or Pharma/GxP workflow packs yet.
 
@@ -61,6 +62,15 @@ same evaluation returns the existing terminal run instead of creating an
 unexpected duplicate. Ensen-flow does not run a background scheduler daemon, cron
 service integration, cloud scheduler, external calendar integration, or
 production time-zone policy.
+
+Webhook triggers are also local intake boundaries only. A workflow may declare
+`trigger.type: "webhook"` with a stable local path, and callers may pass a
+placeholder-only `flow.webhook.input.v1` fixture to `consumeWebhookInput`. The
+helper validates bounded metadata, rejects credential-shaped or forwarded
+boundary headers, derives an idempotent run state path from `requestId`, and
+records `trigger.type: "webhook"` in JSONL run state. It does not start an HTTP
+server, expose a public endpoint, validate production signatures, store raw
+secrets, or trust client-supplied identity/proxy headers.
 
 ## Workflow Run JSONL State
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Start here:
 
 - [Mission](./mission.md): the Ensen-flow short-form development charter.
 - [Workflow Definition Schema](./workflow-definition.md): the Phase 1 standalone workflow definition boundary and validation shape.
+- Webhook intake boundary: see the webhook section in [Workflow Definition Schema](./workflow-definition.md), the placeholder fixture in `fixtures/webhook-inputs/local-demo.valid.json`, and focused coverage via `npm test -- test/webhook-intake-boundary.test.ts`.
 - [X-Gate 2 Loop-Flow Smoke Runbook](./x-gate2-loop-flow-smoke-runbook.md): local smoke commands, artifacts, failure routing, and non-production boundaries.
 - [X-Gate 3 Flow Caller Boundary Runbook](./x-gate3-flow-caller-boundary-runbook.md): Flow-owned caller boundary for Loop local fake lane smoke input, stdout output, artifacts, and failure routing.
 - Focused Flow X-Gate 3 smoke coverage: `npm test -- test/x-gate3-flow-smoke.test.ts`.

--- a/docs/workflow-definition.md
+++ b/docs/workflow-definition.md
@@ -36,6 +36,18 @@ run ID and JSONL state path, and preserve trigger idempotency. This is not a
 long-running scheduler daemon, cron service integration, cloud scheduler,
 external calendar integration, or production time-zone policy.
 
+Webhook triggers are intentionally small too. The schema accepts only a local
+`webhook` trigger with a stable local `path`. The runtime helper
+`consumeWebhookInput` accepts a local `flow.webhook.input.v1` object, validates
+the request metadata and payload before persistence, derives a deterministic run
+ID and JSONL state path from `requestId`, and records webhook intake as
+`trigger.type: "webhook"` with webhook context in run state. Malformed input,
+path mismatches, untrusted forwarded headers, credential-shaped headers, and
+credential-shaped payload keys fail closed before run or audit files are
+written. This boundary is not a production HTTP service, public endpoint,
+tunnel, hosted listener, raw secret store, signature validation service, or
+credential vault integration.
+
 Runner audit output is intentionally separate from the workflow definition
 schema. The Phase 1 runner writes an internal neutral JSONL audit shape for
 local lifecycle activity only; a formal mapping to EIP AuditEvent is deferred to
@@ -113,8 +125,55 @@ A bounded schedule trigger uses the same workflow shape with a schedule trigger:
 }
 ```
 
+A bounded webhook trigger uses the same workflow shape with a local path and an
+input idempotency key:
+
+```json
+{
+  "schemaVersion": "flow.workflow.v1",
+  "id": "local-webhook-demo",
+  "trigger": {
+    "type": "webhook",
+    "path": "/hooks/local-demo",
+    "idempotencyKey": {
+      "source": "input",
+      "field": "requestId",
+      "required": true
+    }
+  },
+  "steps": [
+    {
+      "id": "record-webhook",
+      "action": {
+        "type": "local",
+        "name": "record_webhook"
+      }
+    }
+  ]
+}
+```
+
+The matching local webhook input fixture is placeholder-only:
+
+```json
+{
+  "schemaVersion": "flow.webhook.input.v1",
+  "requestId": "webhook-001",
+  "path": "/hooks/local-demo",
+  "receivedAt": "2026-05-02T01:00:00.000Z",
+  "headers": {
+    "content-type": "application/json"
+  },
+  "payload": {
+    "eventType": "local-demo.created",
+    "subject": "placeholder-subject"
+  }
+}
+```
+
 The canonical fixture set lives in `fixtures/workflow-definitions/`. Tests load
-those fixtures and validate them through `validateWorkflowDefinition`.
+those fixtures and validate them through `validateWorkflowDefinition`. Local
+webhook input fixtures live in `fixtures/webhook-inputs/`.
 
 ## Validation
 

--- a/fixtures/webhook-inputs/local-demo.valid.json
+++ b/fixtures/webhook-inputs/local-demo.valid.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": "flow.webhook.input.v1",
+  "requestId": "webhook-001",
+  "path": "/hooks/local-demo",
+  "receivedAt": "2026-05-02T01:00:00.000Z",
+  "headers": {
+    "content-type": "application/json"
+  },
+  "payload": {
+    "eventType": "local-demo.created",
+    "subject": "placeholder-subject"
+  }
+}

--- a/fixtures/workflow-definitions/simple-webhook.valid.json
+++ b/fixtures/workflow-definitions/simple-webhook.valid.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": "flow.workflow.v1",
+  "id": "local-webhook-demo",
+  "trigger": {
+    "type": "webhook",
+    "path": "/hooks/local-demo",
+    "idempotencyKey": {
+      "source": "input",
+      "field": "requestId",
+      "required": true
+    }
+  },
+  "steps": [
+    {
+      "id": "record-webhook",
+      "action": {
+        "type": "local",
+        "name": "record_webhook"
+      }
+    }
+  ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,6 +145,12 @@ export {
   isDueForSchedule
 } from "./schedule-trigger.js";
 
+export {
+  WebhookIntakeRejectedError,
+  consumeWebhookInput,
+  webhookInputSchemaVersion
+} from "./webhook-intake.js";
+
 export type {
   IdempotencyKeyDefinition,
   RetryBackoffPolicy,
@@ -157,6 +163,11 @@ export type {
   WorkflowStep,
   WorkflowTrigger
 } from "./workflow-definition.js";
+
+export type {
+  ConsumeWebhookInputOptions,
+  WebhookInput
+} from "./webhook-intake.js";
 
 export type {
   RunWorkflowInput,

--- a/src/webhook-intake.ts
+++ b/src/webhook-intake.ts
@@ -1,0 +1,302 @@
+import { join } from "node:path";
+
+import type { WorkflowRunState } from "./workflow-run-state.js";
+import { validateWorkflowDefinition } from "./workflow-definition.js";
+import type { WorkflowDefinition } from "./workflow-definition.js";
+import { runWorkflow } from "./workflow-runner.js";
+import type { WorkflowStepHandler } from "./workflow-runner.js";
+
+const WEBHOOK_INPUT_SCHEMA_VERSION = "flow.webhook.input.v1";
+const MAX_HEADER_COUNT = 20;
+const MAX_HEADER_VALUE_LENGTH = 512;
+const MAX_JSON_DEPTH = 6;
+const MAX_JSON_STRING_LENGTH = 2048;
+const MAX_JSON_ARRAY_LENGTH = 50;
+const MAX_JSON_OBJECT_KEYS = 50;
+const WEBHOOK_PATH_PATTERN = /^\/[a-z0-9][a-z0-9-]*(?:\/[a-z0-9][a-z0-9-]*)*$/;
+const WEBHOOK_REQUEST_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const ISO_UTC_MILLIS_TIMESTAMP_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})\.\d{3}Z$/;
+const WEBHOOK_INPUT_ALLOWED_KEYS = new Set([
+  "schemaVersion",
+  "requestId",
+  "path",
+  "receivedAt",
+  "headers",
+  "payload"
+]);
+const BLOCKED_HEADER_NAMES = new Set([
+  "authorization",
+  "cookie",
+  "set-cookie",
+  "x-api-key",
+  "x-auth-token",
+  "x-signature",
+  "x-webhook-signature",
+  "x-forwarded-for",
+  "x-forwarded-host",
+  "x-forwarded-proto",
+  "forwarded",
+  "host",
+  "x-tenant-id",
+  "x-user-id"
+]);
+const CREDENTIAL_KEY_PATTERN = /(?:secret|token|password|credential|api[-_]?key|signature)/i;
+
+export interface WebhookInput {
+  schemaVersion: typeof WEBHOOK_INPUT_SCHEMA_VERSION;
+  requestId: string;
+  path: string;
+  receivedAt: string;
+  headers?: Record<string, string>;
+  payload: Record<string, unknown>;
+}
+
+export interface ConsumeWebhookInputOptions {
+  definition: WorkflowDefinition;
+  stateRoot: string;
+  auditPath?: string;
+  input: WebhookInput;
+  now?: () => string;
+  stepHandler?: WorkflowStepHandler;
+}
+
+export class WebhookIntakeRejectedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WebhookIntakeRejectedError";
+  }
+}
+
+export const webhookInputSchemaVersion = WEBHOOK_INPUT_SCHEMA_VERSION;
+
+type WebhookWorkflowDefinition = WorkflowDefinition & {
+  trigger: {
+    type: "webhook";
+    path: string;
+  };
+};
+
+export const consumeWebhookInput = async (
+  options: ConsumeWebhookInputOptions
+): Promise<WorkflowRunState> => {
+  const definition = assertWebhookWorkflow(options.definition);
+  const normalizedInput = normalizeWebhookInput(options.input, definition.trigger.path);
+  const runId = createWebhookRunId(definition.id, normalizedInput.requestId);
+
+  return runWorkflow({
+    definition,
+    statePath: join(options.stateRoot, `${runId}.jsonl`),
+    auditPath: options.auditPath,
+    runId,
+    triggerContext: {
+      requestId: normalizedInput.requestId,
+      webhook: {
+        path: normalizedInput.path,
+        receivedAt: normalizedInput.receivedAt,
+        ...(normalizedInput.headers === undefined ? {} : { headers: normalizedInput.headers }),
+        payload: normalizedInput.payload
+      }
+    },
+    now: options.now,
+    stepHandler: options.stepHandler
+  });
+};
+
+const assertWebhookWorkflow = (definition: WorkflowDefinition): WebhookWorkflowDefinition => {
+  const validation = validateWorkflowDefinition(definition);
+  if (!validation.valid) {
+    const details = validation.errors
+      .map((error) => `${error.path}: ${error.message}`)
+      .join("; ");
+    throw new WebhookIntakeRejectedError(`workflow definition is invalid: ${details}`);
+  }
+
+  if (definition.trigger.type !== "webhook") {
+    throw new WebhookIntakeRejectedError("consumeWebhookInput requires a webhook trigger workflow");
+  }
+
+  if (!WEBHOOK_PATH_PATTERN.test(definition.trigger.path)) {
+    throw new WebhookIntakeRejectedError(
+      "webhook trigger.path must be a local absolute path with stable kebab-case segments"
+    );
+  }
+
+  return definition as WebhookWorkflowDefinition;
+};
+
+const normalizeWebhookInput = (value: unknown, expectedPath: string): WebhookInput => {
+  if (!isRecord(value)) {
+    throw new WebhookIntakeRejectedError("webhook input must be an object");
+  }
+
+  rejectUnknownKeys(value);
+
+  if (value.schemaVersion !== WEBHOOK_INPUT_SCHEMA_VERSION) {
+    throw new WebhookIntakeRejectedError(
+      `webhook input schemaVersion must be ${WEBHOOK_INPUT_SCHEMA_VERSION}`
+    );
+  }
+
+  if (
+    typeof value.requestId !== "string" ||
+    value.requestId.trim() === "" ||
+    !WEBHOOK_REQUEST_ID_PATTERN.test(value.requestId)
+  ) {
+    throw new WebhookIntakeRejectedError(
+      "webhook input requestId must be a bounded stable identifier"
+    );
+  }
+
+  if (typeof value.path !== "string" || !WEBHOOK_PATH_PATTERN.test(value.path)) {
+    throw new WebhookIntakeRejectedError(
+      "webhook input path must be a local absolute path with stable kebab-case segments"
+    );
+  }
+
+  if (value.path !== expectedPath) {
+    throw new WebhookIntakeRejectedError("webhook input path must match workflow trigger.path");
+  }
+
+  if (typeof value.receivedAt !== "string" || !isStrictUtcMillisTimestamp(value.receivedAt)) {
+    throw new WebhookIntakeRejectedError(
+      "webhook input receivedAt must be an ISO-8601 UTC timestamp with milliseconds"
+    );
+  }
+
+  const headers = normalizeHeaders(value.headers);
+  if (!isRecord(value.payload)) {
+    throw new WebhookIntakeRejectedError("webhook input payload must be an object");
+  }
+  validateBoundedJson(value.payload, "webhook input payload", 0);
+  rejectCredentialShapedKeys(value.payload, "webhook input payload");
+
+  return {
+    schemaVersion: WEBHOOK_INPUT_SCHEMA_VERSION,
+    requestId: value.requestId,
+    path: value.path,
+    receivedAt: value.receivedAt,
+    ...(headers === undefined ? {} : { headers }),
+    payload: value.payload
+  };
+};
+
+const rejectUnknownKeys = (value: Record<string, unknown>): void => {
+  for (const key of Object.keys(value)) {
+    if (!WEBHOOK_INPUT_ALLOWED_KEYS.has(key)) {
+      throw new WebhookIntakeRejectedError(
+        `${key} is outside the webhook intake boundary`
+      );
+    }
+  }
+};
+
+const normalizeHeaders = (value: unknown): Record<string, string> | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    throw new WebhookIntakeRejectedError("webhook input headers must be an object");
+  }
+
+  const entries = Object.entries(value);
+  if (entries.length > MAX_HEADER_COUNT) {
+    throw new WebhookIntakeRejectedError("webhook input headers exceed the bounded header count");
+  }
+
+  const headers: Record<string, string> = {};
+  for (const [rawName, rawValue] of entries) {
+    const name = rawName.toLowerCase();
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(name)) {
+      throw new WebhookIntakeRejectedError("webhook input header names must be stable tokens");
+    }
+
+    if (BLOCKED_HEADER_NAMES.has(name)) {
+      throw new WebhookIntakeRejectedError(
+        "webhook headers must not include credential or forwarded boundary headers"
+      );
+    }
+
+    if (typeof rawValue !== "string" || rawValue.length > MAX_HEADER_VALUE_LENGTH) {
+      throw new WebhookIntakeRejectedError(
+        "webhook input header values must be bounded strings"
+      );
+    }
+
+    headers[name] = rawValue;
+  }
+
+  return headers;
+};
+
+const validateBoundedJson = (value: unknown, path: string, depth: number): void => {
+  if (depth > MAX_JSON_DEPTH) {
+    throw new WebhookIntakeRejectedError(`${path} exceeds the maximum JSON depth`);
+  }
+
+  if (value === null || typeof value === "boolean") {
+    return;
+  }
+
+  if (typeof value === "string") {
+    if (value.length > MAX_JSON_STRING_LENGTH) {
+      throw new WebhookIntakeRejectedError(`${path} string value is too large`);
+    }
+    return;
+  }
+
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new WebhookIntakeRejectedError(`${path} must contain only finite numbers`);
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length > MAX_JSON_ARRAY_LENGTH) {
+      throw new WebhookIntakeRejectedError(`${path} array is too large`);
+    }
+    value.forEach((item, index) => validateBoundedJson(item, `${path}[${index}]`, depth + 1));
+    return;
+  }
+
+  if (isRecord(value)) {
+    const keys = Object.keys(value);
+    if (keys.length > MAX_JSON_OBJECT_KEYS) {
+      throw new WebhookIntakeRejectedError(`${path} object has too many keys`);
+    }
+    keys.forEach((key) => validateBoundedJson(value[key], `${path}.${key}`, depth + 1));
+    return;
+  }
+
+  throw new WebhookIntakeRejectedError(`${path} must contain only JSON values`);
+};
+
+const rejectCredentialShapedKeys = (value: Record<string, unknown>, path: string): void => {
+  for (const [key, nestedValue] of Object.entries(value)) {
+    if (CREDENTIAL_KEY_PATTERN.test(key)) {
+      throw new WebhookIntakeRejectedError(`${path}.${key} looks credential-shaped`);
+    }
+
+    if (isRecord(nestedValue)) {
+      rejectCredentialShapedKeys(nestedValue, `${path}.${key}`);
+    }
+  }
+};
+
+const createWebhookRunId = (workflowId: string, requestId: string): string =>
+  `${workflowId}-webhook-${requestId.toLowerCase().replaceAll(/[^a-z0-9-]+/g, "-")}`;
+
+const isStrictUtcMillisTimestamp = (value: string): boolean => {
+  const match = ISO_UTC_MILLIS_TIMESTAMP_PATTERN.exec(value);
+  if (match === null) {
+    return false;
+  }
+
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString() === value;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);

--- a/src/webhook-intake.ts
+++ b/src/webhook-intake.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 
 import type { WorkflowRunState } from "./workflow-run-state.js";
@@ -273,20 +274,38 @@ const validateBoundedJson = (value: unknown, path: string, depth: number): void 
   throw new WebhookIntakeRejectedError(`${path} must contain only JSON values`);
 };
 
-const rejectCredentialShapedKeys = (value: Record<string, unknown>, path: string): void => {
+const rejectCredentialShapedValue = (value: unknown, path: string): void => {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => rejectCredentialShapedValue(item, `${path}[${index}]`));
+    return;
+  }
+
+  if (!isRecord(value)) {
+    return;
+  }
+
   for (const [key, nestedValue] of Object.entries(value)) {
     if (CREDENTIAL_KEY_PATTERN.test(key)) {
       throw new WebhookIntakeRejectedError(`${path}.${key} looks credential-shaped`);
     }
 
-    if (isRecord(nestedValue)) {
-      rejectCredentialShapedKeys(nestedValue, `${path}.${key}`);
-    }
+    rejectCredentialShapedValue(nestedValue, `${path}.${key}`);
   }
 };
 
-const createWebhookRunId = (workflowId: string, requestId: string): string =>
-  `${workflowId}-webhook-${requestId.toLowerCase().replaceAll(/[^a-z0-9-]+/g, "-")}`;
+const rejectCredentialShapedKeys = (value: Record<string, unknown>, path: string): void => {
+  rejectCredentialShapedValue(value, path);
+};
+
+const createWebhookRunId = (workflowId: string, requestId: string): string => {
+  const slug =
+    requestId
+      .toLowerCase()
+      .replaceAll(/[^a-z0-9-]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "request";
+  const fingerprint = createHash("sha256").update(requestId).digest("hex").slice(0, 12);
+  return `${workflowId}-webhook-${slug}-${fingerprint}`;
+};
 
 const isStrictUtcMillisTimestamp = (value: string): boolean => {
   const match = ISO_UTC_MILLIS_TIMESTAMP_PATTERN.exec(value);

--- a/test/webhook-intake-boundary.test.ts
+++ b/test/webhook-intake-boundary.test.ts
@@ -1,0 +1,172 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  consumeWebhookInput,
+  readWorkflowRunState,
+  validateWorkflowDefinition
+} from "../src/index.js";
+import type { WorkflowDefinition, WebhookInput } from "../src/index.js";
+
+const tempRoots: string[] = [];
+
+const readFixture = <T>(...parts: string[]): T =>
+  JSON.parse(readFileSync(join(process.cwd(), "fixtures", ...parts), "utf8")) as T;
+
+const createWebhookWorkflow = (): WorkflowDefinition =>
+  readFixture("workflow-definitions", "simple-webhook.valid.json");
+
+const createWebhookInput = (): WebhookInput =>
+  readFixture("webhook-inputs", "local-demo.valid.json");
+
+const createTempRoot = async () => {
+  const root = await mkdtemp(join(tmpdir(), "ensen-flow-webhook-"));
+  tempRoots.push(root);
+  return root;
+};
+
+const readAuditEvents = async (auditPath: string): Promise<Array<Record<string, unknown>>> =>
+  (await readFile(auditPath, "utf8"))
+    .trimEnd()
+    .split("\n")
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
+  );
+});
+
+describe("webhook intake boundary", () => {
+  it("accepts the bounded local webhook trigger shape", () => {
+    const result = validateWorkflowDefinition(createWebhookWorkflow());
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("consumes a local webhook-shaped input into one idempotent workflow run", async () => {
+    const definition = createWebhookWorkflow();
+    const root = await createTempRoot();
+    const stateRoot = join(root, "runs");
+    const auditPath = join(root, "audit", "webhook.audit.jsonl");
+
+    const first = await consumeWebhookInput({
+      definition,
+      stateRoot,
+      auditPath,
+      input: createWebhookInput(),
+      now: (() => {
+        let index = 0;
+        const timestamps = [
+          "2026-05-02T01:00:01.000Z",
+          "2026-05-02T01:00:02.000Z",
+          "2026-05-02T01:00:03.000Z",
+          "2026-05-02T01:00:04.000Z"
+        ];
+        return () => timestamps[index++] ?? "2026-05-02T01:00:05.000Z";
+      })()
+    });
+    const second = await consumeWebhookInput({
+      definition,
+      stateRoot,
+      auditPath,
+      input: createWebhookInput()
+    });
+
+    expect(second).toEqual(first);
+    expect(first.run.runId).toBe("local-webhook-demo-webhook-webhook-001");
+    expect(first.run.trigger).toEqual({
+      type: "webhook",
+      receivedAt: "2026-05-02T01:00:01.000Z",
+      context: {
+        webhook: {
+          path: "/hooks/local-demo",
+          receivedAt: "2026-05-02T01:00:00.000Z",
+          headers: {
+            "content-type": "application/json"
+          },
+          payload: {
+            eventType: "local-demo.created",
+            subject: "placeholder-subject"
+          }
+        },
+        requestId: "webhook-001"
+      },
+      idempotencyKey: {
+        source: "input",
+        key: "webhook-001"
+      }
+    });
+
+    const persisted = await readWorkflowRunState(
+      join(stateRoot, "local-webhook-demo-webhook-webhook-001.jsonl")
+    );
+    expect(persisted.events.map((event) => event.type)).toEqual([
+      "run.created",
+      "step.attempt.started",
+      "step.attempt.completed",
+      "run.completed"
+    ]);
+
+    const auditEvents = await readAuditEvents(auditPath);
+    expect(auditEvents.map((event) => event.type)).toEqual([
+      "workflow.started",
+      "step.started",
+      "step.completed",
+      "workflow.completed"
+    ]);
+    expect(auditEvents[0]).toMatchObject({
+      id: "audit.local-webhook-demo-webhook-webhook-001.000001",
+      run: { id: "local-webhook-demo-webhook-webhook-001" }
+    });
+  });
+
+  it("rejects malformed webhook payloads before writing partial run state", async () => {
+    const root = await createTempRoot();
+    const stateRoot = join(root, "runs");
+    const auditPath = join(root, "audit", "webhook.audit.jsonl");
+    const malformed = createWebhookInput();
+    malformed.path = "/hooks/other";
+
+    await expect(
+      consumeWebhookInput({
+        definition: createWebhookWorkflow(),
+        stateRoot,
+        auditPath,
+        input: malformed
+      })
+    ).rejects.toThrow("webhook input path must match workflow trigger.path");
+
+    await expect(
+      readFile(join(stateRoot, "local-webhook-demo-webhook-webhook-001.jsonl"), "utf8")
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(readFile(auditPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects untrusted forwarded or credential-shaped webhook headers fail-closed", async () => {
+    const root = await createTempRoot();
+    const stateRoot = join(root, "runs");
+    const input = createWebhookInput();
+    input.headers = {
+      authorization: "redacted",
+      "x-forwarded-for": "203.0.113.10"
+    };
+
+    await expect(
+      consumeWebhookInput({
+        definition: createWebhookWorkflow(),
+        stateRoot,
+        input
+      })
+    ).rejects.toThrow("webhook headers must not include credential or forwarded boundary headers");
+
+    await expect(
+      readFile(join(stateRoot, "local-webhook-demo-webhook-webhook-001.jsonl"), "utf8")
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});

--- a/test/webhook-intake-boundary.test.ts
+++ b/test/webhook-intake-boundary.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -22,6 +23,16 @@ const createWebhookWorkflow = (): WorkflowDefinition =>
 
 const createWebhookInput = (): WebhookInput =>
   readFixture("webhook-inputs", "local-demo.valid.json");
+
+const createExpectedWebhookRunId = (workflowId: string, requestId: string): string => {
+  const slug =
+    requestId
+      .toLowerCase()
+      .replaceAll(/[^a-z0-9-]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "request";
+  const fingerprint = createHash("sha256").update(requestId).digest("hex").slice(0, 12);
+  return `${workflowId}-webhook-${slug}-${fingerprint}`;
+};
 
 const createTempRoot = async () => {
   const root = await mkdtemp(join(tmpdir(), "ensen-flow-webhook-"));
@@ -79,7 +90,8 @@ describe("webhook intake boundary", () => {
     });
 
     expect(second).toEqual(first);
-    expect(first.run.runId).toBe("local-webhook-demo-webhook-webhook-001");
+    const expectedRunId = createExpectedWebhookRunId(definition.id, "webhook-001");
+    expect(first.run.runId).toBe(expectedRunId);
     expect(first.run.trigger).toEqual({
       type: "webhook",
       receivedAt: "2026-05-02T01:00:01.000Z",
@@ -104,7 +116,7 @@ describe("webhook intake boundary", () => {
     });
 
     const persisted = await readWorkflowRunState(
-      join(stateRoot, "local-webhook-demo-webhook-webhook-001.jsonl")
+      join(stateRoot, `${expectedRunId}.jsonl`)
     );
     expect(persisted.events.map((event) => event.type)).toEqual([
       "run.created",
@@ -121,21 +133,56 @@ describe("webhook intake boundary", () => {
       "workflow.completed"
     ]);
     expect(auditEvents[0]).toMatchObject({
-      id: "audit.local-webhook-demo-webhook-webhook-001.000001",
-      run: { id: "local-webhook-demo-webhook-webhook-001" }
+      id: `audit.${expectedRunId}.000001`,
+      run: { id: expectedRunId }
     });
   });
 
+  it("keeps distinct requestIds with the same normalized slug in separate runs", async () => {
+    const definition = createWebhookWorkflow();
+    const root = await createTempRoot();
+    const stateRoot = join(root, "runs");
+    const firstInput = createWebhookInput();
+    const secondInput = createWebhookInput();
+    firstInput.requestId = "A.B";
+    secondInput.requestId = "a-b";
+
+    const first = await consumeWebhookInput({
+      definition,
+      stateRoot,
+      input: firstInput
+    });
+    const second = await consumeWebhookInput({
+      definition,
+      stateRoot,
+      input: secondInput
+    });
+
+    expect(first.run.runId).toBe(createExpectedWebhookRunId(definition.id, "A.B"));
+    expect(second.run.runId).toBe(createExpectedWebhookRunId(definition.id, "a-b"));
+    expect(first.run.runId).not.toBe(second.run.runId);
+    expect(first.run.trigger.idempotencyKey).toEqual({ source: "input", key: "A.B" });
+    expect(second.run.trigger.idempotencyKey).toEqual({ source: "input", key: "a-b" });
+    await expect(readFile(join(stateRoot, `${first.run.runId}.jsonl`), "utf8")).resolves.toContain(
+      first.run.runId
+    );
+    await expect(readFile(join(stateRoot, `${second.run.runId}.jsonl`), "utf8")).resolves.toContain(
+      second.run.runId
+    );
+  });
+
   it("rejects malformed webhook payloads before writing partial run state", async () => {
+    const definition = createWebhookWorkflow();
     const root = await createTempRoot();
     const stateRoot = join(root, "runs");
     const auditPath = join(root, "audit", "webhook.audit.jsonl");
     const malformed = createWebhookInput();
     malformed.path = "/hooks/other";
+    const expectedRunId = createExpectedWebhookRunId(definition.id, malformed.requestId);
 
     await expect(
       consumeWebhookInput({
-        definition: createWebhookWorkflow(),
+        definition,
         stateRoot,
         auditPath,
         input: malformed
@@ -143,12 +190,37 @@ describe("webhook intake boundary", () => {
     ).rejects.toThrow("webhook input path must match workflow trigger.path");
 
     await expect(
-      readFile(join(stateRoot, "local-webhook-demo-webhook-webhook-001.jsonl"), "utf8")
+      readFile(join(stateRoot, `${expectedRunId}.jsonl`), "utf8")
     ).rejects.toMatchObject({ code: "ENOENT" });
     await expect(readFile(auditPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("rejects credential-shaped payload keys nested in arrays before writing state", async () => {
+    const definition = createWebhookWorkflow();
+    const root = await createTempRoot();
+    const stateRoot = join(root, "runs");
+    const input = createWebhookInput();
+    input.payload = {
+      eventType: "local-demo.created",
+      items: [{ apiKey: "redacted" }]
+    };
+    const expectedRunId = createExpectedWebhookRunId(definition.id, input.requestId);
+
+    await expect(
+      consumeWebhookInput({
+        definition,
+        stateRoot,
+        input
+      })
+    ).rejects.toThrow("webhook input payload.items[0].apiKey looks credential-shaped");
+
+    await expect(readFile(join(stateRoot, `${expectedRunId}.jsonl`), "utf8")).rejects.toMatchObject({
+      code: "ENOENT"
+    });
+  });
+
   it("rejects untrusted forwarded or credential-shaped webhook headers fail-closed", async () => {
+    const definition = createWebhookWorkflow();
     const root = await createTempRoot();
     const stateRoot = join(root, "runs");
     const input = createWebhookInput();
@@ -156,17 +228,18 @@ describe("webhook intake boundary", () => {
       authorization: "redacted",
       "x-forwarded-for": "203.0.113.10"
     };
+    const expectedRunId = createExpectedWebhookRunId(definition.id, input.requestId);
 
     await expect(
       consumeWebhookInput({
-        definition: createWebhookWorkflow(),
+        definition,
         stateRoot,
         input
       })
     ).rejects.toThrow("webhook headers must not include credential or forwarded boundary headers");
 
     await expect(
-      readFile(join(stateRoot, "local-webhook-demo-webhook-webhook-001.jsonl"), "utf8")
+      readFile(join(stateRoot, `${expectedRunId}.jsonl`), "utf8")
     ).rejects.toMatchObject({ code: "ENOENT" });
   });
 });


### PR DESCRIPTION
## Summary
- add a bounded local webhook intake helper that validates `flow.webhook.input.v1` before run/audit persistence
- add placeholder-only webhook workflow and input fixtures plus focused boundary coverage
- document that webhook intake is local-only and not a production HTTP listener, public endpoint, secret store, or signature service

## Verification
- `npm run build`
- `npm test -- test/webhook-intake-boundary.test.ts`
- `npm test`

Part of #61
Closes #63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local webhook trigger support with input validation, idempotent run creation, and secure header/payload handling (rejects credential-like or forwarded headers).

* **Documentation**
  * Guides, examples, and fixtures for webhook triggers and local demo inputs; notes that the helper does not run an HTTP server, does not validate production signatures, and does not store raw secrets.

* **Tests**
  * End-to-end tests covering intake, idempotency, validation, and rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->