### PR TITLE
FLOW-043: Add file connector skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This repository is in the Phase 1 baseline stage. The current package exposes a
 minimal TypeScript scaffold plus the initial standalone workflow definition
 schema, append-only JSONL workflow run state helpers, a local sequential runner,
 neutral audit JSONL events, a bounded local schedule trigger evaluator, and a
-bounded local webhook intake helper. It
+bounded local webhook intake helper, and a bounded local file connector
+skeleton for fixture read/write actions. It
 does not implement executor connectors, Ensen-loop integration, ERPNext
 behavior, or Pharma/GxP workflow packs yet.
 
@@ -37,6 +38,8 @@ authority, and no premature compliance claims.
 
 - `docs/mission.md`: Ensen-flow mission and development charter short form.
 - `docs/workflow-definition.md`: Phase 1 workflow definition schema boundary.
+- `docs/file-connector.md`: local file connector safe-root boundary,
+  idempotency behavior, cleanup ownership, and non-goals.
 - `docs/x-gate2-loop-flow-smoke-runbook.md`: local X-Gate 2 loop-flow smoke
   runbook, expected artifacts, failure classification, and non-production
   boundaries.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Start here:
 - [Workflow Definition Schema](./workflow-definition.md): the Phase 1 standalone workflow definition boundary and validation shape.
 - Webhook intake boundary: see the webhook section in [Workflow Definition Schema](./workflow-definition.md), the placeholder fixture in `fixtures/webhook-inputs/local-demo.valid.json`, and focused coverage via `npm test -- test/webhook-intake-boundary.test.ts`.
 - [HTTP Notification Connector Skeleton](./http-notification-connector.md): local fake notification connector behavior, unsupported capability behavior, safe fixture expectations, and non-goals for real outbound HTTP integration.
+- [Local File Connector Skeleton](./file-connector.md): bounded fixture file read/write behavior, safe root requirements, idempotency behavior, cleanup ownership, and non-goals for unrestricted filesystem automation.
 - [X-Gate 2 Loop-Flow Smoke Runbook](./x-gate2-loop-flow-smoke-runbook.md): local smoke commands, artifacts, failure routing, and non-production boundaries.
 - [X-Gate 3 Flow Caller Boundary Runbook](./x-gate3-flow-caller-boundary-runbook.md): Flow-owned caller boundary for Loop local fake lane smoke input, stdout output, artifacts, and failure routing.
 - Focused Flow X-Gate 3 smoke coverage: `npm test -- test/x-gate3-flow-smoke.test.ts`.

--- a/docs/file-connector.md
+++ b/docs/file-connector.md
@@ -1,0 +1,55 @@
+# Local File Connector Skeleton
+
+The local file connector is a Phase 1 skeleton for bounded fixture file actions.
+It lets a workflow step read or write a small local fixture through an explicit
+root alias without turning Ensen-flow into unrestricted filesystem automation.
+
+## Safe Root Boundary
+
+Callers must construct the connector with one or more allowed roots:
+
+```ts
+createLocalFileConnector({
+  allowedRoots: [{ alias: "fixture-root", path: "<absolute-temp-fixture-root>" }]
+});
+```
+
+The root alias is the durable reference. Submit results, run state evidence, and
+audit-oriented surfaces use the alias plus a relative path such as
+`inputs/payload.txt`; they must not publish workstation-local absolute paths.
+
+Requests fail closed when the root alias is missing, the requested path is
+absolute, the path traverses outside the allowed root, the action is not `read`
+or `write`, or write content is not an explicit string.
+
+## Actions
+
+`read` loads a UTF-8 fixture file and returns the content inline with sanitized
+evidence. Missing read targets return a retryable connector failure so the local
+runner can record explicit retry behavior through the step retry policy.
+
+`write` creates parent directories under the allowed root and writes UTF-8
+fixture content. Repeating a successful submission with the same idempotency key
+and the same request fingerprint replays the stored receipt instead of writing a
+second time. Reusing the idempotency key with a changed action, path, root, or
+content fails closed.
+
+## Cleanup
+
+Tests and callers own the temporary fixture root lifecycle. Use a per-run
+temporary root and remove it after verification. The connector does not clean a
+root, scan a home directory, mutate repository files outside an explicit test
+root, or manage production artifact storage.
+
+## Non-Goals
+
+This connector does not provide unrestricted filesystem access, binary blob
+processing, customer data handling, lane-state file access, repository
+automation, production artifact storage, ERPNext behavior, Ensen-loop executor
+integration, Pharma/GxP workflow packs, e-signatures, or compliance claims.
+
+Use focused local verification:
+
+```sh
+npm test -- test/file-connector.test.ts
+```

--- a/docs/file-connector.md
+++ b/docs/file-connector.md
@@ -34,6 +34,26 @@ and the same request fingerprint replays the stored receipt instead of writing a
 second time. Reusing the idempotency key with a changed action, path, root, or
 content fails closed.
 
+By default, `createLocalFileConnector` creates an in-memory idempotency store
+scoped to that connector instance. Callers that recreate connectors during a
+retry must pass a shared or durable `idempotencyStore` so successful receipts
+survive connector recreation:
+
+```ts
+const idempotencyStore = createInMemoryLocalFileIdempotencyStore();
+
+createLocalFileConnector({
+  allowedRoots: [{ alias: "fixture-root", path: "<absolute-temp-fixture-root>" }],
+  idempotencyStore
+});
+```
+
+The bundled in-memory store serializes same-process submissions for one key and
+rejects changed replays. Cross-process workers need a caller-owned durable store
+with equivalent compare-and-set behavior, such as one backed by run state or a
+database record. The connector does not silently infer durability from the
+fixture root.
+
 ## Cleanup
 
 Tests and callers own the temporary fixture root lifecycle. Use a per-run

--- a/docs/file-connector.md
+++ b/docs/file-connector.md
@@ -20,7 +20,9 @@ audit-oriented surfaces use the alias plus a relative path such as
 
 Requests fail closed when the root alias is missing, the requested path is
 absolute, the path traverses outside the allowed root, the action is not `read`
-or `write`, or write content is not an explicit string.
+or `write`, or write content is not an explicit string. Existing symbolic links
+in the allowed root or requested path are rejected before the connector reads or
+writes fixture content.
 
 ## Actions
 

--- a/docs/workflow-definition.md
+++ b/docs/workflow-definition.md
@@ -66,6 +66,15 @@ The fixture must not include a real URL, customer endpoint, raw secret,
 authorization header, cookie, API key, OAuth token, or provider-specific
 credential. Real outbound HTTP integration is not enabled by this skeleton.
 
+The local file connector skeleton also stays behind the neutral action
+boundary. A workflow may use `action.type: "local"` with a file-oriented action
+name in focused tests, then route the step through `createLocalFileConnector`.
+The connector accepts only explicit safe-root aliases and relative fixture
+paths. It records sanitized alias/path evidence and rejects traversal, absolute
+paths, unsupported actions, and changed idempotency replays. It is not
+unrestricted filesystem automation, lane-state access, repository mutation, or
+production artifact storage.
+
 ## Shape
 
 ```json

--- a/src/file-connector.ts
+++ b/src/file-connector.ts
@@ -1,0 +1,442 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import {
+  dirname,
+  isAbsolute,
+  normalize,
+  parse,
+  relative,
+  resolve,
+  sep
+} from "node:path";
+
+import {
+  createUnsupportedConnectorOperationResult
+} from "./connector.js";
+import type {
+  ConnectorCapabilities,
+  ConnectorResult,
+  ConnectorSubmitRequest
+} from "./connector.js";
+
+export type LocalFileAction = "read" | "write";
+
+export interface LocalFileAllowedRoot {
+  alias: string;
+  path: string;
+}
+
+export interface LocalFileRequest {
+  action: LocalFileAction;
+  rootAlias: string;
+  path: string;
+  content?: string;
+}
+
+export interface LocalFileSubmitRequest extends ConnectorSubmitRequest {
+  idempotencyKey: string;
+  file: LocalFileRequest;
+}
+
+export interface LocalFileReceipt {
+  requestId: string;
+  acceptedAt: string;
+  file: {
+    action: LocalFileAction;
+    rootAlias: string;
+    path: string;
+    bytes: number;
+    summary: string;
+  };
+  output?: {
+    content: string;
+  };
+  evidence: {
+    kind: "local-file-fixture";
+    rootAlias: string;
+    path: string;
+    bytes: number;
+  };
+}
+
+export type LocalFileSubmitResult = ConnectorResult<LocalFileReceipt>;
+
+export interface CreateLocalFileConnectorInput {
+  connectorId?: string;
+  allowedRoots: LocalFileAllowedRoot[];
+  now?: () => string;
+}
+
+export interface LocalFileConnector {
+  identity: {
+    id: string;
+    displayName: string;
+    version: "flow.local-file.v1";
+  };
+  capabilities: ConnectorCapabilities;
+  submit(request: LocalFileSubmitRequest): Promise<LocalFileSubmitResult>;
+  status(request: { requestId: string }): ReturnType<typeof createUnsupportedConnectorOperationResult>;
+  cancel(request: { requestId: string; reason?: string }): ReturnType<typeof createUnsupportedConnectorOperationResult>;
+  fetchEvidence(request: { requestId: string }): ReturnType<typeof createUnsupportedConnectorOperationResult>;
+}
+
+interface NormalizedAllowedRoot {
+  alias: string;
+  path: string;
+}
+
+interface ResolvedLocalFileRequest {
+  file: LocalFileRequest;
+  sanitizedPath: string;
+  absolutePath: string;
+}
+
+interface IdempotencyRecord {
+  receipt: LocalFileReceipt;
+  fingerprint: string;
+}
+
+const defaultStatusReason = "local file connector completes fixture file actions inline";
+const defaultCancelReason = "local file connector does not support cancellation";
+const defaultEvidenceReason = "local file connector returns sanitized evidence from submit only";
+const stableAliasPattern = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+const credentialValuePattern = /(authorization|cookie|password|secret|token|api[-_]?key)/i;
+
+export const createLocalFileConnector = (
+  input: CreateLocalFileConnectorInput
+): LocalFileConnector => {
+  const connectorId = input.connectorId ?? "local-file";
+  const now = input.now ?? (() => new Date().toISOString());
+  const allowedRoots = normalizeAllowedRoots(input.allowedRoots);
+  const successfulReceipts = new Map<string, IdempotencyRecord>();
+  const capabilities: ConnectorCapabilities = {
+    submit: { supported: true },
+    status: { supported: false, reason: defaultStatusReason },
+    cancel: { supported: false, reason: defaultCancelReason },
+    fetchEvidence: { supported: false, reason: defaultEvidenceReason }
+  };
+
+  return {
+    identity: {
+      id: connectorId,
+      displayName: "Local File Connector",
+      version: "flow.local-file.v1"
+    },
+    capabilities,
+    async submit(request: LocalFileSubmitRequest): Promise<LocalFileSubmitResult> {
+      const validationError = validateSubmitRequest(request);
+      if (validationError !== undefined) {
+        return invalidRequest(connectorId, validationError);
+      }
+
+      const resolved = resolveLocalFileRequest(request.file, allowedRoots);
+      if (typeof resolved === "string") {
+        return invalidRequest(connectorId, resolved);
+      }
+
+      const fingerprint = fingerprintFileRequest(request, resolved.sanitizedPath);
+      const replayed = successfulReceipts.get(request.idempotencyKey);
+      if (replayed !== undefined) {
+        if (replayed.fingerprint !== fingerprint) {
+          return invalidRequest(
+            connectorId,
+            "local file idempotencyKey reuse must keep workflowId/runId/stepId/action/rootAlias/path/content unchanged"
+          );
+        }
+
+        return {
+          ok: true,
+          connectorId,
+          operation: "submit",
+          value: replayed.receipt
+        };
+      }
+
+      const requestId = `${connectorId}-${request.runId}-${request.stepId}`;
+      const outcome = await executeFileRequest(resolved);
+      if (!outcome.ok) {
+        return {
+          ok: false,
+          connectorId,
+          operation: "submit",
+          error: {
+            code: "execution-failed",
+            message: outcome.message,
+            retryable: outcome.retryable
+          }
+        };
+      }
+
+      const acceptedAt = now();
+      const summary =
+        resolved.file.action === "read"
+          ? "local fixture file read"
+          : "local fixture file written";
+      const receipt: LocalFileReceipt = {
+        requestId,
+        acceptedAt,
+        file: {
+          action: resolved.file.action,
+          rootAlias: resolved.file.rootAlias,
+          path: resolved.sanitizedPath,
+          bytes: outcome.bytes,
+          summary
+        },
+        ...(outcome.content === undefined ? {} : { output: { content: outcome.content } }),
+        evidence: {
+          kind: "local-file-fixture",
+          rootAlias: resolved.file.rootAlias,
+          path: resolved.sanitizedPath,
+          bytes: outcome.bytes
+        }
+      };
+      successfulReceipts.set(request.idempotencyKey, { receipt, fingerprint });
+
+      return {
+        ok: true,
+        connectorId,
+        operation: "submit",
+        value: receipt
+      };
+    },
+    status() {
+      return createUnsupportedConnectorOperationResult({
+        connectorId,
+        operation: "status",
+        reason: defaultStatusReason
+      });
+    },
+    cancel() {
+      return createUnsupportedConnectorOperationResult({
+        connectorId,
+        operation: "cancel",
+        reason: defaultCancelReason
+      });
+    },
+    fetchEvidence() {
+      return createUnsupportedConnectorOperationResult({
+        connectorId,
+        operation: "fetchEvidence",
+        reason: defaultEvidenceReason
+      });
+    }
+  };
+};
+
+const normalizeAllowedRoots = (
+  allowedRoots: LocalFileAllowedRoot[]
+): Map<string, NormalizedAllowedRoot> => {
+  if (!Array.isArray(allowedRoots) || allowedRoots.length === 0) {
+    throw new Error("local file connector requires at least one allowed root");
+  }
+
+  const normalized = new Map<string, NormalizedAllowedRoot>();
+  for (const root of allowedRoots) {
+    if (!isRecord(root)) {
+      throw new Error("local file allowed root must be an object");
+    }
+
+    if (typeof root.alias !== "string" || !stableAliasPattern.test(root.alias)) {
+      throw new Error("local file allowed root alias must be stable kebab-case");
+    }
+
+    if (normalized.has(root.alias)) {
+      throw new Error(`local file allowed root alias ${root.alias} must be unique`);
+    }
+
+    if (typeof root.path !== "string" || root.path.trim() === "") {
+      throw new Error("local file allowed root path must be a non-empty absolute path");
+    }
+
+    if (!isAbsolute(root.path)) {
+      throw new Error("local file allowed root path must be absolute");
+    }
+
+    if (credentialValuePattern.test(root.path)) {
+      throw new Error("local file allowed root path must not contain credential-shaped segments");
+    }
+
+    const rootPath = resolve(root.path);
+    if (rootPath === parse(rootPath).root) {
+      throw new Error("local file allowed root path must not be a filesystem root");
+    }
+
+    normalized.set(root.alias, { alias: root.alias, path: rootPath });
+  }
+
+  return normalized;
+};
+
+const validateSubmitRequest = (request: LocalFileSubmitRequest): string | undefined => {
+  if (typeof request.workflowId !== "string" || request.workflowId.trim().length === 0) {
+    return "local file workflowId must be a non-empty string";
+  }
+
+  if (typeof request.runId !== "string" || request.runId.trim().length === 0) {
+    return "local file runId must be a non-empty string";
+  }
+
+  if (typeof request.stepId !== "string" || request.stepId.trim().length === 0) {
+    return "local file stepId must be a non-empty string";
+  }
+
+  if (typeof request.idempotencyKey !== "string" || request.idempotencyKey.trim().length === 0) {
+    return "local file idempotencyKey must be a non-empty string";
+  }
+
+  if (!isRecord(request.file)) {
+    return "local file request must include a file object";
+  }
+
+  if (request.file.action !== "read" && request.file.action !== "write") {
+    return "local file action must be read or write";
+  }
+
+  if (typeof request.file.rootAlias !== "string" || !stableAliasPattern.test(request.file.rootAlias)) {
+    return "local file rootAlias must be a configured stable alias";
+  }
+
+  if (typeof request.file.path !== "string" || request.file.path.trim() === "") {
+    return "local file path must be a non-empty relative path";
+  }
+
+  if (request.file.action === "write" && typeof request.file.content !== "string") {
+    return "local file write content must be a string";
+  }
+
+  if (request.file.action === "read" && request.file.content !== undefined) {
+    return "local file read request must not include content";
+  }
+
+  return undefined;
+};
+
+const resolveLocalFileRequest = (
+  file: LocalFileRequest,
+  allowedRoots: Map<string, NormalizedAllowedRoot>
+): ResolvedLocalFileRequest | string => {
+  const root = allowedRoots.get(file.rootAlias);
+  if (root === undefined) {
+    return "local file rootAlias is not configured";
+  }
+
+  if (file.path.includes("\\") || isAbsolute(file.path)) {
+    return "local file path must be relative to an allowed root";
+  }
+
+  const normalizedRelativePath = normalize(file.path);
+  if (
+    normalizedRelativePath === ".." ||
+    normalizedRelativePath.startsWith(`..${sep}`)
+  ) {
+    return "local file path must stay under the allowed root";
+  }
+
+  const absolutePath = resolve(root.path, normalizedRelativePath);
+  const relativeToRoot = relative(root.path, absolutePath);
+  if (
+    relativeToRoot === "" ||
+    relativeToRoot === ".." ||
+    relativeToRoot.startsWith(`..${sep}`) ||
+    isAbsolute(relativeToRoot)
+  ) {
+    return "local file path must stay under the allowed root";
+  }
+
+  return {
+    file,
+    sanitizedPath: relativeToRoot.split(sep).join("/"),
+    absolutePath
+  };
+};
+
+const executeFileRequest = async (
+  request: ResolvedLocalFileRequest
+): Promise<
+  | { ok: true; bytes: number; content?: string }
+  | { ok: false; message: string; retryable: boolean }
+> => {
+  if (request.file.action === "read") {
+    try {
+      const content = await readFile(request.absolutePath, "utf8");
+      return { ok: true, bytes: Buffer.byteLength(content, "utf8"), content };
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return {
+          ok: false,
+          message: "local file read target was not found",
+          retryable: true
+        };
+      }
+
+      return {
+        ok: false,
+        message: "local file read failed",
+        retryable: false
+      };
+    }
+  }
+
+  try {
+    await mkdir(dirname(request.absolutePath), { recursive: true });
+    await writeFile(request.absolutePath, request.file.content ?? "", "utf8");
+    return {
+      ok: true,
+      bytes: Buffer.byteLength(request.file.content ?? "", "utf8")
+    };
+  } catch {
+    return {
+      ok: false,
+      message: "local file write failed",
+      retryable: false
+    };
+  }
+};
+
+const invalidRequest = (
+  connectorId: string,
+  message: string
+): LocalFileSubmitResult => ({
+  ok: false,
+  connectorId,
+  operation: "submit",
+  error: {
+    code: "invalid-request",
+    message,
+    retryable: false
+  }
+});
+
+const fingerprintFileRequest = (
+  request: LocalFileSubmitRequest,
+  sanitizedPath: string
+): string =>
+  stableStringify({
+    workflowId: request.workflowId,
+    runId: request.runId,
+    stepId: request.stepId,
+    action: request.file.action,
+    rootAlias: request.file.rootAlias,
+    path: sanitizedPath,
+    content: request.file.content ?? null
+  });
+
+const stableStringify = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
+  }
+
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+      .join(",")}}`;
+  }
+
+  return JSON.stringify(value);
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isNodeError = (error: unknown): error is NodeJS.ErrnoException =>
+  error instanceof Error && "code" in error;

--- a/src/file-connector.ts
+++ b/src/file-connector.ts
@@ -60,9 +60,32 @@ export interface LocalFileReceipt {
 
 export type LocalFileSubmitResult = ConnectorResult<LocalFileReceipt>;
 
+export interface LocalFileIdempotencyRecord {
+  receipt: LocalFileReceipt;
+  fingerprint: string;
+}
+
+export type LocalFileIdempotencyStoreResult =
+  | {
+      status: "stored" | "replayed";
+      record: LocalFileIdempotencyRecord;
+    }
+  | {
+      status: "conflict";
+    };
+
+export interface LocalFileIdempotencyStore {
+  submitSuccessfulReceipt(input: {
+    idempotencyKey: string;
+    fingerprint: string;
+    createReceipt: () => Promise<LocalFileReceipt>;
+  }): Promise<LocalFileIdempotencyStoreResult>;
+}
+
 export interface CreateLocalFileConnectorInput {
   connectorId?: string;
   allowedRoots: LocalFileAllowedRoot[];
+  idempotencyStore?: LocalFileIdempotencyStore;
   now?: () => string;
 }
 
@@ -90,16 +113,69 @@ interface ResolvedLocalFileRequest {
   absolutePath: string;
 }
 
-interface IdempotencyRecord {
-  receipt: LocalFileReceipt;
-  fingerprint: string;
-}
-
 const defaultStatusReason = "local file connector completes fixture file actions inline";
 const defaultCancelReason = "local file connector does not support cancellation";
 const defaultEvidenceReason = "local file connector returns sanitized evidence from submit only";
 const stableAliasPattern = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
 const credentialValuePattern = /(authorization|cookie|password|secret|token|api[-_]?key)/i;
+
+export const createInMemoryLocalFileIdempotencyStore = (): LocalFileIdempotencyStore => {
+  const records = new Map<string, LocalFileIdempotencyRecord>();
+  const pending = new Map<
+    string,
+    {
+      fingerprint: string;
+      promise: Promise<LocalFileIdempotencyStoreResult>;
+    }
+  >();
+
+  return {
+    async submitSuccessfulReceipt(input) {
+      const existing = records.get(input.idempotencyKey);
+      if (existing !== undefined) {
+        return existing.fingerprint === input.fingerprint
+          ? { status: "replayed", record: existing }
+          : { status: "conflict" };
+      }
+
+      const inFlight = pending.get(input.idempotencyKey);
+      if (inFlight !== undefined) {
+        if (inFlight.fingerprint !== input.fingerprint) {
+          return { status: "conflict" };
+        }
+
+        const result = await inFlight.promise;
+        return result.status === "conflict"
+          ? result
+          : { status: "replayed", record: result.record };
+      }
+
+      const promise = (async (): Promise<LocalFileIdempotencyStoreResult> => {
+        const receipt = await input.createReceipt();
+        const record: LocalFileIdempotencyRecord = {
+          receipt,
+          fingerprint: input.fingerprint
+        };
+        records.set(input.idempotencyKey, record);
+        return { status: "stored", record };
+      })();
+
+      pending.set(input.idempotencyKey, {
+        fingerprint: input.fingerprint,
+        promise
+      });
+
+      try {
+        return await promise;
+      } finally {
+        const current = pending.get(input.idempotencyKey);
+        if (current?.promise === promise) {
+          pending.delete(input.idempotencyKey);
+        }
+      }
+    }
+  };
+};
 
 export const createLocalFileConnector = (
   input: CreateLocalFileConnectorInput
@@ -107,7 +183,7 @@ export const createLocalFileConnector = (
   const connectorId = input.connectorId ?? "local-file";
   const now = input.now ?? (() => new Date().toISOString());
   const allowedRoots = normalizeAllowedRoots(input.allowedRoots);
-  const successfulReceipts = new Map<string, IdempotencyRecord>();
+  const idempotencyStore = input.idempotencyStore ?? createInMemoryLocalFileIdempotencyStore();
   const capabilities: ConnectorCapabilities = {
     submit: { supported: true },
     status: { supported: false, reason: defaultStatusReason },
@@ -134,68 +210,47 @@ export const createLocalFileConnector = (
       }
 
       const fingerprint = fingerprintFileRequest(request, resolved.sanitizedPath);
-      const replayed = successfulReceipts.get(request.idempotencyKey);
-      if (replayed !== undefined) {
-        if (replayed.fingerprint !== fingerprint) {
-          return invalidRequest(
+      let storedReceipt: LocalFileIdempotencyStoreResult;
+      try {
+        storedReceipt = await idempotencyStore.submitSuccessfulReceipt({
+          idempotencyKey: request.idempotencyKey,
+          fingerprint,
+          createReceipt: async () => createLocalFileReceipt({
             connectorId,
-            "local file idempotencyKey reuse must keep workflowId/runId/stepId/action/rootAlias/path/content unchanged"
-          );
+            now,
+            request,
+            resolved
+          })
+        });
+      } catch (error) {
+        if (!isLocalFileExecutionError(error)) {
+          throw error;
         }
 
-        return {
-          ok: true,
-          connectorId,
-          operation: "submit",
-          value: replayed.receipt
-        };
-      }
-
-      const requestId = `${connectorId}-${request.runId}-${request.stepId}`;
-      const outcome = await executeFileRequest(resolved);
-      if (!outcome.ok) {
         return {
           ok: false,
           connectorId,
           operation: "submit",
           error: {
             code: "execution-failed",
-            message: outcome.message,
-            retryable: outcome.retryable
+            message: error.message,
+            retryable: error.retryable
           }
         };
       }
 
-      const acceptedAt = now();
-      const summary =
-        resolved.file.action === "read"
-          ? "local fixture file read"
-          : "local fixture file written";
-      const receipt: LocalFileReceipt = {
-        requestId,
-        acceptedAt,
-        file: {
-          action: resolved.file.action,
-          rootAlias: resolved.file.rootAlias,
-          path: resolved.sanitizedPath,
-          bytes: outcome.bytes,
-          summary
-        },
-        ...(outcome.content === undefined ? {} : { output: { content: outcome.content } }),
-        evidence: {
-          kind: "local-file-fixture",
-          rootAlias: resolved.file.rootAlias,
-          path: resolved.sanitizedPath,
-          bytes: outcome.bytes
-        }
-      };
-      successfulReceipts.set(request.idempotencyKey, { receipt, fingerprint });
+      if (storedReceipt.status === "conflict") {
+        return invalidRequest(
+          connectorId,
+          "local file idempotencyKey reuse must keep workflowId/runId/stepId/action/rootAlias/path/content unchanged"
+        );
+      }
 
       return {
         ok: true,
         connectorId,
         operation: "submit",
-        value: receipt
+        value: storedReceipt.record.receipt
       };
     },
     status() {
@@ -218,6 +273,44 @@ export const createLocalFileConnector = (
         operation: "fetchEvidence",
         reason: defaultEvidenceReason
       });
+    }
+  };
+};
+
+const createLocalFileReceipt = async (input: {
+  connectorId: string;
+  now: () => string;
+  request: LocalFileSubmitRequest;
+  resolved: ResolvedLocalFileRequest;
+}): Promise<LocalFileReceipt> => {
+  const outcome = await executeFileRequest(input.resolved);
+  if (!outcome.ok) {
+    throw new LocalFileExecutionError(outcome.message, outcome.retryable);
+  }
+
+  const requestId = `${input.connectorId}-${input.request.runId}-${input.request.stepId}`;
+  const acceptedAt = input.now();
+  const summary =
+    input.resolved.file.action === "read"
+      ? "local fixture file read"
+      : "local fixture file written";
+
+  return {
+    requestId,
+    acceptedAt,
+    file: {
+      action: input.resolved.file.action,
+      rootAlias: input.resolved.file.rootAlias,
+      path: input.resolved.sanitizedPath,
+      bytes: outcome.bytes,
+      summary
+    },
+    ...(outcome.content === undefined ? {} : { output: { content: outcome.content } }),
+    evidence: {
+      kind: "local-file-fixture",
+      rootAlias: input.resolved.file.rootAlias,
+      path: input.resolved.sanitizedPath,
+      bytes: outcome.bytes
     }
   };
 };
@@ -405,6 +498,19 @@ const invalidRequest = (
     retryable: false
   }
 });
+
+class LocalFileExecutionError extends Error {
+  readonly retryable: boolean;
+
+  constructor(message: string, retryable: boolean) {
+    super(message);
+    this.name = "LocalFileExecutionError";
+    this.retryable = retryable;
+  }
+}
+
+const isLocalFileExecutionError = (error: unknown): error is LocalFileExecutionError =>
+  error instanceof LocalFileExecutionError;
 
 const fingerprintFileRequest = (
   request: LocalFileSubmitRequest,

--- a/src/file-connector.ts
+++ b/src/file-connector.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readFile, writeFile } from "node:fs/promises";
 import {
   dirname,
   isAbsolute,
@@ -204,7 +204,7 @@ export const createLocalFileConnector = (
         return invalidRequest(connectorId, validationError);
       }
 
-      const resolved = resolveLocalFileRequest(request.file, allowedRoots);
+      const resolved = await resolveLocalFileRequest(request.file, allowedRoots);
       if (typeof resolved === "string") {
         return invalidRequest(connectorId, resolved);
       }
@@ -403,10 +403,10 @@ const validateSubmitRequest = (request: LocalFileSubmitRequest): string | undefi
   return undefined;
 };
 
-const resolveLocalFileRequest = (
+const resolveLocalFileRequest = async (
   file: LocalFileRequest,
   allowedRoots: Map<string, NormalizedAllowedRoot>
-): ResolvedLocalFileRequest | string => {
+): Promise<ResolvedLocalFileRequest | string> => {
   const root = allowedRoots.get(file.rootAlias);
   if (root === undefined) {
     return "local file rootAlias is not configured";
@@ -435,11 +435,55 @@ const resolveLocalFileRequest = (
     return "local file path must stay under the allowed root";
   }
 
+  const symlinkTraversalError = await validateNoSymbolicLinkTraversal(
+    root.path,
+    relativeToRoot
+  );
+  if (symlinkTraversalError !== undefined) {
+    return symlinkTraversalError;
+  }
+
   return {
     file,
     sanitizedPath: relativeToRoot.split(sep).join("/"),
     absolutePath
   };
+};
+
+const validateNoSymbolicLinkTraversal = async (
+  rootPath: string,
+  relativePath: string
+): Promise<string | undefined> => {
+  const rootState = await readPathState(rootPath);
+  if (rootState === "symbolic-link" || rootState === "blocked") {
+    return "local file path must stay under the allowed root";
+  }
+
+  let currentPath = rootPath;
+  for (const segment of relativePath.split(sep)) {
+    currentPath = resolve(currentPath, segment);
+    const state = await readPathState(currentPath);
+    if (state === "missing") {
+      return undefined;
+    }
+
+    if (state === "symbolic-link" || state === "blocked") {
+      return "local file path must stay under the allowed root";
+    }
+  }
+
+  return undefined;
+};
+
+const readPathState = async (
+  path: string
+): Promise<"regular" | "symbolic-link" | "missing" | "blocked"> => {
+  try {
+    const stats = await lstat(path);
+    return stats.isSymbolicLink() ? "symbolic-link" : "regular";
+  } catch (error) {
+    return isNodeError(error) && error.code === "ENOENT" ? "missing" : "blocked";
+  }
 };
 
 const executeFileRequest = async (

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,10 @@ export {
 } from "./http-notification-connector.js";
 
 export {
+  createLocalFileConnector
+} from "./file-connector.js";
+
+export {
   eipVersionBoundary,
   isSupportedEipProtocolVersion
 } from "./eip-version.js";
@@ -124,6 +128,17 @@ export type {
   HttpNotificationTransport,
   HttpNotificationTransportDelivery
 } from "./http-notification-connector.js";
+
+export type {
+  CreateLocalFileConnectorInput,
+  LocalFileAction,
+  LocalFileAllowedRoot,
+  LocalFileConnector,
+  LocalFileReceipt,
+  LocalFileRequest,
+  LocalFileSubmitRequest,
+  LocalFileSubmitResult
+} from "./file-connector.js";
 
 export type { EipVersionBoundary } from "./eip-version.js";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export {
 } from "./http-notification-connector.js";
 
 export {
+  createInMemoryLocalFileIdempotencyStore,
   createLocalFileConnector
 } from "./file-connector.js";
 
@@ -134,6 +135,9 @@ export type {
   LocalFileAction,
   LocalFileAllowedRoot,
   LocalFileConnector,
+  LocalFileIdempotencyRecord,
+  LocalFileIdempotencyStore,
+  LocalFileIdempotencyStoreResult,
   LocalFileReceipt,
   LocalFileRequest,
   LocalFileSubmitRequest,

--- a/test/file-connector.test.ts
+++ b/test/file-connector.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -252,6 +252,65 @@ describe("local file connector skeleton", () => {
         retryable: false
       }
     });
+  });
+
+  it("rejects symlink traversal before reading or writing fixture files", async () => {
+    const fixtureRoot = await createTempRoot();
+    const outsideRoot = await createTempRoot();
+    await mkdir(join(outsideRoot, "data"), { recursive: true });
+    await writeFile(join(outsideRoot, "data", "secret.txt"), "outside", "utf8");
+    await symlink(join(outsideRoot, "data"), join(fixtureRoot, "linked-data"));
+    const connector = createLocalFileConnector({
+      allowedRoots: [{ alias: "fixture-root", path: fixtureRoot }]
+    });
+
+    await expect(
+      connector.submit({
+        workflowId: "file-demo",
+        runId: "file-demo-run",
+        stepId: "read-symlink",
+        idempotencyKey: "file-demo-run:read-symlink",
+        file: {
+          action: "read",
+          rootAlias: "fixture-root",
+          path: "linked-data/secret.txt"
+        }
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      operation: "submit",
+      error: {
+        code: "invalid-request",
+        message: "local file path must stay under the allowed root",
+        retryable: false
+      }
+    });
+
+    await expect(
+      connector.submit({
+        workflowId: "file-demo",
+        runId: "file-demo-run",
+        stepId: "write-symlink",
+        idempotencyKey: "file-demo-run:write-symlink",
+        file: {
+          action: "write",
+          rootAlias: "fixture-root",
+          path: "linked-data/secret.txt",
+          content: "overwritten"
+        }
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      operation: "submit",
+      error: {
+        code: "invalid-request",
+        message: "local file path must stay under the allowed root",
+        retryable: false
+      }
+    });
+    await expect(readFile(join(outsideRoot, "data", "secret.txt"), "utf8")).resolves.toBe(
+      "outside"
+    );
   });
 
   it("rejects unsafe allowed root configuration before fixture operations are available", () => {

--- a/test/file-connector.test.ts
+++ b/test/file-connector.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  createInMemoryLocalFileIdempotencyStore,
   createLocalFileConnector,
   readWorkflowRunState,
   runWorkflow
@@ -78,9 +79,16 @@ describe("local file connector skeleton", () => {
 
   it("writes local fixture files idempotently without leaking absolute paths", async () => {
     const fixtureRoot = await createTempRoot();
+    const idempotencyStore = createInMemoryLocalFileIdempotencyStore();
     const connector = createLocalFileConnector({
       allowedRoots: [{ alias: "fixture-root", path: fixtureRoot }],
+      idempotencyStore,
       now: () => "2026-05-02T04:01:00.000Z"
+    });
+    const recreatedConnector = createLocalFileConnector({
+      allowedRoots: [{ alias: "fixture-root", path: fixtureRoot }],
+      idempotencyStore,
+      now: () => "2026-05-02T04:01:01.000Z"
     });
     const request: LocalFileSubmitRequest = {
       workflowId: "file-demo",
@@ -96,13 +104,101 @@ describe("local file connector skeleton", () => {
     };
 
     const first = await connector.submit(request);
-    const replay = await connector.submit(request);
+    await writeFile(join(fixtureRoot, "outputs", "result.txt"), "tampered", "utf8");
+    const replay = await recreatedConnector.submit(request);
 
     expect(first).toEqual(replay);
     await expect(readFile(join(fixtureRoot, "outputs", "result.txt"), "utf8")).resolves.toBe(
-      "first write"
+      "tampered"
     );
     expect(JSON.stringify(first)).not.toContain(fixtureRoot);
+  });
+
+  it("rejects changed replays from a shared idempotency store after connector recreation", async () => {
+    const fixtureRoot = await createTempRoot();
+    const idempotencyStore = createInMemoryLocalFileIdempotencyStore();
+    const connector = createLocalFileConnector({
+      allowedRoots: [{ alias: "fixture-root", path: fixtureRoot }],
+      idempotencyStore
+    });
+    const recreatedConnector = createLocalFileConnector({
+      allowedRoots: [{ alias: "fixture-root", path: fixtureRoot }],
+      idempotencyStore
+    });
+    const request: LocalFileSubmitRequest = {
+      workflowId: "file-demo",
+      runId: "file-demo-run",
+      stepId: "write-fixture",
+      idempotencyKey: "file-demo-run:write-fixture",
+      file: {
+        action: "write",
+        rootAlias: "fixture-root",
+        path: "outputs/result.txt",
+        content: "first write"
+      }
+    };
+
+    await expect(connector.submit(request)).resolves.toMatchObject({ ok: true });
+    await expect(
+      recreatedConnector.submit({
+        ...request,
+        file: {
+          ...request.file,
+          content: "changed write"
+        }
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid-request",
+        message:
+          "local file idempotencyKey reuse must keep workflowId/runId/stepId/action/rootAlias/path/content unchanged",
+        retryable: false
+      }
+    });
+  });
+
+  it("serializes concurrent same-key submissions through the shared idempotency store", async () => {
+    const fixtureRoot = await createTempRoot();
+    const idempotencyStore = createInMemoryLocalFileIdempotencyStore();
+    const timestamps = [
+      "2026-05-02T04:01:10.000Z",
+      "2026-05-02T04:01:11.000Z"
+    ];
+    let timestampIndex = 0;
+    const connector = createLocalFileConnector({
+      allowedRoots: [{ alias: "fixture-root", path: fixtureRoot }],
+      idempotencyStore,
+      now: () => timestamps[Math.min(timestampIndex++, timestamps.length - 1)]
+    });
+    const request: LocalFileSubmitRequest = {
+      workflowId: "file-demo",
+      runId: "file-demo-run",
+      stepId: "write-fixture",
+      idempotencyKey: "file-demo-run:write-fixture",
+      file: {
+        action: "write",
+        rootAlias: "fixture-root",
+        path: "outputs/result.txt",
+        content: "first write"
+      }
+    };
+
+    const [first, second] = await Promise.all([
+      connector.submit(request),
+      connector.submit(request)
+    ]);
+
+    expect(first).toEqual(second);
+    expect(first).toMatchObject({
+      ok: true,
+      value: {
+        acceptedAt: "2026-05-02T04:01:10.000Z"
+      }
+    });
+    await expect(readFile(join(fixtureRoot, "outputs", "result.txt"), "utf8")).resolves.toBe(
+      "first write"
+    );
   });
 
   it.each([

--- a/test/file-connector.test.ts
+++ b/test/file-connector.test.ts
@@ -1,0 +1,285 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createLocalFileConnector,
+  readWorkflowRunState,
+  runWorkflow
+} from "../src/index.js";
+import type {
+  LocalFileSubmitRequest,
+  WorkflowDefinition
+} from "../src/index.js";
+
+const tempRoots: string[] = [];
+
+const createTempRoot = async (): Promise<string> => {
+  const root = await mkdtemp(join(tmpdir(), "ensen-flow-file-connector-"));
+  tempRoots.push(root);
+  return root;
+};
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
+  );
+});
+
+describe("local file connector skeleton", () => {
+  it("reads local fixture files under an explicit allowed root with sanitized evidence", async () => {
+    const fixtureRoot = await createTempRoot();
+    await mkdir(join(fixtureRoot, "inputs"), { recursive: true });
+    await writeFile(join(fixtureRoot, "inputs", "payload.txt"), "fixture payload", "utf8");
+    const connector = createLocalFileConnector({
+      allowedRoots: [{ alias: "fixture-root", path: fixtureRoot }],
+      now: () => "2026-05-02T04:00:00.000Z"
+    });
+
+    const result = await connector.submit({
+      workflowId: "file-demo",
+      runId: "file-demo-run",
+      stepId: "read-fixture",
+      idempotencyKey: "file-demo-run:read-fixture",
+      file: {
+        action: "read",
+        rootAlias: "fixture-root",
+        path: "inputs/payload.txt"
+      }
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      connectorId: "local-file",
+      operation: "submit",
+      value: {
+        requestId: "local-file-file-demo-run-read-fixture",
+        acceptedAt: "2026-05-02T04:00:00.000Z",
+        file: {
+          action: "read",
+          rootAlias: "fixture-root",
+          path: "inputs/payload.txt",
+          bytes: 15
+        },
+        output: {
+          content: "fixture payload"
+        },
+        evidence: {
+          kind: "local-file-fixture",
+          rootAlias: "fixture-root",
+          path: "inputs/payload.txt"
+        }
+      }
+    });
+    expect(JSON.stringify(result)).not.toContain(fixtureRoot);
+  });
+
+  it("writes local fixture files idempotently without leaking absolute paths", async () => {
+    const fixtureRoot = await createTempRoot();
+    const connector = createLocalFileConnector({
+      allowedRoots: [{ alias: "fixture-root", path: fixtureRoot }],
+      now: () => "2026-05-02T04:01:00.000Z"
+    });
+    const request: LocalFileSubmitRequest = {
+      workflowId: "file-demo",
+      runId: "file-demo-run",
+      stepId: "write-fixture",
+      idempotencyKey: "file-demo-run:write-fixture",
+      file: {
+        action: "write",
+        rootAlias: "fixture-root",
+        path: "outputs/result.txt",
+        content: "first write"
+      }
+    };
+
+    const first = await connector.submit(request);
+    const replay = await connector.submit(request);
+
+    expect(first).toEqual(replay);
+    await expect(readFile(join(fixtureRoot, "outputs", "result.txt"), "utf8")).resolves.toBe(
+      "first write"
+    );
+    expect(JSON.stringify(first)).not.toContain(fixtureRoot);
+  });
+
+  it.each([
+    {
+      name: "path traversal",
+      file: {
+        action: "read",
+        rootAlias: "fixture-root",
+        path: "../outside.txt"
+      },
+      message: "local file path must stay under the allowed root"
+    },
+    {
+      name: "absolute path",
+      file: {
+        action: "read",
+        rootAlias: "fixture-root",
+        path: join(tmpdir(), "outside.txt")
+      },
+      message: "local file path must be relative to an allowed root"
+    },
+    {
+      name: "unsupported action",
+      file: {
+        action: "delete",
+        rootAlias: "fixture-root",
+        path: "outputs/result.txt"
+      },
+      message: "local file action must be read or write"
+    }
+  ])("fails closed for unsafe local file requests: $name", async ({ file, message }) => {
+    const fixtureRoot = await createTempRoot();
+    const connector = createLocalFileConnector({
+      allowedRoots: [{ alias: "fixture-root", path: fixtureRoot }]
+    });
+
+    await expect(
+      connector.submit({
+        workflowId: "file-demo",
+        runId: "file-demo-run",
+        stepId: "file-step",
+        idempotencyKey: "file-demo-run:file-step",
+        file
+      } as LocalFileSubmitRequest)
+    ).resolves.toMatchObject({
+      ok: false,
+      operation: "submit",
+      error: {
+        code: "invalid-request",
+        message,
+        retryable: false
+      }
+    });
+  });
+
+  it("rejects unsafe allowed root configuration before fixture operations are available", () => {
+    expect(() =>
+      createLocalFileConnector({
+        allowedRoots: [{ alias: "fixture-root", path: "relative-fixtures" }]
+      })
+    ).toThrow("local file allowed root path must be absolute");
+  });
+
+  it("records retryable file connector failures in run state with sanitized evidence", async () => {
+    const tempRoot = await createTempRoot();
+    const fixtureRoot = join(tempRoot, "fixtures");
+    const statePath = join(tempRoot, "state", "file-demo.jsonl");
+    const connector = createLocalFileConnector({
+      allowedRoots: [{ alias: "fixture-root", path: fixtureRoot }]
+    });
+
+    const result = await runWorkflow({
+      definition: fileWorkflow,
+      statePath,
+      runId: "file-demo-run",
+      now: createClock([
+        "2026-05-02T04:02:00.000Z",
+        "2026-05-02T04:02:00.000Z",
+        "2026-05-02T04:02:01.000Z",
+        "2026-05-02T04:02:02.000Z",
+        "2026-05-02T04:02:03.000Z",
+        "2026-05-02T04:02:04.000Z",
+        "2026-05-02T04:02:05.000Z"
+      ]),
+      stepHandler: async ({ attempt, runState, step }) => {
+        if (attempt === 2) {
+          await mkdir(join(fixtureRoot, "inputs"), { recursive: true });
+          await writeFile(join(fixtureRoot, "inputs", "ready.txt"), "ready", "utf8");
+        }
+
+        const submitted = await connector.submit({
+          workflowId: runState.run.workflowId,
+          runId: runState.run.runId,
+          stepId: step.id,
+          idempotencyKey: `${runState.run.runId}:${step.id}:attempt-${attempt}`,
+          file: {
+            action: "read",
+            rootAlias: "fixture-root",
+            path: attempt === 1 ? "inputs/missing.txt" : "inputs/ready.txt"
+          }
+        });
+
+        if (!submitted.ok) {
+          throw new Error(submitted.error.message);
+        }
+
+        return {
+          executor: {
+            requestId: submitted.value.requestId,
+            status: "succeeded",
+            result: {
+              status: "succeeded",
+              summary: submitted.value.file.summary,
+              evidence: submitted.value.evidence
+            }
+          }
+        };
+      }
+    });
+
+    const persisted = await readWorkflowRunState(statePath);
+
+    expect(result.run.status).toBe("succeeded");
+    expect(persisted.stepAttempts["read-fixture"]).toMatchObject([
+      {
+        attempt: 1,
+        status: "retryable-failed",
+        retry: {
+          retryable: true,
+          reason: "local file read target was not found"
+        }
+      },
+      {
+        attempt: 2,
+        status: "succeeded",
+        result: {
+          executor: {
+            result: {
+              evidence: {
+                kind: "local-file-fixture",
+                rootAlias: "fixture-root",
+                path: "inputs/ready.txt"
+              }
+            }
+          }
+        }
+      }
+    ]);
+    expect(JSON.stringify(persisted)).not.toContain(fixtureRoot);
+  });
+});
+
+const fileWorkflow: WorkflowDefinition = {
+  schemaVersion: "flow.workflow.v1",
+  id: "file-demo",
+  trigger: {
+    type: "manual"
+  },
+  steps: [
+    {
+      id: "read-fixture",
+      action: {
+        type: "local",
+        name: "local_file_read"
+      },
+      retry: {
+        maxAttempts: 2,
+        backoff: {
+          strategy: "none"
+        }
+      }
+    }
+  ]
+};
+
+const createClock = (timestamps: string[]): (() => string) => {
+  let index = 0;
+
+  return () => timestamps[Math.min(index++, timestamps.length - 1)];
+};


### PR DESCRIPTION
## Summary
- add a bounded local file connector skeleton with explicit allowed root aliases
- support UTF-8 fixture read/write actions with sanitized alias/path evidence
- fail closed for unsafe roots, path traversal, absolute paths, unsupported actions, and changed idempotency replays
- document safe-root, cleanup, and non-goal boundaries

## Verification
- npm run build
- npm test -- test/file-connector.test.ts
- npm test
- rg -n '(/Users/|C:\\Users\\|/home/|/var/folders/)' docs fixtures test src README.md

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local file connector for reading/writing fixture files in workflow steps with safe-root enforcement, symlink checks, strict path validation, and idempotency controls.

* **Documentation**
  * New docs covering configuration, allowed-root semantics, idempotency behavior, fail-closed rules, evidence sanitization, lifecycle responsibilities, and non-goals.

* **Tests**
  * New test suite validating idempotency, concurrency, security fail-closed behavior, read retry semantics, and workflow retry integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->