### PR TITLE
FLOW-046: Add Protocol v0.2.0 connection smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ authority, and no premature compliance claims.
   boundary, Loop local fake lane command shape, stdout contract, failure
   routing, focused Flow smoke coverage, local cleanup limits, and
   non-production limits.
+- `docs/loop-flow-protocol-v0.2.0-connection-smoke.md`: pre-Phase 5
+  Protocol v0.2.0 Loop-Flow connection smoke, capability checks, focused
+  commands, and failure routing.
 
 ## Workflow Definition Schema
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Start here:
 - [X-Gate 2 Loop-Flow Smoke Runbook](./x-gate2-loop-flow-smoke-runbook.md): local smoke commands, artifacts, failure routing, and non-production boundaries.
 - [X-Gate 3 Flow Caller Boundary Runbook](./x-gate3-flow-caller-boundary-runbook.md): Flow-owned caller boundary for Loop local fake lane smoke input, stdout output, artifacts, and failure routing.
 - Focused Flow X-Gate 3 smoke coverage: `npm test -- test/x-gate3-flow-smoke.test.ts`.
+- [Loop-Flow Protocol v0.2.0 Connection Smoke](./loop-flow-protocol-v0.2.0-connection-smoke.md): pre-Phase 5 local/fake/dry-run smoke, capability variant checks, focused commands, and `protocol-gap` / `loop-gap` / `flow-gap` routing.
 - [Ensen-protocol v0.2.0 Snapshot](../protocol-snapshots/ensen-protocol/v0.2.0/README.md): active copied protocol schemas, conformance fixtures, capability variant examples, and contract docs for pre-Phase 5 connector tests.
 
 Ensen-flow documentation should preserve the product boundary: lightweight explainable workflow orchestration, no shared runtime dependency with Ensen-loop, and no premature Pharma/GxP compliance claims.

--- a/docs/loop-flow-protocol-v0.2.0-connection-smoke.md
+++ b/docs/loop-flow-protocol-v0.2.0-connection-smoke.md
@@ -43,12 +43,12 @@ repository root:
 ```sh
 npm ci
 npm run build
-npm test -- test/executor-connector.test.ts test/cli-loop-executor-smoke.test.ts test/protocol-snapshot.test.ts
+npm test -- test/executor-connector.test.ts test/cli-loop-executor-smoke.test.ts test/protocol-snapshot.test.ts test/loop-flow-protocol-v020-smoke-runbook.test.ts
 ```
 
 The focused command validates the Flow executor connector, the local/fake Loop
-CLI stdout smoke, and the copied Protocol v0.2.0 snapshot. The full repo check
-remains:
+CLI stdout smoke, the copied Protocol v0.2.0 snapshot, and the runbook guard.
+The full repo check remains:
 
 ```sh
 npm test

--- a/docs/loop-flow-protocol-v0.2.0-connection-smoke.md
+++ b/docs/loop-flow-protocol-v0.2.0-connection-smoke.md
@@ -1,0 +1,109 @@
+# Loop-Flow Protocol v0.2.0 Connection Smoke
+
+This runbook is the pre-Phase 5 Flow-owned smoke for the Loop-Flow executor
+boundary. It verifies that Flow constructs and consumes Protocol v0.2.0-shaped
+artifacts through the executor connector boundary without importing Ensen-loop
+runtime code, importing an Ensen-protocol runtime package, or depending on a
+mutable sibling checkout at Flow runtime.
+
+It is local smoke evidence only. It is not production Loop dispatch, provider
+execution, SCM mutation, pull request creation, ERPNext behavior,
+Pharma/GxP readiness, or compliance evidence.
+
+Out of scope: no production Loop dispatch, no real executor service, no real
+provider run, no repository mutation, no real pull request, no customer data,
+not compliance evidence, and no production evidence archive.
+
+## Snapshot Boundary
+
+Use the copied active snapshot under
+`protocol-snapshots/ensen-protocol/v0.2.0/` as the contract boundary:
+
+- RunRequest: `schemas/eip.run-request.v1.schema.json` and
+  `fixtures/run-request/v1/valid/`;
+- RunStatusSnapshot: `schemas/eip.run-status.v1.schema.json` and
+  `fixtures/run-status/v1/valid/`;
+- RunResult: `schemas/eip.run-result.v1.schema.json` and
+  `fixtures/run-result/v1/valid/`;
+- EvidenceBundleRef: `schemas/eip.evidence-bundle-ref.v1.schema.json` and
+  `fixtures/evidence-bundle-ref/v1/valid/`;
+- capability vocabulary:
+  `docs/integration/executor-transport-capabilities.md` and
+  `fixtures/capability-variants/v1/valid/`.
+
+Do not resolve this boundary by importing Ensen-protocol code or reading a
+sibling checkout at Flow runtime. Snapshot drift is repaired by replacing the
+copied snapshot from a tagged Protocol release.
+
+## Local Commands
+
+Install, build, and run the focused pre-Phase 5 smoke from the Ensen-flow
+repository root:
+
+```sh
+npm ci
+npm run build
+npm test -- test/executor-connector.test.ts test/cli-loop-executor-smoke.test.ts test/protocol-snapshot.test.ts
+```
+
+The focused command validates the Flow executor connector, the local/fake Loop
+CLI stdout smoke, and the copied Protocol v0.2.0 snapshot. The full repo check
+remains:
+
+```sh
+npm test
+```
+
+If an operator also has a local Loop CLI, keep it optional and sanitized:
+
+```sh
+CODEX_SUPERVISOR_CONFIG=<supervisor-config-path> npm test -- test/cli-loop-executor-smoke.test.ts
+```
+
+The local CLI boundary is expected to accept a protocol-shaped
+`<run-request-json-file>` and return a deterministic local/fake/dry-run
+aggregate. It must not start a real provider session, mutate a repository,
+create a real pull request, call production Loop services, or write customer
+data.
+
+## Capability Checks
+
+The smoke keeps Protocol v0.2.0 capability levels explicit:
+
+| Capability | Required smoke behavior |
+| --- | --- |
+| `submit` | Required baseline. Flow must submit a RunRequest-shaped payload with an idempotency key and explicit source/requester/work-item binding. |
+| `status` | Optional or partial. Unsupported polling must return an unsupported operation or fail closed; Flow must not fabricate terminal RunStatusSnapshot success. |
+| `cancel` | Optional or unsupported. Unsupported cancel leaves the run unchanged and reports unsupported cancellation; Flow must not mark the run cancelled by inference. |
+| `fetchEvidence` | Optional, partial, or unsupported. Evidence absence does not rewrite authoritative terminal status, and unsupported fetch does not invent an EvidenceBundleRef. |
+| polling support | Optional or partial. Repeated reads must stay anchored to the submitted request and authoritative status/result artifacts. |
+| evidence reference support | Optional or partial. References remain public-safe local refs or fixture refs, not embedded evidence bodies or workstation paths. |
+| idempotency expectation | Required baseline. Replays must stay bound to the same logical RunRequest scope instead of relying on correlation id or naming. |
+
+Use
+`protocol-snapshots/ensen-protocol/v0.2.0/fixtures/capability-variants/v1/valid/`
+as the comparison set for unsupported, partial, and fully supported examples.
+
+## Failure Routing
+
+| Failure class | Route follow-up to | Use when |
+| --- | --- | --- |
+| `protocol-gap` | TommyKammy/Ensen-protocol, using TommyKammy/Ensen-protocol#28 as the template | The copied v0.2.0 snapshot is missing or ambiguous, fixture capability vocabulary disagrees with contract docs, an artifact shape cannot be represented by Protocol v0.2.0, or a successful local CLI output is not valid protocol-shaped JSON. |
+| `loop-gap` | TommyKammy/Ensen-loop | The local/fake/dry-run Loop boundary cannot produce the expected aggregate, reports unsupported behavior that contradicts explicit Protocol text, exits non-zero without a valid blocked aggregate, times out, or claims real mutation/provider behavior in this smoke. |
+| `flow-gap` | TommyKammy/Ensen-flow | Flow constructs an invalid RunRequest, rejects valid v0.2.0 artifacts, fabricates status/result/evidence/cancellation success, loses the submitted request binding, or documents an unsafe command or path. |
+
+When ownership is unclear, keep the guard in place and route the ambiguity as
+`protocol-gap` instead of resolving it through Flow-specific interpretation.
+
+## Cleanup
+
+The focused tests create temporary local artifacts and clean them up
+automatically. Manual smoke cleanup is limited to caller-provided scratch paths:
+
+```sh
+rm -f <state-jsonl-path>
+rm -rf <local-smoke-artifact-root>
+```
+
+Do not delete repository checkouts, supervisor state, sibling repositories,
+customer artifacts, or production evidence stores as part of this smoke.

--- a/test/executor-connector.test.ts
+++ b/test/executor-connector.test.ts
@@ -35,6 +35,17 @@ const readProtocolFixture = async (relativePath: string): Promise<unknown> =>
 const isFixtureRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+const readCapabilitySummary = async (
+  relativePath: string
+): Promise<Record<string, unknown>> => {
+  const fixture = await readProtocolFixture(relativePath);
+  if (!isFixtureRecord(fixture) || !isFixtureRecord(fixture.capabilitySummary)) {
+    throw new Error(`${relativePath} must include capabilitySummary`);
+  }
+
+  return fixture.capabilitySummary;
+};
+
 const readFixtureRequestId = (value: unknown): string => {
   if (!isFixtureRecord(value) || typeof value.requestId !== "string") {
     throw new Error("fixture must include requestId");
@@ -340,6 +351,131 @@ describe("executor connector abstraction", () => {
       error: {
         code: "unsupported-operation",
         reason: "fake partial executor does not expose durable evidence"
+      }
+    });
+  });
+
+  it("keeps Protocol v0.2.0 capability variants explicit at the Flow connector boundary", async () => {
+    const submitOnlySummary = await readCapabilitySummary(
+      "fixtures/capability-variants/v1/valid/submit-only-no-polling.json"
+    );
+    const unsupportedCancelSummary = await readCapabilitySummary(
+      "fixtures/capability-variants/v1/valid/unsupported-cancel.json"
+    );
+    const evidenceUnavailableSummary = await readCapabilitySummary(
+      "fixtures/capability-variants/v1/valid/evidence-unavailable.json"
+    );
+
+    expect(submitOnlySummary).toMatchObject({
+      submit: "required baseline",
+      status: "unsupported",
+      cancel: "unsupported",
+      fetchEvidence: "unsupported",
+      "polling support": "unsupported",
+      "evidence reference support": "partial",
+      "idempotency expectation": "required baseline"
+    });
+    expect(unsupportedCancelSummary).toMatchObject({
+      cancel: "unsupported",
+      fetchEvidence: "partial",
+      "polling support": "partial"
+    });
+    expect(evidenceUnavailableSummary).toMatchObject({
+      fetchEvidence: "unsupported",
+      "evidence reference support": "partial"
+    });
+
+    const submitOnly = createFakeExecutorTransport({
+      connectorId: "protocol-v020-submit-only",
+      capabilities: createImmediateOnlyConnectorCapabilities({
+        unsupportedReason:
+          "protocol v0.2.0 submit-only-no-polling: status, cancel, and fetchEvidence are unsupported"
+      })
+    });
+    const submitted = await submitOnly.submit({
+      ...submitRequest,
+      policyDecision: { decision: "allow" }
+    });
+
+    expect(submitted).toMatchObject({
+      ok: true,
+      value: {
+        flowControl: { state: "ready" }
+      }
+    });
+    if (!submitted.ok) {
+      throw new Error("submit-only connector should accept the baseline RunRequest");
+    }
+
+    for (const operation of ["status", "cancel", "fetchEvidence"] as const) {
+      const result =
+        operation === "status"
+          ? await submitOnly.status({ requestId: submitted.value.requestId })
+          : operation === "cancel"
+            ? await submitOnly.cancel({ requestId: submitted.value.requestId })
+            : await submitOnly.fetchEvidence({ requestId: submitted.value.requestId });
+
+      expect(result).toMatchObject({
+        ok: false,
+        operation,
+        error: {
+          code: "unsupported-operation",
+          retryable: false,
+          reason:
+            "protocol v0.2.0 submit-only-no-polling: status, cancel, and fetchEvidence are unsupported"
+        }
+      });
+    }
+
+    const evidenceUnavailable = createFakeExecutorTransport({
+      connectorId: "protocol-v020-evidence-unavailable",
+      capabilities: {
+        fetchEvidence: {
+          supported: false,
+          reason:
+            "protocol v0.2.0 evidence-unavailable: fetchEvidence is unsupported and evidence reference support is partial"
+        }
+      },
+      statusScript: [
+        {
+          status: "succeeded",
+          result: {
+            status: "succeeded",
+            summary: "terminal result remains authoritative without evidence fetch success"
+          }
+        }
+      ]
+    });
+    const evidenceSubmitted = await evidenceUnavailable.submit({
+      ...submitRequest,
+      run: { id: "evidence-unavailable-run" },
+      policyDecision: { decision: "allow" }
+    });
+    if (!evidenceSubmitted.ok) {
+      throw new Error("evidence-unavailable submit should succeed");
+    }
+
+    expect(await evidenceUnavailable.status({ requestId: evidenceSubmitted.value.requestId }))
+      .toMatchObject({
+        ok: true,
+        value: {
+          status: "succeeded",
+          result: {
+            status: "succeeded",
+            summary: "terminal result remains authoritative without evidence fetch success"
+          }
+        }
+      });
+    expect(
+      await evidenceUnavailable.fetchEvidence({ requestId: evidenceSubmitted.value.requestId })
+    ).toMatchObject({
+      ok: false,
+      operation: "fetchEvidence",
+      error: {
+        code: "unsupported-operation",
+        retryable: false,
+        reason:
+          "protocol v0.2.0 evidence-unavailable: fetchEvidence is unsupported and evidence reference support is partial"
       }
     });
   });

--- a/test/loop-flow-protocol-v020-smoke-runbook.test.ts
+++ b/test/loop-flow-protocol-v020-smoke-runbook.test.ts
@@ -1,0 +1,66 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+const runbookPath = "docs/loop-flow-protocol-v0.2.0-connection-smoke.md";
+const readmePath = "README.md";
+const docsIndexPath = "docs/README.md";
+const posixHomeRootPattern = new RegExp(["", "Users", "[A-Za-z0-9._-]+"].join("\\/"));
+const linuxHomeRootPattern = new RegExp(["", "home", "[A-Za-z0-9._-]+"].join("\\/"));
+const windowsHomeRootPattern = new RegExp(["[A-Za-z]:", "Users", ""].join("\\\\"));
+
+describe("Loop-Flow Protocol v0.2.0 connection smoke runbook", () => {
+  it("documents the pre-Phase 5 snapshot boundary, commands, capability checks, and routing", async () => {
+    const runbook = await readFile(runbookPath, "utf8");
+
+    for (const requiredText of [
+      "pre-Phase 5",
+      "protocol-snapshots/ensen-protocol/v0.2.0/",
+      "RunRequest",
+      "RunStatusSnapshot",
+      "RunResult",
+      "EvidenceBundleRef",
+      "fixtures/capability-variants/v1/valid/",
+      "npm run build",
+      "npm test -- test/executor-connector.test.ts test/cli-loop-executor-smoke.test.ts test/protocol-snapshot.test.ts",
+      "CODEX_SUPERVISOR_CONFIG=<supervisor-config-path>",
+      "<run-request-json-file>",
+      "submit",
+      "status",
+      "cancel",
+      "fetchEvidence",
+      "polling support",
+      "evidence reference support",
+      "idempotency expectation",
+      "unsupported operation",
+      "must not fabricate terminal RunStatusSnapshot success",
+      "must not mark the run cancelled by inference",
+      "does not invent an EvidenceBundleRef",
+      "protocol-gap",
+      "loop-gap",
+      "flow-gap",
+      "TommyKammy/Ensen-protocol#28",
+      "no production Loop dispatch",
+      "not production Loop dispatch",
+      "not production",
+      "not compliance evidence",
+      "Do not delete repository checkouts"
+    ]) {
+      expect(runbook).toContain(requiredText);
+    }
+
+    expect(runbook).not.toMatch(posixHomeRootPattern);
+    expect(runbook).not.toMatch(linuxHomeRootPattern);
+    expect(runbook).not.toMatch(windowsHomeRootPattern);
+  });
+
+  it("links the pre-Phase 5 smoke from public documentation navigation", async () => {
+    const [readme, docsIndex] = await Promise.all([
+      readFile(readmePath, "utf8"),
+      readFile(docsIndexPath, "utf8")
+    ]);
+
+    expect(readme).toContain("docs/loop-flow-protocol-v0.2.0-connection-smoke.md");
+    expect(docsIndex).toContain("loop-flow-protocol-v0.2.0-connection-smoke.md");
+  });
+});


### PR DESCRIPTION
## Summary
- add a pre-Phase 5 Loop-Flow Protocol v0.2.0 connection smoke runbook
- link the smoke from README and docs navigation
- tighten Flow connector coverage against Protocol v0.2.0 capability-variant fixtures for unsupported/partial capability behavior

## Verification
- npm run build
- npm test -- test/executor-connector.test.ts test/cli-loop-executor-smoke.test.ts test/protocol-snapshot.test.ts test/loop-flow-protocol-v020-smoke-runbook.test.ts
- npm test

Closes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Loop-Flow Protocol v0.2.0 Connection Smoke runbook with pre-Phase 5 smoke test guidance, capability checks, focused commands, failure-routing rules, idempotency expectations, evidence/cleanup guidance, and navigation links in docs.

* **Tests**
  * Added tests validating the runbook’s required sections and absence of platform-specific paths, plus executor-connector capability-variant tests to verify expected operation support and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->