### PR TITLE
FLOW-FU-P4-002: Reject changed webhook replay

### DIFF
--- a/src/webhook-intake.ts
+++ b/src/webhook-intake.ts
@@ -312,7 +312,9 @@ const assertExistingWebhookInputMatches = async (
     return;
   }
 
-  const existingFingerprint = readStoredWebhookInputFingerprint(existingState);
+  const existingFingerprint =
+    readStoredWebhookInputFingerprint(existingState) ??
+    deriveLegacyWebhookInputFingerprint(existingState);
   if (existingFingerprint !== inputFingerprint) {
     throw new WebhookIntakeRejectedError(
       "webhook requestId reuse must keep normalized input unchanged"
@@ -346,6 +348,59 @@ const readStoredWebhookInputFingerprint = (state: WorkflowRunState): string | un
   }
 
   return typeof webhook.inputFingerprint === "string" ? webhook.inputFingerprint : undefined;
+};
+
+const deriveLegacyWebhookInputFingerprint = (
+  state: WorkflowRunState
+): string | undefined => {
+  const triggerContext = state.run.trigger.context;
+  if (!isRecord(triggerContext) || !isRecord(triggerContext.webhook)) {
+    return undefined;
+  }
+
+  const webhook = triggerContext.webhook;
+  const requestId = triggerContext.requestId;
+  const headers = readLegacyWebhookHeaders(webhook.headers);
+  if (
+    typeof requestId !== "string" ||
+    typeof webhook.path !== "string" ||
+    typeof webhook.receivedAt !== "string" ||
+    !isRecord(webhook.payload) ||
+    headers === null
+  ) {
+    return undefined;
+  }
+
+  return createWebhookInputFingerprint({
+    schemaVersion: WEBHOOK_INPUT_SCHEMA_VERSION,
+    requestId,
+    path: webhook.path,
+    receivedAt: webhook.receivedAt,
+    ...(headers === undefined ? {} : { headers }),
+    payload: webhook.payload
+  });
+};
+
+const readLegacyWebhookHeaders = (
+  value: unknown
+): Record<string, string> | undefined | null => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const headers: Record<string, string> = {};
+  for (const [key, headerValue] of Object.entries(value)) {
+    if (typeof headerValue !== "string") {
+      return null;
+    }
+    headers[key] = headerValue;
+  }
+
+  return headers;
 };
 
 const createWebhookInputFingerprint = (input: WebhookInput): string =>

--- a/src/webhook-intake.ts
+++ b/src/webhook-intake.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { join } from "node:path";
 
 import type { WorkflowRunState } from "./workflow-run-state.js";
+import { readWorkflowRunState } from "./workflow-run-state.js";
 import { validateWorkflowDefinition } from "./workflow-definition.js";
 import type { WorkflowDefinition } from "./workflow-definition.js";
 import { runWorkflow } from "./workflow-runner.js";
@@ -84,15 +85,20 @@ export const consumeWebhookInput = async (
   const definition = assertWebhookWorkflow(options.definition);
   const normalizedInput = normalizeWebhookInput(options.input, definition.trigger.path);
   const runId = createWebhookRunId(definition.id, normalizedInput.requestId);
+  const statePath = join(options.stateRoot, `${runId}.jsonl`);
+  const inputFingerprint = createWebhookInputFingerprint(normalizedInput);
+
+  await assertExistingWebhookInputMatches(statePath, inputFingerprint);
 
   return runWorkflow({
     definition,
-    statePath: join(options.stateRoot, `${runId}.jsonl`),
+    statePath,
     auditPath: options.auditPath,
     runId,
     triggerContext: {
       requestId: normalizedInput.requestId,
       webhook: {
+        inputFingerprint,
         path: normalizedInput.path,
         receivedAt: normalizedInput.receivedAt,
         ...(normalizedInput.headers === undefined ? {} : { headers: normalizedInput.headers }),
@@ -297,6 +303,73 @@ const rejectCredentialShapedKeys = (value: Record<string, unknown>, path: string
   rejectCredentialShapedValue(value, path);
 };
 
+const assertExistingWebhookInputMatches = async (
+  statePath: string,
+  inputFingerprint: string
+): Promise<void> => {
+  const existingState = await readExistingWebhookRunState(statePath);
+  if (existingState === undefined) {
+    return;
+  }
+
+  const existingFingerprint = readStoredWebhookInputFingerprint(existingState);
+  if (existingFingerprint !== inputFingerprint) {
+    throw new WebhookIntakeRejectedError(
+      "webhook requestId reuse must keep normalized input unchanged"
+    );
+  }
+};
+
+const readExistingWebhookRunState = async (
+  statePath: string
+): Promise<WorkflowRunState | undefined> => {
+  try {
+    return await readWorkflowRunState(statePath);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  }
+};
+
+const readStoredWebhookInputFingerprint = (state: WorkflowRunState): string | undefined => {
+  const triggerContext = state.run.trigger.context;
+  if (triggerContext === undefined) {
+    return undefined;
+  }
+
+  const webhook = triggerContext.webhook;
+  if (!isRecord(webhook)) {
+    return undefined;
+  }
+
+  return typeof webhook.inputFingerprint === "string" ? webhook.inputFingerprint : undefined;
+};
+
+const createWebhookInputFingerprint = (input: WebhookInput): string =>
+  createHash("sha256")
+    .update(stableStringify(input))
+    .digest("hex");
+
+const stableStringify = (value: unknown): string => {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>).sort(([left], [right]) =>
+    left.localeCompare(right)
+  );
+  return `{${entries
+    .map(([key, nestedValue]) => `${JSON.stringify(key)}:${stableStringify(nestedValue)}`)
+    .join(",")}}`;
+};
+
 const createWebhookRunId = (workflowId: string, requestId: string): string => {
   const slug =
     requestId
@@ -319,3 +392,6 @@ const isStrictUtcMillisTimestamp = (value: string): boolean => {
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isNodeError = (error: unknown): error is NodeJS.ErrnoException =>
+  error instanceof Error && "code" in error;

--- a/src/webhook-intake.ts
+++ b/src/webhook-intake.ts
@@ -2,7 +2,6 @@ import { createHash } from "node:crypto";
 import { join } from "node:path";
 
 import type { WorkflowRunState } from "./workflow-run-state.js";
-import { readWorkflowRunState } from "./workflow-run-state.js";
 import { validateWorkflowDefinition } from "./workflow-definition.js";
 import type { WorkflowDefinition } from "./workflow-definition.js";
 import { runWorkflow } from "./workflow-runner.js";
@@ -88,8 +87,6 @@ export const consumeWebhookInput = async (
   const statePath = join(options.stateRoot, `${runId}.jsonl`);
   const inputFingerprint = createWebhookInputFingerprint(normalizedInput);
 
-  await assertExistingWebhookInputMatches(statePath, inputFingerprint);
-
   return runWorkflow({
     definition,
     statePath,
@@ -105,6 +102,8 @@ export const consumeWebhookInput = async (
         payload: normalizedInput.payload
       }
     },
+    existingRunStateGuard: (existingState) =>
+      assertWebhookInputMatchesState(existingState, inputFingerprint),
     now: options.now,
     stepHandler: options.stepHandler
   });
@@ -303,15 +302,10 @@ const rejectCredentialShapedKeys = (value: Record<string, unknown>, path: string
   rejectCredentialShapedValue(value, path);
 };
 
-const assertExistingWebhookInputMatches = async (
-  statePath: string,
+const assertWebhookInputMatchesState = (
+  existingState: WorkflowRunState,
   inputFingerprint: string
-): Promise<void> => {
-  const existingState = await readExistingWebhookRunState(statePath);
-  if (existingState === undefined) {
-    return;
-  }
-
+): void => {
   const existingFingerprint =
     readStoredWebhookInputFingerprint(existingState) ??
     deriveLegacyWebhookInputFingerprint(existingState);
@@ -319,20 +313,6 @@ const assertExistingWebhookInputMatches = async (
     throw new WebhookIntakeRejectedError(
       "webhook requestId reuse must keep normalized input unchanged"
     );
-  }
-};
-
-const readExistingWebhookRunState = async (
-  statePath: string
-): Promise<WorkflowRunState | undefined> => {
-  try {
-    return await readWorkflowRunState(statePath);
-  } catch (error) {
-    if (isNodeError(error) && error.code === "ENOENT") {
-      return undefined;
-    }
-
-    throw error;
   }
 };
 
@@ -447,6 +427,3 @@ const isStrictUtcMillisTimestamp = (value: string): boolean => {
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
-
-const isNodeError = (error: unknown): error is NodeJS.ErrnoException =>
-  error instanceof Error && "code" in error;

--- a/src/webhook-intake.ts
+++ b/src/webhook-intake.ts
@@ -363,7 +363,7 @@ const stableStringify = (value: unknown): string => {
   }
 
   const entries = Object.entries(value as Record<string, unknown>).sort(([left], [right]) =>
-    left.localeCompare(right)
+    left < right ? -1 : left > right ? 1 : 0
   );
   return `{${entries
     .map(([key, nestedValue]) => `${JSON.stringify(key)}:${stableStringify(nestedValue)}`)

--- a/src/workflow-runner.ts
+++ b/src/workflow-runner.ts
@@ -37,6 +37,7 @@ export interface RunWorkflowInput {
   auditPath?: string;
   runId?: string;
   triggerContext?: Record<string, unknown>;
+  existingRunStateGuard?: (existingState: WorkflowRunState) => void;
   now?: () => string;
   stepHandler?: WorkflowStepHandler;
 }
@@ -103,6 +104,7 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
   const existingState = await readExistingRunState(input.statePath);
   if (existingState !== undefined) {
     assertExistingRunMatches(existingState, input.definition, runId, triggerIdempotencyKey);
+    input.existingRunStateGuard?.(existingState);
     if (existingState.run.terminalState !== undefined) {
       return existingState;
     }
@@ -111,18 +113,32 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
 
   const triggerReceivedAt = now();
   const createdAt = now();
-  await createWorkflowRun(input.statePath, {
-    runId,
-    workflowId: input.definition.id,
-    workflowVersion: workflowDefinitionSchemaVersion,
-    trigger: {
-      type: input.definition.trigger.type,
-      receivedAt: triggerReceivedAt,
-      context: triggerContext,
-      ...(triggerIdempotencyKey === undefined ? {} : { idempotencyKey: triggerIdempotencyKey })
-    },
-    createdAt
-  });
+  try {
+    await createWorkflowRun(input.statePath, {
+      runId,
+      workflowId: input.definition.id,
+      workflowVersion: workflowDefinitionSchemaVersion,
+      trigger: {
+        type: input.definition.trigger.type,
+        receivedAt: triggerReceivedAt,
+        context: triggerContext,
+        ...(triggerIdempotencyKey === undefined ? {} : { idempotencyKey: triggerIdempotencyKey })
+      },
+      createdAt
+    });
+  } catch (error) {
+    if (!isNodeError(error) || error.code !== "EEXIST") {
+      throw error;
+    }
+
+    const competingState = await readWorkflowRunState(input.statePath);
+    assertExistingRunMatches(competingState, input.definition, runId, triggerIdempotencyKey);
+    input.existingRunStateGuard?.(competingState);
+    if (competingState.run.terminalState !== undefined) {
+      return competingState;
+    }
+    throw new Error("workflow run state already exists but is not terminal; resume is out of scope");
+  }
   await auditWriter?.write({
     type: "workflow.started",
     occurredAt: createdAt

--- a/test/webhook-intake-boundary.test.ts
+++ b/test/webhook-intake-boundary.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -45,6 +45,23 @@ const readAuditEvents = async (auditPath: string): Promise<Array<Record<string, 
     .trimEnd()
     .split("\n")
     .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const removePersistedWebhookInputFingerprint = async (statePath: string): Promise<void> => {
+  const events = (await readFile(statePath, "utf8"))
+    .trimEnd()
+    .split("\n")
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+  const trigger = events[0]?.trigger;
+  if (!isRecord(trigger) || !isRecord(trigger.context) || !isRecord(trigger.context.webhook)) {
+    throw new Error("fixture state must include webhook trigger context");
+  }
+
+  delete trigger.context.webhook.inputFingerprint;
+  await writeFile(statePath, `${events.map((event) => JSON.stringify(event)).join("\n")}\n`);
+};
 
 afterEach(async () => {
   await Promise.all(
@@ -137,6 +154,52 @@ describe("webhook intake boundary", () => {
       id: `audit.${expectedRunId}.000001`,
       run: { id: expectedRunId }
     });
+  });
+
+  it("replays legacy webhook run state without a stored fingerprint when normalized input is unchanged", async () => {
+    const definition = createWebhookWorkflow();
+    const root = await createTempRoot();
+    const stateRoot = join(root, "runs");
+    const auditPath = join(root, "audit", "webhook.audit.jsonl");
+    const input = createWebhookInput();
+
+    const first = await consumeWebhookInput({
+      definition,
+      stateRoot,
+      auditPath,
+      input
+    });
+    const statePath = join(stateRoot, `${first.run.runId}.jsonl`);
+    await removePersistedWebhookInputFingerprint(statePath);
+    const legacyState = await readWorkflowRunState(statePath);
+    const auditBeforeReplay = await readAuditEvents(auditPath);
+
+    const replay = await consumeWebhookInput({
+      definition,
+      stateRoot,
+      auditPath,
+      input: createWebhookInput()
+    });
+
+    expect(replay).toEqual(legacyState);
+    expect(await readAuditEvents(auditPath)).toEqual(auditBeforeReplay);
+
+    const changedInput = createWebhookInput();
+    changedInput.payload = {
+      eventType: "local-demo.updated",
+      subject: "placeholder-subject"
+    };
+    await expect(
+      consumeWebhookInput({
+        definition,
+        stateRoot,
+        auditPath,
+        input: changedInput
+      })
+    ).rejects.toThrow("webhook requestId reuse must keep normalized input unchanged");
+
+    expect(await readWorkflowRunState(statePath)).toEqual(legacyState);
+    expect(await readAuditEvents(auditPath)).toEqual(auditBeforeReplay);
   });
 
   it("rejects reused requestIds when normalized webhook payload changes without writing audit events", async () => {

--- a/test/webhook-intake-boundary.test.ts
+++ b/test/webhook-intake-boundary.test.ts
@@ -97,6 +97,7 @@ describe("webhook intake boundary", () => {
       receivedAt: "2026-05-02T01:00:01.000Z",
       context: {
         webhook: {
+          inputFingerprint: expect.any(String),
           path: "/hooks/local-demo",
           receivedAt: "2026-05-02T01:00:00.000Z",
           headers: {
@@ -136,6 +137,76 @@ describe("webhook intake boundary", () => {
       id: `audit.${expectedRunId}.000001`,
       run: { id: expectedRunId }
     });
+  });
+
+  it("rejects reused requestIds when normalized webhook payload changes without writing audit events", async () => {
+    const definition = createWebhookWorkflow();
+    const root = await createTempRoot();
+    const stateRoot = join(root, "runs");
+    const auditPath = join(root, "audit", "webhook.audit.jsonl");
+    const firstInput = createWebhookInput();
+    const changedInput = createWebhookInput();
+    changedInput.payload = {
+      eventType: "local-demo.updated",
+      subject: "placeholder-subject"
+    };
+
+    const first = await consumeWebhookInput({
+      definition,
+      stateRoot,
+      auditPath,
+      input: firstInput
+    });
+    const auditBeforeReplay = await readAuditEvents(auditPath);
+
+    await expect(
+      consumeWebhookInput({
+        definition,
+        stateRoot,
+        auditPath,
+        input: changedInput
+      })
+    ).rejects.toThrow("webhook requestId reuse must keep normalized input unchanged");
+
+    const persisted = await readWorkflowRunState(join(stateRoot, `${first.run.runId}.jsonl`));
+    expect(persisted).toEqual(first);
+    expect(await readAuditEvents(auditPath)).toEqual(auditBeforeReplay);
+  });
+
+  it("rejects reused requestIds when normalized webhook headers or receivedAt change", async () => {
+    const definition = createWebhookWorkflow();
+    const root = await createTempRoot();
+    const stateRoot = join(root, "runs");
+    const firstInput = createWebhookInput();
+    const changedHeaders = createWebhookInput();
+    changedHeaders.headers = {
+      "content-type": "application/json",
+      "x-event-type": "local-demo.updated"
+    };
+    const changedReceivedAt = createWebhookInput();
+    changedReceivedAt.receivedAt = "2026-05-02T01:00:01.000Z";
+
+    await consumeWebhookInput({
+      definition,
+      stateRoot,
+      input: firstInput
+    });
+
+    await expect(
+      consumeWebhookInput({
+        definition,
+        stateRoot,
+        input: changedHeaders
+      })
+    ).rejects.toThrow("webhook requestId reuse must keep normalized input unchanged");
+
+    await expect(
+      consumeWebhookInput({
+        definition,
+        stateRoot,
+        input: changedReceivedAt
+      })
+    ).rejects.toThrow("webhook requestId reuse must keep normalized input unchanged");
   });
 
   it("keeps distinct requestIds with the same normalized slug in separate runs", async () => {

--- a/test/webhook-intake-boundary.test.ts
+++ b/test/webhook-intake-boundary.test.ts
@@ -9,7 +9,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   consumeWebhookInput,
   readWorkflowRunState,
-  validateWorkflowDefinition
+  validateWorkflowDefinition,
+  WebhookIntakeRejectedError
 } from "../src/index.js";
 import type { WorkflowDefinition, WebhookInput } from "../src/index.js";
 
@@ -234,6 +235,65 @@ describe("webhook intake boundary", () => {
     const persisted = await readWorkflowRunState(join(stateRoot, `${first.run.runId}.jsonl`));
     expect(persisted).toEqual(first);
     expect(await readAuditEvents(auditPath)).toEqual(auditBeforeReplay);
+  });
+
+  it("rejects concurrent reused requestIds when normalized webhook payload changes", async () => {
+    const definition = createWebhookWorkflow();
+    const root = await createTempRoot();
+    const stateRoot = join(root, "runs");
+    const auditPath = join(root, "audit", "webhook.audit.jsonl");
+    const firstInput = createWebhookInput();
+    const changedInput = createWebhookInput();
+    changedInput.payload = {
+      eventType: "local-demo.updated",
+      subject: "placeholder-subject"
+    };
+
+    const results = await Promise.allSettled([
+      consumeWebhookInput({
+        definition,
+        stateRoot,
+        auditPath,
+        input: firstInput
+      }),
+      consumeWebhookInput({
+        definition,
+        stateRoot,
+        auditPath,
+        input: changedInput
+      })
+    ]);
+
+    const fulfilled = results.filter(
+      (result): result is PromiseFulfilledResult<Awaited<ReturnType<typeof consumeWebhookInput>>> =>
+        result.status === "fulfilled"
+    );
+    const rejected = results.filter(
+      (result): result is PromiseRejectedResult => result.status === "rejected"
+    );
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]!.reason).toBeInstanceOf(WebhookIntakeRejectedError);
+    expect(rejected[0]!.reason.message).toBe(
+      "webhook requestId reuse must keep normalized input unchanged"
+    );
+
+    const persisted = await readWorkflowRunState(
+      join(stateRoot, `${fulfilled[0]!.value.run.runId}.jsonl`)
+    );
+    expect(persisted).toEqual(fulfilled[0]!.value);
+    expect(persisted.events.map((event) => event.type)).toEqual([
+      "run.created",
+      "step.attempt.started",
+      "step.attempt.completed",
+      "run.completed"
+    ]);
+    expect((await readAuditEvents(auditPath)).map((event) => event.type)).toEqual([
+      "workflow.started",
+      "step.started",
+      "step.completed",
+      "workflow.completed"
+    ]);
   });
 
   it("rejects reused requestIds when normalized webhook headers or receivedAt change", async () => {


### PR DESCRIPTION
## Summary
- persist a stable fingerprint for normalized webhook input in run trigger context
- reject reused requestIds when the normalized webhook path, receivedAt, headers, or payload changes
- keep exact replay behavior for unchanged webhook input and prove conflict paths do not append audit/state

## Verification
- npm run build
- npm test -- test/webhook-intake-boundary.test.ts
- npm test

Closes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook intake now enforces deterministic input fingerprints: reused request IDs with changed normalized input are rejected; legacy persisted runs without fingerprints are accepted if inputs match. Concurrent replay/create races are handled to ensure idempotent behavior and consistent persisted run state.

* **Tests**
  * Added coverage for fingerprint enforcement, legacy-compat replay, concurrency/race scenarios, and verification that rejected replays do not write extra audit events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->