### PR TITLE
Serialize HTTP notification idempotency submissions

### DIFF
--- a/src/http-notification-connector.ts
+++ b/src/http-notification-connector.ts
@@ -186,7 +186,7 @@ export const createHttpNotificationConnector = (
 
       const attempt = request.attempt ?? 1;
       const requestId = formatRequestId(connectorId, request.runId, request.stepId, attempt);
-      const submission = (async (): Promise<HttpNotificationSubmitResult> => {
+      const submission = Promise.resolve().then(async (): Promise<HttpNotificationSubmitResult> => {
         const outcome = await input.transport.deliver({
           workflowId: request.workflowId,
           runId: request.runId,
@@ -246,7 +246,7 @@ export const createHttpNotificationConnector = (
           operation: "submit",
           value: receipt
         };
-      })();
+      });
 
       pendingSubmissions.set(request.idempotencyKey, {
         fingerprint,

--- a/src/http-notification-connector.ts
+++ b/src/http-notification-connector.ts
@@ -109,6 +109,11 @@ interface IdempotencyRecord {
   fingerprint: string;
 }
 
+interface PendingIdempotencySubmission {
+  fingerprint: string;
+  promise: Promise<HttpNotificationSubmitResult>;
+}
+
 const defaultStatusReason = "HTTP notification skeleton records local submit outcomes only";
 const defaultCancelReason = "HTTP notification skeleton does not support cancellation";
 const defaultEvidenceReason = "HTTP notification skeleton does not fetch external evidence";
@@ -122,6 +127,7 @@ export const createHttpNotificationConnector = (
   const now = input.now ?? (() => new Date().toISOString());
   const capabilities = createHttpNotificationCapabilities(input.transport.capabilities?.notify);
   const successfulReceipts = new Map<string, IdempotencyRecord>();
+  const pendingSubmissions = new Map<string, PendingIdempotencySubmission>();
 
   const unsupported = (reason: string) =>
     createUnsupportedConnectorOperationResult({
@@ -166,67 +172,95 @@ export const createHttpNotificationConnector = (
         };
       }
 
-      const attempt = request.attempt ?? 1;
-      const requestId = formatRequestId(connectorId, request.runId, request.stepId, attempt);
-      const outcome = await input.transport.deliver({
-        workflowId: request.workflowId,
-        runId: request.runId,
-        stepId: request.stepId,
-        requestId,
-        idempotencyKey: request.idempotencyKey,
-        attempt,
-        endpointAlias: request.notification.endpointAlias,
-        method,
-        ...(request.notification.headers === undefined
-          ? {}
-          : { headers: request.notification.headers }),
-        ...(request.notification.payload === undefined
-          ? {}
-          : { payload: request.notification.payload })
-      });
+      const pending = pendingSubmissions.get(request.idempotencyKey);
+      if (pending !== undefined) {
+        if (pending.fingerprint !== fingerprint) {
+          return invalidRequest(
+            connectorId,
+            "HTTP notification idempotencyKey reuse must keep workflowId/runId/stepId/endpointAlias/method/headers/payload unchanged"
+          );
+        }
 
-      if (outcome.status === "failed") {
-        return {
-          ok: false,
-          connectorId,
-          operation: "submit",
-          error: {
-            code: "execution-failed",
-            message: outcome.summary ?? "HTTP notification failed in local fake transport",
-            retryable: outcome.retryable === true
-          }
-        };
+        return pending.promise;
       }
 
-      const acceptedAt = now();
-      const receipt: HttpNotificationReceipt = {
-        requestId,
-        acceptedAt,
-        notification: {
-          status: outcome.status,
+      const attempt = request.attempt ?? 1;
+      const requestId = formatRequestId(connectorId, request.runId, request.stepId, attempt);
+      const submission = (async (): Promise<HttpNotificationSubmitResult> => {
+        const outcome = await input.transport.deliver({
+          workflowId: request.workflowId,
+          runId: request.runId,
+          stepId: request.stepId,
+          requestId,
+          idempotencyKey: request.idempotencyKey,
+          attempt,
           endpointAlias: request.notification.endpointAlias,
           method,
-          attempt,
-          idempotencyKey: request.idempotencyKey,
-          ...(outcome.summary === undefined ? {} : { summary: outcome.summary }),
-          ...(outcome.retryable === undefined ? {} : { retryable: outcome.retryable })
-        },
-        evidence: {
-          kind: "http-notification-local",
-          endpointAlias: request.notification.endpointAlias,
-          attempt,
-          idempotencyKey: request.idempotencyKey,
-          ...(outcome.evidence === undefined ? {} : { transport: outcome.evidence })
-        }
-      };
-      successfulReceipts.set(request.idempotencyKey, { receipt, fingerprint });
+          ...(request.notification.headers === undefined
+            ? {}
+            : { headers: request.notification.headers }),
+          ...(request.notification.payload === undefined
+            ? {}
+            : { payload: request.notification.payload })
+        });
 
-      return {
-        ok: true,
-        connectorId,
-        operation: "submit",
-        value: receipt
-      };
+        if (outcome.status === "failed") {
+          return {
+            ok: false,
+            connectorId,
+            operation: "submit",
+            error: {
+              code: "execution-failed",
+              message: outcome.summary ?? "HTTP notification failed in local fake transport",
+              retryable: outcome.retryable === true
+            }
+          };
+        }
+
+        const acceptedAt = now();
+        const receipt: HttpNotificationReceipt = {
+          requestId,
+          acceptedAt,
+          notification: {
+            status: outcome.status,
+            endpointAlias: request.notification.endpointAlias,
+            method,
+            attempt,
+            idempotencyKey: request.idempotencyKey,
+            ...(outcome.summary === undefined ? {} : { summary: outcome.summary }),
+            ...(outcome.retryable === undefined ? {} : { retryable: outcome.retryable })
+          },
+          evidence: {
+            kind: "http-notification-local",
+            endpointAlias: request.notification.endpointAlias,
+            attempt,
+            idempotencyKey: request.idempotencyKey,
+            ...(outcome.evidence === undefined ? {} : { transport: outcome.evidence })
+          }
+        };
+        successfulReceipts.set(request.idempotencyKey, { receipt, fingerprint });
+
+        return {
+          ok: true,
+          connectorId,
+          operation: "submit",
+          value: receipt
+        };
+      })();
+
+      pendingSubmissions.set(request.idempotencyKey, {
+        fingerprint,
+        promise: submission
+      });
+
+      try {
+        return await submission;
+      } finally {
+        const current = pendingSubmissions.get(request.idempotencyKey);
+        if (current?.promise === submission) {
+          pendingSubmissions.delete(request.idempotencyKey);
+        }
+      }
     },
     status() {
       return createUnsupportedConnectorOperationResult({

--- a/test/http-notification-connector.test.ts
+++ b/test/http-notification-connector.test.ts
@@ -11,7 +11,9 @@ import {
   runWorkflow
 } from "../src/index.js";
 import type {
+  HttpNotificationOutcome,
   HttpNotificationSubmitRequest,
+  HttpNotificationTransportDelivery,
   WorkflowDefinition
 } from "../src/index.js";
 
@@ -107,6 +109,79 @@ describe("HTTP notification connector skeleton", () => {
 
     expect(first).toEqual(replay);
     expect(transport.deliveries).toHaveLength(1);
+  });
+
+  it("serializes concurrent same-key submits before transport delivery completes", async () => {
+    const deliveries: HttpNotificationTransportDelivery[] = [];
+    const delivery = createDeferred<HttpNotificationOutcome>();
+    const connector = createHttpNotificationConnector({
+      transport: {
+        deliver(request) {
+          deliveries.push(request);
+          return delivery.promise;
+        }
+      },
+      now: () => "2026-05-02T03:00:00.000Z"
+    });
+
+    const first = connector.submit(notifyRequest);
+    const replay = connector.submit(notifyRequest);
+
+    await Promise.resolve();
+    expect(deliveries).toHaveLength(1);
+
+    delivery.resolve({
+      status: "succeeded",
+      summary: "local fake notification accepted"
+    });
+
+    await expect(first).resolves.toMatchObject({ ok: true });
+    await expect(replay).resolves.toMatchObject({ ok: true });
+    await expect(first).resolves.toEqual(await replay);
+    expect(deliveries).toHaveLength(1);
+  });
+
+  it("fails closed for concurrent same-key submits with a changed fingerprint", async () => {
+    const deliveries: HttpNotificationTransportDelivery[] = [];
+    const delivery = createDeferred<HttpNotificationOutcome>();
+    const connector = createHttpNotificationConnector({
+      transport: {
+        deliver(request) {
+          deliveries.push(request);
+          return delivery.promise;
+        }
+      },
+      now: () => "2026-05-02T03:00:00.000Z"
+    });
+
+    const first = connector.submit(notifyRequest);
+    const changed = await connector.submit({
+      ...notifyRequest,
+      notification: {
+        ...notifyRequest.notification,
+        endpointAlias: "local-operator-escalation"
+      }
+    });
+
+    expect(changed).toMatchObject({
+      ok: false,
+      operation: "submit",
+      error: {
+        code: "invalid-request",
+        retryable: false,
+        message:
+          "HTTP notification idempotencyKey reuse must keep workflowId/runId/stepId/endpointAlias/method/headers/payload unchanged"
+      }
+    });
+    expect(deliveries).toHaveLength(1);
+
+    delivery.resolve({
+      status: "succeeded",
+      summary: "local fake notification accepted"
+    });
+
+    await expect(first).resolves.toMatchObject({ ok: true });
+    expect(deliveries).toHaveLength(1);
   });
 
   it("rejects idempotency replay when the request shape changes", async () => {
@@ -217,6 +292,43 @@ describe("HTTP notification connector skeleton", () => {
         message: "local fake endpoint is temporarily unavailable"
       }
     });
+  });
+
+  it("does not store a successful replay receipt for failed delivery", async () => {
+    const transport = createFakeHttpNotificationTransport({
+      outcomes: [
+        {
+          status: "failed",
+          summary: "local fake endpoint rejected notification",
+          retryable: false
+        },
+        {
+          status: "succeeded",
+          summary: "local fake notification accepted on retry"
+        }
+      ]
+    });
+    const connector = createHttpNotificationConnector({
+      transport,
+      now: createClock(["2026-05-02T03:00:00.000Z"])
+    });
+
+    await expect(connector.submit(notifyRequest)).resolves.toMatchObject({
+      ok: false,
+      error: {
+        code: "execution-failed",
+        message: "local fake endpoint rejected notification"
+      }
+    });
+    await expect(connector.submit(notifyRequest)).resolves.toMatchObject({
+      ok: true,
+      value: {
+        notification: {
+          summary: "local fake notification accepted on retry"
+        }
+      }
+    });
+    expect(transport.deliveries).toHaveLength(2);
   });
 
   it("fails closed for unsupported notification submit capability", async () => {
@@ -421,4 +533,16 @@ const createClock = (timestamps: string[]): (() => string) => {
   let index = 0;
 
   return () => timestamps[Math.min(index++, timestamps.length - 1)];
+};
+
+const createDeferred = <T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} => {
+  let resolve: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+
+  return { promise, resolve };
 };

--- a/test/http-notification-connector.test.ts
+++ b/test/http-notification-connector.test.ts
@@ -141,6 +141,35 @@ describe("HTTP notification connector skeleton", () => {
     expect(deliveries).toHaveLength(1);
   });
 
+  it("preinstalls the in-flight reservation before synchronously re-entrant delivery callbacks", async () => {
+    const deliveries: HttpNotificationTransportDelivery[] = [];
+    let reentrant: Promise<unknown> | undefined;
+    let connector: ReturnType<typeof createHttpNotificationConnector>;
+
+    connector = createHttpNotificationConnector({
+      transport: {
+        deliver(request) {
+          deliveries.push(request);
+          reentrant = connector.submit(notifyRequest);
+
+          return {
+            status: "succeeded",
+            summary: "local fake notification accepted"
+          };
+        }
+      },
+      now: () => "2026-05-02T03:00:00.000Z"
+    });
+
+    const first = connector.submit(notifyRequest);
+    const firstResult = await first;
+
+    expect(firstResult).toMatchObject({ ok: true });
+    expect(reentrant).toBeDefined();
+    await expect(reentrant).resolves.toEqual(firstResult);
+    expect(deliveries).toHaveLength(1);
+  });
+
   it("fails closed for concurrent same-key submits with a changed fingerprint", async () => {
     const deliveries: HttpNotificationTransportDelivery[] = [];
     const delivery = createDeferred<HttpNotificationOutcome>();


### PR DESCRIPTION
## Summary
- add in-flight HTTP notification idempotency reservations before transport delivery
- make concurrent same-key same-fingerprint submits share the same delivery result
- fail closed for concurrent changed-fingerprint submits and preserve failed-delivery retry behavior

## Verification
- npm run build
- npm test -- test/http-notification-connector.test.ts
- npm test

Closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Concurrent requests with the same idempotency key are deduplicated by reusing in-flight submissions, preventing duplicate deliveries and ensuring consistent results.
  * Reusing an idempotency key with a different request fingerprint now returns an `invalid-request` error (non-retryable).
  * Failed submissions no longer create cached receipts, enabling proper retries.

* **Tests**
  * Added tests covering concurrency deduplication, re-entrant submissions, fingerprint mismatch behavior, and replay after failed delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->