### PR TITLE
FLOW-042: Add HTTP notification connector skeleton

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Start here:
 - [Mission](./mission.md): the Ensen-flow short-form development charter.
 - [Workflow Definition Schema](./workflow-definition.md): the Phase 1 standalone workflow definition boundary and validation shape.
 - Webhook intake boundary: see the webhook section in [Workflow Definition Schema](./workflow-definition.md), the placeholder fixture in `fixtures/webhook-inputs/local-demo.valid.json`, and focused coverage via `npm test -- test/webhook-intake-boundary.test.ts`.
+- [HTTP Notification Connector Skeleton](./http-notification-connector.md): local fake notification connector behavior, unsupported capability behavior, safe fixture expectations, and non-goals for real outbound HTTP integration.
 - [X-Gate 2 Loop-Flow Smoke Runbook](./x-gate2-loop-flow-smoke-runbook.md): local smoke commands, artifacts, failure routing, and non-production boundaries.
 - [X-Gate 3 Flow Caller Boundary Runbook](./x-gate3-flow-caller-boundary-runbook.md): Flow-owned caller boundary for Loop local fake lane smoke input, stdout output, artifacts, and failure routing.
 - Focused Flow X-Gate 3 smoke coverage: `npm test -- test/x-gate3-flow-smoke.test.ts`.

--- a/docs/http-notification-connector.md
+++ b/docs/http-notification-connector.md
@@ -1,0 +1,48 @@
+# HTTP Notification Connector Skeleton
+
+The HTTP notification connector is a local skeleton for workflow steps whose
+neutral action is `notification`. It lets tests describe an outbound HTTP-style
+notification without enabling a real network call, credential lookup, webhook
+provider, SaaS adapter, or Ensen-loop special case.
+
+## Capability Boundary
+
+The connector identity is `flow.http-notification.v1`. The connector declares a
+notification capability through `capabilities.notify` and mirrors that support
+onto the generic connector `submit` operation. In this skeleton, `status`,
+`cancel`, and `fetchEvidence` are explicitly unsupported by default and return
+fail-closed `unsupported-operation` results.
+
+`submit` accepts a local endpoint alias, method, payload, attempt number, and
+idempotency key. Endpoint aliases are stable placeholder names such as
+`local-operator-notification`; they are not URLs and must not contain raw
+hosts, customer endpoints, tokens, passwords, cookies, authorization headers, or
+API keys.
+
+## Fake Transport
+
+`createFakeHttpNotificationTransport` is the only transport included here. It
+records local deliveries in memory and returns scripted local outcomes:
+
+- success
+- terminal failure
+- retryable failure
+- unsupported notification capability
+
+Repeated successful submissions with the same idempotency key replay the stored
+receipt instead of recording another fake delivery. Retry tests can still
+exercise multiple attempts by keeping the idempotency key explicit in each
+delivery and using the runner retry state as the authoritative attempt record.
+
+## Non-Goals
+
+This issue does not enable outbound HTTP, public webhook listeners, signature
+validation, OAuth, secret injection, provider-specific Slack or Teams behavior,
+ERPNext behavior, Ensen-loop executor integration, Pharma/GxP workflow packs, or
+any compliance claim.
+
+Use focused local verification:
+
+```sh
+npm test -- test/http-notification-connector.test.ts
+```

--- a/docs/workflow-definition.md
+++ b/docs/workflow-definition.md
@@ -59,6 +59,13 @@ definition can name that a step requires an approval or notification action, but
 the schema does not bind that action to a provider, credential, channel, or
 runtime dispatch implementation.
 
+The HTTP notification connector skeleton keeps that boundary. A workflow may use
+`action.type: "notification"` with a placeholder `endpointAlias`, and focused
+tests may route that action through the local fake HTTP notification transport.
+The fixture must not include a real URL, customer endpoint, raw secret,
+authorization header, cookie, API key, OAuth token, or provider-specific
+credential. Real outbound HTTP integration is not enabled by this skeleton.
+
 ## Shape
 
 ```json

--- a/fixtures/workflow-definitions/http-notification.valid.json
+++ b/fixtures/workflow-definitions/http-notification.valid.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": "flow.workflow.v1",
+  "id": "local-http-notification-demo",
+  "trigger": {
+    "type": "manual",
+    "idempotencyKey": {
+      "source": "input",
+      "field": "requestId",
+      "required": true
+    }
+  },
+  "steps": [
+    {
+      "id": "notify-operator",
+      "action": {
+        "type": "notification",
+        "name": "http_notification",
+        "with": {
+          "endpointAlias": "local-operator-notification",
+          "method": "POST",
+          "payload": {
+            "subject": "placeholder-subject",
+            "outcome": "ready"
+          }
+        }
+      },
+      "retry": {
+        "maxAttempts": 2,
+        "backoff": {
+          "strategy": "fixed",
+          "delayMs": 1000
+        }
+      },
+      "idempotencyKey": {
+        "source": "workflow",
+        "template": "{run.id}:{step.id}"
+      }
+    }
+  ]
+}

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -53,6 +53,7 @@ export interface ConnectorSubmitRequest {
   workflowId: string;
   runId: string;
   stepId: string;
+  idempotencyKey?: string;
   input?: Record<string, unknown>;
 }
 

--- a/src/http-notification-connector.ts
+++ b/src/http-notification-connector.ts
@@ -61,6 +61,7 @@ export interface HttpNotificationTransportDelivery {
   attempt: number;
   endpointAlias: string;
   method: HttpNotificationMethod;
+  headers?: Record<string, string>;
   payload?: Record<string, unknown>;
 }
 
@@ -176,6 +177,9 @@ export const createHttpNotificationConnector = (
         attempt,
         endpointAlias: request.notification.endpointAlias,
         method,
+        ...(request.notification.headers === undefined
+          ? {}
+          : { headers: request.notification.headers }),
         ...(request.notification.payload === undefined
           ? {}
           : { payload: request.notification.payload })

--- a/src/http-notification-connector.ts
+++ b/src/http-notification-connector.ts
@@ -103,6 +103,11 @@ export interface HttpNotificationConnector {
   fetchEvidence(request: { requestId: string }): ReturnType<typeof createUnsupportedConnectorOperationResult>;
 }
 
+interface IdempotencyRecord {
+  receipt: HttpNotificationReceipt;
+  fingerprint: string;
+}
+
 const defaultStatusReason = "HTTP notification skeleton records local submit outcomes only";
 const defaultCancelReason = "HTTP notification skeleton does not support cancellation";
 const defaultEvidenceReason = "HTTP notification skeleton does not fetch external evidence";
@@ -115,7 +120,7 @@ export const createHttpNotificationConnector = (
   const connectorId = input.connectorId ?? "http-notification";
   const now = input.now ?? (() => new Date().toISOString());
   const capabilities = createHttpNotificationCapabilities(input.transport.capabilities?.notify);
-  const successfulReceipts = new Map<string, HttpNotificationReceipt>();
+  const successfulReceipts = new Map<string, IdempotencyRecord>();
 
   const unsupported = (reason: string) =>
     createUnsupportedConnectorOperationResult({
@@ -141,18 +146,26 @@ export const createHttpNotificationConnector = (
         return invalidRequest(connectorId, validationError);
       }
 
+      const method = request.notification.method ?? "POST";
+      const fingerprint = fingerprintNotificationRequest(request, method);
       const replayed = successfulReceipts.get(request.idempotencyKey);
       if (replayed !== undefined) {
+        if (replayed.fingerprint !== fingerprint) {
+          return invalidRequest(
+            connectorId,
+            "HTTP notification idempotencyKey reuse must keep workflowId/runId/stepId/endpointAlias/method/headers/payload unchanged"
+          );
+        }
+
         return {
           ok: true,
           connectorId,
           operation: "submit",
-          value: replayed
+          value: replayed.receipt
         };
       }
 
       const attempt = request.attempt ?? 1;
-      const method = request.notification.method ?? "POST";
       const requestId = formatRequestId(connectorId, request.runId, request.stepId, attempt);
       const outcome = await input.transport.deliver({
         workflowId: request.workflowId,
@@ -199,10 +212,10 @@ export const createHttpNotificationConnector = (
           endpointAlias: request.notification.endpointAlias,
           attempt,
           idempotencyKey: request.idempotencyKey,
-          ...(outcome.evidence === undefined ? {} : outcome.evidence)
+          ...(outcome.evidence === undefined ? {} : { transport: outcome.evidence })
         }
       };
-      successfulReceipts.set(request.idempotencyKey, receipt);
+      successfulReceipts.set(request.idempotencyKey, { receipt, fingerprint });
 
       return {
         ok: true,
@@ -288,6 +301,13 @@ const validateSubmitRequest = (request: HttpNotificationSubmitRequest): string |
     return "HTTP notification idempotencyKey must be a non-empty string";
   }
 
+  if (
+    request.attempt !== undefined &&
+    (!Number.isInteger(request.attempt) || request.attempt < 1)
+  ) {
+    return "HTTP notification attempt must be a positive integer";
+  }
+
   if (!isRecord(request.notification)) {
     return "HTTP notification target must be an object";
   }
@@ -367,3 +387,32 @@ const formatRequestId = (
   stepId: string,
   attempt: number
 ): string => `${connectorId}-${runId}-${stepId}-attempt-${attempt}`;
+
+const fingerprintNotificationRequest = (
+  request: HttpNotificationSubmitRequest,
+  method: HttpNotificationMethod
+): string =>
+  stableStringify({
+    workflowId: request.workflowId,
+    runId: request.runId,
+    stepId: request.stepId,
+    endpointAlias: request.notification.endpointAlias,
+    method,
+    headers: request.notification.headers ?? null,
+    payload: request.notification.payload ?? null
+  });
+
+const stableStringify = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
+  }
+
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(",")}}`;
+  }
+
+  return JSON.stringify(value);
+};

--- a/src/http-notification-connector.ts
+++ b/src/http-notification-connector.ts
@@ -1,0 +1,369 @@
+import {
+  createUnsupportedConnectorOperationResult
+} from "./connector.js";
+import type {
+  ConnectorCapabilities,
+  ConnectorOperationSupport,
+  ConnectorResult,
+  ConnectorSubmitRequest
+} from "./connector.js";
+
+export type HttpNotificationMethod = "POST" | "PUT" | "PATCH";
+export type HttpNotificationOutcomeStatus = "succeeded" | "failed";
+
+export interface HttpNotificationTarget {
+  endpointAlias: string;
+  method?: HttpNotificationMethod;
+  headers?: Record<string, string>;
+  payload?: Record<string, unknown>;
+}
+
+export interface HttpNotificationSubmitRequest extends ConnectorSubmitRequest {
+  idempotencyKey: string;
+  attempt?: number;
+  notification: HttpNotificationTarget;
+}
+
+export interface HttpNotificationOutcome {
+  status: HttpNotificationOutcomeStatus;
+  summary?: string;
+  retryable?: boolean;
+  evidence?: Record<string, unknown>;
+}
+
+export interface HttpNotificationReceipt {
+  requestId: string;
+  acceptedAt: string;
+  notification: {
+    status: HttpNotificationOutcomeStatus;
+    endpointAlias: string;
+    method: HttpNotificationMethod;
+    attempt: number;
+    idempotencyKey: string;
+    summary?: string;
+    retryable?: boolean;
+  };
+  evidence: Record<string, unknown>;
+}
+
+export type HttpNotificationSubmitResult = ConnectorResult<HttpNotificationReceipt>;
+
+export interface HttpNotificationCapabilities extends ConnectorCapabilities {
+  notify: ConnectorOperationSupport;
+}
+
+export interface HttpNotificationTransportDelivery {
+  workflowId: string;
+  runId: string;
+  stepId: string;
+  requestId: string;
+  idempotencyKey: string;
+  attempt: number;
+  endpointAlias: string;
+  method: HttpNotificationMethod;
+  payload?: Record<string, unknown>;
+}
+
+export interface HttpNotificationTransport {
+  capabilities?: {
+    notify?: ConnectorOperationSupport;
+  };
+  deliver(
+    delivery: HttpNotificationTransportDelivery
+  ): Promise<HttpNotificationOutcome> | HttpNotificationOutcome;
+}
+
+export interface FakeHttpNotificationTransport extends HttpNotificationTransport {
+  readonly deliveries: HttpNotificationTransportDelivery[];
+}
+
+export interface CreateHttpNotificationConnectorInput {
+  connectorId?: string;
+  transport: HttpNotificationTransport;
+  now?: () => string;
+}
+
+export interface CreateFakeHttpNotificationTransportInput {
+  capabilities?: {
+    notify?: ConnectorOperationSupport;
+  };
+  outcomes?: HttpNotificationOutcome[];
+}
+
+export interface HttpNotificationConnector {
+  identity: {
+    id: string;
+    displayName: string;
+    version: "flow.http-notification.v1";
+  };
+  capabilities: HttpNotificationCapabilities;
+  submit(request: HttpNotificationSubmitRequest): Promise<HttpNotificationSubmitResult>;
+  status(request: { requestId: string }): ReturnType<typeof createUnsupportedConnectorOperationResult>;
+  cancel(request: { requestId: string; reason?: string }): ReturnType<typeof createUnsupportedConnectorOperationResult>;
+  fetchEvidence(request: { requestId: string }): ReturnType<typeof createUnsupportedConnectorOperationResult>;
+}
+
+const defaultStatusReason = "HTTP notification skeleton records local submit outcomes only";
+const defaultCancelReason = "HTTP notification skeleton does not support cancellation";
+const defaultEvidenceReason = "HTTP notification skeleton does not fetch external evidence";
+const stableAliasPattern = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+const credentialKeyPattern = /(^|[-_])(authorization|cookie|password|secret|token|api[-_]?key)([-_]|$)/i;
+
+export const createHttpNotificationConnector = (
+  input: CreateHttpNotificationConnectorInput
+): HttpNotificationConnector => {
+  const connectorId = input.connectorId ?? "http-notification";
+  const now = input.now ?? (() => new Date().toISOString());
+  const capabilities = createHttpNotificationCapabilities(input.transport.capabilities?.notify);
+  const successfulReceipts = new Map<string, HttpNotificationReceipt>();
+
+  const unsupported = (reason: string) =>
+    createUnsupportedConnectorOperationResult({
+      connectorId,
+      operation: "submit",
+      reason
+    });
+
+  return {
+    identity: {
+      id: connectorId,
+      displayName: "HTTP Notification Connector",
+      version: "flow.http-notification.v1"
+    },
+    capabilities,
+    async submit(request: HttpNotificationSubmitRequest): Promise<HttpNotificationSubmitResult> {
+      if (!capabilities.notify.supported) {
+        return unsupported(capabilities.notify.reason);
+      }
+
+      const validationError = validateSubmitRequest(request);
+      if (validationError !== undefined) {
+        return invalidRequest(connectorId, validationError);
+      }
+
+      const replayed = successfulReceipts.get(request.idempotencyKey);
+      if (replayed !== undefined) {
+        return {
+          ok: true,
+          connectorId,
+          operation: "submit",
+          value: replayed
+        };
+      }
+
+      const attempt = request.attempt ?? 1;
+      const method = request.notification.method ?? "POST";
+      const requestId = formatRequestId(connectorId, request.runId, request.stepId, attempt);
+      const outcome = await input.transport.deliver({
+        workflowId: request.workflowId,
+        runId: request.runId,
+        stepId: request.stepId,
+        requestId,
+        idempotencyKey: request.idempotencyKey,
+        attempt,
+        endpointAlias: request.notification.endpointAlias,
+        method,
+        ...(request.notification.payload === undefined
+          ? {}
+          : { payload: request.notification.payload })
+      });
+
+      if (outcome.status === "failed") {
+        return {
+          ok: false,
+          connectorId,
+          operation: "submit",
+          error: {
+            code: "execution-failed",
+            message: outcome.summary ?? "HTTP notification failed in local fake transport",
+            retryable: outcome.retryable === true
+          }
+        };
+      }
+
+      const acceptedAt = now();
+      const receipt: HttpNotificationReceipt = {
+        requestId,
+        acceptedAt,
+        notification: {
+          status: outcome.status,
+          endpointAlias: request.notification.endpointAlias,
+          method,
+          attempt,
+          idempotencyKey: request.idempotencyKey,
+          ...(outcome.summary === undefined ? {} : { summary: outcome.summary }),
+          ...(outcome.retryable === undefined ? {} : { retryable: outcome.retryable })
+        },
+        evidence: {
+          kind: "http-notification-local",
+          endpointAlias: request.notification.endpointAlias,
+          attempt,
+          idempotencyKey: request.idempotencyKey,
+          ...(outcome.evidence === undefined ? {} : outcome.evidence)
+        }
+      };
+      successfulReceipts.set(request.idempotencyKey, receipt);
+
+      return {
+        ok: true,
+        connectorId,
+        operation: "submit",
+        value: receipt
+      };
+    },
+    status() {
+      return createUnsupportedConnectorOperationResult({
+        connectorId,
+        operation: "status",
+        reason: defaultStatusReason
+      });
+    },
+    cancel() {
+      return createUnsupportedConnectorOperationResult({
+        connectorId,
+        operation: "cancel",
+        reason: defaultCancelReason
+      });
+    },
+    fetchEvidence() {
+      return createUnsupportedConnectorOperationResult({
+        connectorId,
+        operation: "fetchEvidence",
+        reason: defaultEvidenceReason
+      });
+    }
+  };
+};
+
+export const createFakeHttpNotificationTransport = (
+  input: CreateFakeHttpNotificationTransportInput = {}
+): FakeHttpNotificationTransport => {
+  const deliveries: HttpNotificationTransportDelivery[] = [];
+  const outcomes =
+    input.outcomes === undefined || input.outcomes.length === 0
+      ? [{ status: "succeeded" as const, summary: "local fake notification accepted" }]
+      : input.outcomes;
+
+  return {
+    capabilities: input.capabilities,
+    get deliveries() {
+      return deliveries.map((delivery) => ({ ...delivery }));
+    },
+    deliver(delivery: HttpNotificationTransportDelivery): HttpNotificationOutcome {
+      deliveries.push({ ...delivery });
+
+      return outcomes[Math.min(deliveries.length - 1, outcomes.length - 1)];
+    }
+  };
+};
+
+const createHttpNotificationCapabilities = (
+  notifyOverride: ConnectorOperationSupport | undefined
+): HttpNotificationCapabilities => {
+  const notify = notifyOverride ?? { supported: true as const };
+
+  return {
+    notify,
+    submit: notify,
+    status: { supported: false, reason: defaultStatusReason },
+    cancel: { supported: false, reason: defaultCancelReason },
+    fetchEvidence: { supported: false, reason: defaultEvidenceReason }
+  };
+};
+
+const validateSubmitRequest = (request: HttpNotificationSubmitRequest): string | undefined => {
+  if (typeof request.workflowId !== "string" || request.workflowId.trim().length === 0) {
+    return "HTTP notification workflowId must be a non-empty string";
+  }
+
+  if (typeof request.runId !== "string" || request.runId.trim().length === 0) {
+    return "HTTP notification runId must be a non-empty string";
+  }
+
+  if (typeof request.stepId !== "string" || request.stepId.trim().length === 0) {
+    return "HTTP notification stepId must be a non-empty string";
+  }
+
+  if (typeof request.idempotencyKey !== "string" || request.idempotencyKey.trim().length === 0) {
+    return "HTTP notification idempotencyKey must be a non-empty string";
+  }
+
+  if (!isRecord(request.notification)) {
+    return "HTTP notification target must be an object";
+  }
+
+  if (
+    typeof request.notification.endpointAlias !== "string" ||
+    !stableAliasPattern.test(request.notification.endpointAlias)
+  ) {
+    return "HTTP notification endpointAlias must be a stable local alias, not a URL or secret";
+  }
+
+  if (
+    request.notification.method !== undefined &&
+    !["POST", "PUT", "PATCH"].includes(request.notification.method)
+  ) {
+    return "HTTP notification method must be POST, PUT, or PATCH";
+  }
+
+  const credentialKey = findCredentialShapedKey(request.notification);
+  if (credentialKey !== undefined) {
+    return `HTTP notification fixture must not include credential-shaped field ${credentialKey}`;
+  }
+
+  return undefined;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const findCredentialShapedKey = (value: unknown, path = "notification"): string | undefined => {
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      const nested = findCredentialShapedKey(value[index], `${path}[${index}]`);
+      if (nested !== undefined) {
+        return nested;
+      }
+    }
+
+    return undefined;
+  }
+
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+
+  for (const [key, nestedValue] of Object.entries(value)) {
+    const nestedPath = `${path}.${key}`;
+    if (credentialKeyPattern.test(key)) {
+      return nestedPath;
+    }
+    const nested = findCredentialShapedKey(nestedValue, nestedPath);
+    if (nested !== undefined) {
+      return nested;
+    }
+  }
+
+  return undefined;
+};
+
+const invalidRequest = (
+  connectorId: string,
+  message: string
+): HttpNotificationSubmitResult => ({
+  ok: false,
+  connectorId,
+  operation: "submit",
+  error: {
+    code: "invalid-request",
+    message,
+    retryable: false
+  }
+});
+
+const formatRequestId = (
+  connectorId: string,
+  runId: string,
+  stepId: string,
+  attempt: number
+): string => `${connectorId}-${runId}-${stepId}-attempt-${attempt}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,11 @@ export {
 } from "./executor-connector.js";
 
 export {
+  createFakeHttpNotificationTransport,
+  createHttpNotificationConnector
+} from "./http-notification-connector.js";
+
+export {
   eipVersionBoundary,
   isSupportedEipProtocolVersion
 } from "./eip-version.js";
@@ -102,6 +107,23 @@ export type {
   ExecutorPolicyDecisionPayload,
   ExecutorSubmitRequest
 } from "./executor-connector.js";
+
+export type {
+  CreateFakeHttpNotificationTransportInput,
+  CreateHttpNotificationConnectorInput,
+  FakeHttpNotificationTransport,
+  HttpNotificationCapabilities,
+  HttpNotificationConnector,
+  HttpNotificationMethod,
+  HttpNotificationOutcome,
+  HttpNotificationOutcomeStatus,
+  HttpNotificationReceipt,
+  HttpNotificationSubmitRequest,
+  HttpNotificationSubmitResult,
+  HttpNotificationTarget,
+  HttpNotificationTransport,
+  HttpNotificationTransportDelivery
+} from "./http-notification-connector.js";
 
 export type { EipVersionBoundary } from "./eip-version.js";
 

--- a/test/http-notification-connector.test.ts
+++ b/test/http-notification-connector.test.ts
@@ -103,6 +103,72 @@ describe("HTTP notification connector skeleton", () => {
     expect(transport.deliveries).toHaveLength(1);
   });
 
+  it("rejects idempotency replay when the request shape changes", async () => {
+    const transport = createFakeHttpNotificationTransport();
+    const connector = createHttpNotificationConnector({ transport });
+
+    await expect(connector.submit(notifyRequest)).resolves.toMatchObject({
+      ok: true
+    });
+    await expect(
+      connector.submit({
+        ...notifyRequest,
+        notification: {
+          ...notifyRequest.notification,
+          endpointAlias: "local-operator-escalation"
+        }
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      operation: "submit",
+      error: {
+        code: "invalid-request",
+        retryable: false,
+        message:
+          "HTTP notification idempotencyKey reuse must keep workflowId/runId/stepId/endpointAlias/method/headers/payload unchanged"
+      }
+    });
+    expect(transport.deliveries).toHaveLength(1);
+  });
+
+  it("keeps canonical evidence fields separate from transport evidence", async () => {
+    const connector = createHttpNotificationConnector({
+      transport: createFakeHttpNotificationTransport({
+        outcomes: [
+          {
+            status: "succeeded",
+            evidence: {
+              kind: "untrusted-kind",
+              endpointAlias: "untrusted-endpoint",
+              attempt: 999,
+              idempotencyKey: "untrusted-key",
+              localStatus: "accepted"
+            }
+          }
+        ]
+      })
+    });
+
+    await expect(connector.submit(notifyRequest)).resolves.toMatchObject({
+      ok: true,
+      value: {
+        evidence: {
+          kind: "http-notification-local",
+          endpointAlias: "local-operator-notification",
+          attempt: 1,
+          idempotencyKey: "notification-demo-run:notify-operator:attempt-1",
+          transport: {
+            kind: "untrusted-kind",
+            endpointAlias: "untrusted-endpoint",
+            attempt: 999,
+            idempotencyKey: "untrusted-key",
+            localStatus: "accepted"
+          }
+        }
+      }
+    });
+  });
+
   it("returns terminal and retryable fake notification failures explicitly", async () => {
     const terminalConnector = createHttpNotificationConnector({
       transport: createFakeHttpNotificationTransport({
@@ -167,6 +233,31 @@ describe("HTTP notification connector skeleton", () => {
         code: "unsupported-operation",
         retryable: false,
         reason: "real outbound HTTP is not enabled"
+      }
+    });
+  });
+
+  it("rejects invalid retry attempt values", async () => {
+    const connector = createHttpNotificationConnector({
+      transport: createFakeHttpNotificationTransport()
+    });
+
+    await expect(connector.submit({ ...notifyRequest, attempt: 0 })).resolves.toMatchObject({
+      ok: false,
+      operation: "submit",
+      error: {
+        code: "invalid-request",
+        retryable: false,
+        message: "HTTP notification attempt must be a positive integer"
+      }
+    });
+    await expect(connector.submit({ ...notifyRequest, attempt: 1.5 })).resolves.toMatchObject({
+      ok: false,
+      operation: "submit",
+      error: {
+        code: "invalid-request",
+        retryable: false,
+        message: "HTTP notification attempt must be a positive integer"
       }
     });
   });

--- a/test/http-notification-connector.test.ts
+++ b/test/http-notification-connector.test.ts
@@ -1,0 +1,327 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createFakeHttpNotificationTransport,
+  createHttpNotificationConnector,
+  readWorkflowRunState,
+  runWorkflow
+} from "../src/index.js";
+import type {
+  HttpNotificationSubmitRequest,
+  WorkflowDefinition
+} from "../src/index.js";
+
+describe("HTTP notification connector skeleton", () => {
+  const notifyRequest: HttpNotificationSubmitRequest = {
+    workflowId: "notification-demo",
+    runId: "notification-demo-run",
+    stepId: "notify-operator",
+    idempotencyKey: "notification-demo-run:notify-operator:attempt-1",
+    notification: {
+      endpointAlias: "local-operator-notification",
+      method: "POST",
+      payload: {
+        subject: "placeholder-subject",
+        outcome: "ready"
+      }
+    }
+  };
+
+  it("submits a local fake HTTP notification without exposing a real endpoint", async () => {
+    const transport = createFakeHttpNotificationTransport({
+      outcomes: [
+        {
+          status: "succeeded",
+          summary: "local fake notification accepted"
+        }
+      ]
+    });
+    const connector = createHttpNotificationConnector({
+      transport,
+      now: () => "2026-05-02T03:00:00.000Z"
+    });
+
+    expect(connector.capabilities).toEqual({
+      notify: { supported: true },
+      submit: { supported: true },
+      status: {
+        supported: false,
+        reason: "HTTP notification skeleton records local submit outcomes only"
+      },
+      cancel: {
+        supported: false,
+        reason: "HTTP notification skeleton does not support cancellation"
+      },
+      fetchEvidence: {
+        supported: false,
+        reason: "HTTP notification skeleton does not fetch external evidence"
+      }
+    });
+
+    const submitted = await connector.submit(notifyRequest);
+
+    expect(submitted).toMatchObject({
+      ok: true,
+      connectorId: "http-notification",
+      operation: "submit",
+      value: {
+        requestId: "http-notification-notification-demo-run-notify-operator-attempt-1",
+        acceptedAt: "2026-05-02T03:00:00.000Z",
+        notification: {
+          status: "succeeded",
+          endpointAlias: "local-operator-notification",
+          attempt: 1,
+          idempotencyKey: "notification-demo-run:notify-operator:attempt-1",
+          summary: "local fake notification accepted"
+        },
+        evidence: {
+          kind: "http-notification-local",
+          endpointAlias: "local-operator-notification"
+        }
+      }
+    });
+    expect(JSON.stringify(submitted)).not.toContain("https://");
+    expect(transport.deliveries).toHaveLength(1);
+    expect(transport.deliveries[0]).toMatchObject({
+      endpointAlias: "local-operator-notification",
+      idempotencyKey: "notification-demo-run:notify-operator:attempt-1"
+    });
+  });
+
+  it("replays the same idempotency key without duplicating fake delivery", async () => {
+    const transport = createFakeHttpNotificationTransport();
+    const connector = createHttpNotificationConnector({ transport });
+
+    const first = await connector.submit(notifyRequest);
+    const replay = await connector.submit(notifyRequest);
+
+    expect(first).toEqual(replay);
+    expect(transport.deliveries).toHaveLength(1);
+  });
+
+  it("returns terminal and retryable fake notification failures explicitly", async () => {
+    const terminalConnector = createHttpNotificationConnector({
+      transport: createFakeHttpNotificationTransport({
+        outcomes: [
+          {
+            status: "failed",
+            summary: "local fake endpoint rejected notification",
+            retryable: false
+          }
+        ]
+      })
+    });
+    const retryableConnector = createHttpNotificationConnector({
+      transport: createFakeHttpNotificationTransport({
+        outcomes: [
+          {
+            status: "failed",
+            summary: "local fake endpoint is temporarily unavailable",
+            retryable: true
+          }
+        ]
+      })
+    });
+
+    await expect(terminalConnector.submit(notifyRequest)).resolves.toMatchObject({
+      ok: false,
+      operation: "submit",
+      error: {
+        code: "execution-failed",
+        retryable: false,
+        message: "local fake endpoint rejected notification"
+      }
+    });
+    await expect(retryableConnector.submit(notifyRequest)).resolves.toMatchObject({
+      ok: false,
+      operation: "submit",
+      error: {
+        code: "execution-failed",
+        retryable: true,
+        message: "local fake endpoint is temporarily unavailable"
+      }
+    });
+  });
+
+  it("fails closed for unsupported notification submit capability", async () => {
+    const connector = createHttpNotificationConnector({
+      transport: createFakeHttpNotificationTransport({
+        capabilities: {
+          notify: {
+            supported: false,
+            reason: "real outbound HTTP is not enabled"
+          }
+        }
+      })
+    });
+
+    await expect(connector.submit(notifyRequest)).resolves.toMatchObject({
+      ok: false,
+      connectorId: "http-notification",
+      operation: "submit",
+      error: {
+        code: "unsupported-operation",
+        retryable: false,
+        reason: "real outbound HTTP is not enabled"
+      }
+    });
+  });
+
+  it("records retryable notification attempts in run state and neutral audit output", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-http-notification-"));
+    const statePath = join(tempRoot, "runs", "http-notification.jsonl");
+    const auditPath = join(tempRoot, "audit", "http-notification.jsonl");
+    const transport = createFakeHttpNotificationTransport({
+      outcomes: [
+        {
+          status: "failed",
+          summary: "local fake endpoint is temporarily unavailable",
+          retryable: true
+        },
+        {
+          status: "succeeded",
+          summary: "local fake notification accepted on retry"
+        }
+      ]
+    });
+    const connector = createHttpNotificationConnector({
+      transport,
+      now: createClock([
+        "2026-05-02T03:10:00.000Z",
+        "2026-05-02T03:10:02.000Z"
+      ])
+    });
+
+    try {
+      await runWorkflow({
+        definition: notificationWorkflow,
+        statePath,
+        auditPath,
+        runId: "notification-demo-run",
+        now: createClock([
+          "2026-05-02T03:09:58.000Z",
+          "2026-05-02T03:09:58.000Z",
+          "2026-05-02T03:09:59.000Z",
+          "2026-05-02T03:10:01.000Z",
+          "2026-05-02T03:10:01.000Z",
+          "2026-05-02T03:10:03.000Z",
+          "2026-05-02T03:10:04.000Z"
+        ]),
+        stepHandler: async ({ attempt, runState, step }) => {
+          const submitted = await connector.submit({
+            workflowId: runState.run.workflowId,
+            runId: runState.run.runId,
+            stepId: step.id,
+            idempotencyKey: `${runState.run.runId}:${step.id}`,
+            attempt,
+            notification: {
+              endpointAlias: "local-operator-notification",
+              method: "POST",
+              payload: {
+                subject: "placeholder-subject"
+              }
+            }
+          });
+
+          if (!submitted.ok) {
+            throw new Error(submitted.error.message);
+          }
+
+          return {
+            executor: {
+              requestId: submitted.value.requestId,
+              status: "succeeded",
+              observedAt: submitted.value.acceptedAt,
+              result: {
+                status: "succeeded",
+                summary: submitted.value.notification.summary,
+                evidence: submitted.value.evidence
+              }
+            }
+          };
+        }
+      });
+
+      const persisted = await readWorkflowRunState(statePath);
+      expect(persisted.run.terminalState).toBe("succeeded");
+      expect(persisted.stepAttempts["notify-operator"]).toMatchObject([
+        {
+          attempt: 1,
+          status: "retryable-failed",
+          retry: {
+            retryable: true,
+            reason: "local fake endpoint is temporarily unavailable"
+          }
+        },
+        {
+          attempt: 2,
+          status: "succeeded",
+          result: {
+            executor: {
+              result: {
+                summary: "local fake notification accepted on retry",
+                evidence: {
+                  endpointAlias: "local-operator-notification"
+                }
+              }
+            }
+          }
+        }
+      ]);
+      expect(transport.deliveries).toHaveLength(2);
+      expect(transport.deliveries.map((delivery) => delivery.idempotencyKey)).toEqual([
+        "notification-demo-run:notify-operator",
+        "notification-demo-run:notify-operator"
+      ]);
+
+      const auditJsonl = await readFile(auditPath, "utf8");
+      expect(auditJsonl).toContain("step.retry.scheduled");
+      expect(auditJsonl).toContain("local fake endpoint is temporarily unavailable");
+      expect(auditJsonl).not.toContain("https://");
+      expect(auditJsonl).not.toContain("secret");
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+const notificationWorkflow: WorkflowDefinition = {
+  schemaVersion: "flow.workflow.v1",
+  id: "notification-demo",
+  trigger: {
+    type: "manual"
+  },
+  steps: [
+    {
+      id: "notify-operator",
+      action: {
+        type: "notification",
+        name: "http_notification",
+        with: {
+          endpointAlias: "local-operator-notification"
+        }
+      },
+      retry: {
+        maxAttempts: 2,
+        backoff: {
+          strategy: "fixed",
+          delayMs: 1000
+        }
+      },
+      idempotencyKey: {
+        source: "workflow",
+        template: "{run.id}:{step.id}"
+      }
+    }
+  ]
+};
+
+const createClock = (timestamps: string[]): (() => string) => {
+  let index = 0;
+
+  return () => timestamps[Math.min(index++, timestamps.length - 1)];
+};

--- a/test/http-notification-connector.test.ts
+++ b/test/http-notification-connector.test.ts
@@ -24,6 +24,9 @@ describe("HTTP notification connector skeleton", () => {
     notification: {
       endpointAlias: "local-operator-notification",
       method: "POST",
+      headers: {
+        "x-flow-fixture": "local-notification"
+      },
       payload: {
         subject: "placeholder-subject",
         outcome: "ready"
@@ -88,6 +91,9 @@ describe("HTTP notification connector skeleton", () => {
     expect(transport.deliveries).toHaveLength(1);
     expect(transport.deliveries[0]).toMatchObject({
       endpointAlias: "local-operator-notification",
+      headers: {
+        "x-flow-fixture": "local-notification"
+      },
       idempotencyKey: "notification-demo-run:notify-operator:attempt-1"
     });
   });

--- a/test/workflow-definition.test.ts
+++ b/test/workflow-definition.test.ts
@@ -33,6 +33,13 @@ describe("workflow definition schema", () => {
     expect(result.errors).toEqual([]);
   });
 
+  it("accepts a placeholder-only HTTP notification workflow fixture", () => {
+    const result = validateWorkflowDefinition(readFixture("http-notification.valid.json"));
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
   it("accepts the supported optional EIP protocol version", () => {
     const workflow = readMutableWorkflowFixture();
     workflow.protocolVersion = "0.1.0";


### PR DESCRIPTION
## Summary
- add a local-only HTTP notification connector skeleton with explicit notify/submit capabilities
- add fake transport coverage for success, terminal failure, retryable failure, unsupported capability, and idempotency replay
- document safe fixture expectations and add a placeholder-only workflow fixture

Closes #64
Part of #61
Depends on #63

## Verification
- npm ci
- npm run build
- npm test -- test/http-notification-connector.test.ts
- npm test -- test/workflow-definition.test.ts
- npm test
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP notification connector for workflow notification actions with local fake transport and idempotency handling

* **Documentation**
  * New connector specification and reference, updated workflow-definition guidance, and a fixture demonstrating local testing without real network targets

* **Tests**
  * Comprehensive connector behavior tests (idempotency, outcomes, error mapping, retry flows) and workflow-definition validation tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->