### PR TITLE
FLOW-X3A-001: Enforce dry-run-first input boundary

### DIFF
--- a/docs/connector-capability-matrix.md
+++ b/docs/connector-capability-matrix.md
@@ -29,6 +29,28 @@ production integration readiness.
 | local file connector | fake/local-only: `flow.local-file.v1` reads and writes UTF-8 fixture files under explicit allowed root aliases. | Supported for retryable local read failures such as missing fixture targets when the workflow retry policy allows another attempt. | Supported for successful `submit` calls through the connector idempotency store; changed replay fingerprints fail closed. | Unsupported; file access is bounded by allowed roots and does not request approvals. | Unsupported and returns `unsupported-operation`; actions complete inline. | Unsupported and returns `unsupported-operation`. | Unsupported and returns `unsupported-operation`; submit receipts include sanitized alias plus relative-path evidence only. | Deferred: unrestricted filesystem automation, binary blob processing, lane-state file access, repository mutation, production artifact storage, and customer data handling. |
 | executor connector | supported interface boundary for Ensen-protocol v0.2.0: `ExecutorConnector` defines the protocol-facing `submit`, `status`, `cancel`, and `fetchEvidence` operations for future executor implementations, including explicit flow-control states. | Partial support: Flow runner retry handling can react to retryable connector failures, and Protocol v0.2.0 transport error examples define retryable and non-retryable outcomes; provider-specific retry queues remain deferred. | Required baseline for retryable `submit`: Flow carries `idempotencyKey` through `ExecutorSubmitRequest`; each implementation must enforce the protocol idempotency expectation by binding replay to the authoritative scope record and failing closed when idempotency, requester, or provenance is missing or malformed. | Supported as a flow-control state: `approval-required` is represented by `ExecutorPolicyDecisionPayload` and mapped by Flow before executor submission. | Optional capability: supported by the interface contract and v0.2.0 RunStatusSnapshot fixtures. Polling support is partial and must report unsupported or unknown instead of fabricating terminal status when the provider does not advertise polling. | Optional capability: supported by the interface contract and v0.2.0 capability variants, including unsupported cancel behavior. Implementations must leave the authoritative run unchanged when cancellation is unsupported or out of scope. | Optional capability: supported by the interface contract and v0.2.0 EvidenceBundleRef fixtures. Evidence reference support is partial; unsupported or unavailable evidence must be reported without embedding evidence bodies, secrets, customer data, or workstation-local paths. | Deferred: production Ensen-loop dispatch, external executor service integration, remote auth, long-running transaction handling, and protocol contract changes in this repository. Missing policy decisions block instead of allowing execution. Ambiguous capability vocabulary is routed to Ensen-protocol instead of redefined in Flow. |
 
+## Controlled Pilot Input Boundary
+
+Track A controlled pilot candidates are dry-run-first. A current Flow input
+surface is pilot-runnable only when it is explicitly fake, local, or dry-run at
+the Flow boundary before owner-controlled real input is considered.
+
+| Surface | Pilot input boundary before Track A completion | Real input handling before Track A completion |
+| --- | --- | --- |
+| schedule trigger | Dry-run/local only: a caller supplies one UTC `scheduledFor` instant to `evaluateScheduleTrigger`; Flow does not subscribe to a scheduler. | Blocked: no scheduler daemon, cloud schedule, calendar feed, or production timezone policy is treated as runnable here. |
+| webhook intake | Fake/local only: `consumeWebhookInput` accepts bounded `flow.webhook.input.v1` fixture objects for declared local paths. | Blocked: no public HTTP listener, production signature validation, trusted proxy normalization, customer webhook, forwarded identity, tenant hint, or credential-bearing payload is accepted. |
+| local file connector | Local fixture only: callers must configure explicit allowed root aliases, and receipts expose only alias plus relative path evidence. | Blocked: no customer files, unrestricted filesystem access, lane-state files, repository mutation, production artifact storage, or credential-shaped roots are accepted. |
+| HTTP notification connector | Fake/dry-run/local only: fake transports declare `mode: "fake"`, and custom transports must declare a fake, local, or dry-run input boundary before `notify` is supported. | Blocked by default: a missing boundary or real transport without explicit dry-run-first evidence and a human-controlled override is treated as unsupported. |
+
+Real input overrides are not inferred from connector names, endpoint aliases,
+workflow metadata, or nearby documentation. A later real-input connector must
+carry explicit dry-run-first evidence plus a human-controlled override at the
+enforcement boundary before Flow can treat it as pilot-runnable.
+
+Customer data, ERPNext live connectors, regulated data, Pharma/GxP workflow
+packs, production notification providers, and compliance-readiness claims remain
+out of scope until later gates explicitly accept them.
+
 ## Routing Later Connector Gaps
 
 Keep later connector gaps narrow and routed to the owning boundary:

--- a/src/controlled-pilot-input-boundary.ts
+++ b/src/controlled-pilot-input-boundary.ts
@@ -18,6 +18,9 @@ export interface ControlledPilotInputBoundary {
   override?: ControlledPilotOverride;
 }
 
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.trim() !== "";
+
 export const explainControlledPilotBoundaryRejection = (
   input: {
     surface: string;
@@ -25,7 +28,7 @@ export const explainControlledPilotBoundaryRejection = (
   }
 ): string | undefined => {
   const prefix = `${input.surface} must declare a fake, local, or dry-run input boundary`;
-  if (input.boundary === undefined) {
+  if (input.boundary === undefined || input.boundary === null) {
     return `${prefix} before controlled pilot use`;
   }
 
@@ -37,11 +40,11 @@ export const explainControlledPilotBoundaryRejection = (
   const override = input.boundary.override;
   if (
     evidence === undefined ||
-    evidence.reference.trim() === "" ||
+    !isNonEmptyString(evidence?.reference) ||
     override === undefined ||
-    override.approvedBy.trim() === "" ||
-    override.approvedAt.trim() === "" ||
-    override.reason.trim() === ""
+    !isNonEmptyString(override?.approvedBy) ||
+    !isNonEmptyString(override?.approvedAt) ||
+    !isNonEmptyString(override?.reason)
   ) {
     return `${input.surface} real input requires explicit dry-run-first evidence and a human-controlled override`;
   }

--- a/src/controlled-pilot-input-boundary.ts
+++ b/src/controlled-pilot-input-boundary.ts
@@ -1,0 +1,50 @@
+export type DryRunFirstInputBoundaryMode = "fake" | "local" | "dry-run";
+export type ControlledPilotInputBoundaryMode = DryRunFirstInputBoundaryMode | "real";
+
+export interface ControlledPilotOverride {
+  approvedBy: string;
+  approvedAt: string;
+  reason: string;
+}
+
+export interface DryRunFirstEvidence {
+  mode: DryRunFirstInputBoundaryMode;
+  reference: string;
+}
+
+export interface ControlledPilotInputBoundary {
+  mode: ControlledPilotInputBoundaryMode;
+  dryRunFirstEvidence?: DryRunFirstEvidence;
+  override?: ControlledPilotOverride;
+}
+
+export const explainControlledPilotBoundaryRejection = (
+  input: {
+    surface: string;
+    boundary?: ControlledPilotInputBoundary;
+  }
+): string | undefined => {
+  const prefix = `${input.surface} must declare a fake, local, or dry-run input boundary`;
+  if (input.boundary === undefined) {
+    return `${prefix} before controlled pilot use`;
+  }
+
+  if (input.boundary.mode === "fake" || input.boundary.mode === "local" || input.boundary.mode === "dry-run") {
+    return undefined;
+  }
+
+  const evidence = input.boundary.dryRunFirstEvidence;
+  const override = input.boundary.override;
+  if (
+    evidence === undefined ||
+    evidence.reference.trim() === "" ||
+    override === undefined ||
+    override.approvedBy.trim() === "" ||
+    override.approvedAt.trim() === "" ||
+    override.reason.trim() === ""
+  ) {
+    return `${input.surface} real input requires explicit dry-run-first evidence and a human-controlled override`;
+  }
+
+  return undefined;
+};

--- a/src/http-notification-connector.ts
+++ b/src/http-notification-connector.ts
@@ -1,12 +1,18 @@
 import {
   createUnsupportedConnectorOperationResult
 } from "./connector.js";
+import {
+  explainControlledPilotBoundaryRejection
+} from "./controlled-pilot-input-boundary.js";
 import type {
   ConnectorCapabilities,
   ConnectorOperationSupport,
   ConnectorResult,
   ConnectorSubmitRequest
 } from "./connector.js";
+import type {
+  ControlledPilotInputBoundary
+} from "./controlled-pilot-input-boundary.js";
 
 export type HttpNotificationMethod = "POST" | "PUT" | "PATCH";
 export type HttpNotificationOutcomeStatus = "succeeded" | "failed";
@@ -66,6 +72,7 @@ export interface HttpNotificationTransportDelivery {
 }
 
 export interface HttpNotificationTransport {
+  inputBoundary?: ControlledPilotInputBoundary;
   capabilities?: {
     notify?: ConnectorOperationSupport;
   };
@@ -125,7 +132,10 @@ export const createHttpNotificationConnector = (
 ): HttpNotificationConnector => {
   const connectorId = input.connectorId ?? "http-notification";
   const now = input.now ?? (() => new Date().toISOString());
-  const capabilities = createHttpNotificationCapabilities(input.transport.capabilities?.notify);
+  const capabilities = createHttpNotificationCapabilities({
+    notifyOverride: input.transport.capabilities?.notify,
+    inputBoundary: input.transport.inputBoundary
+  });
   const successfulReceipts = new Map<string, IdempotencyRecord>();
   const pendingSubmissions = new Map<string, PendingIdempotencySubmission>();
 
@@ -296,6 +306,7 @@ export const createFakeHttpNotificationTransport = (
       : input.outcomes;
 
   return {
+    inputBoundary: { mode: "fake" },
     capabilities: input.capabilities,
     get deliveries() {
       return deliveries.map((delivery) => ({ ...delivery }));
@@ -308,10 +319,14 @@ export const createFakeHttpNotificationTransport = (
   };
 };
 
-const createHttpNotificationCapabilities = (
-  notifyOverride: ConnectorOperationSupport | undefined
-): HttpNotificationCapabilities => {
-  const notify = notifyOverride ?? { supported: true as const };
+const createHttpNotificationCapabilities = (input: {
+  notifyOverride: ConnectorOperationSupport | undefined;
+  inputBoundary: ControlledPilotInputBoundary | undefined;
+}): HttpNotificationCapabilities => {
+  const notify =
+    input.notifyOverride?.supported === false
+      ? input.notifyOverride
+      : createBoundaryAwareNotifyCapability(input.inputBoundary);
 
   return {
     notify,
@@ -320,6 +335,19 @@ const createHttpNotificationCapabilities = (
     cancel: { supported: false, reason: defaultCancelReason },
     fetchEvidence: { supported: false, reason: defaultEvidenceReason }
   };
+};
+
+const createBoundaryAwareNotifyCapability = (
+  inputBoundary: ControlledPilotInputBoundary | undefined
+): ConnectorOperationSupport => {
+  const rejectionReason = explainControlledPilotBoundaryRejection({
+    surface: "HTTP notification transport",
+    boundary: inputBoundary
+  });
+
+  return rejectionReason === undefined
+    ? { supported: true }
+    : { supported: false, reason: rejectionReason };
 };
 
 const validateSubmitRequest = (request: HttpNotificationSubmitRequest): string | undefined => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,10 @@ export {
 } from "./executor-connector.js";
 
 export {
+  explainControlledPilotBoundaryRejection
+} from "./controlled-pilot-input-boundary.js";
+
+export {
   createFakeHttpNotificationTransport,
   createHttpNotificationConnector
 } from "./http-notification-connector.js";
@@ -237,3 +241,11 @@ export type {
   NeutralAuditStepReference,
   NeutralAuditWorkflowReference
 } from "./audit-event-writer.js";
+
+export type {
+  ControlledPilotInputBoundary,
+  ControlledPilotInputBoundaryMode,
+  ControlledPilotOverride,
+  DryRunFirstEvidence,
+  DryRunFirstInputBoundaryMode
+} from "./controlled-pilot-input-boundary.js";

--- a/test/connector-capability-matrix-docs.test.ts
+++ b/test/connector-capability-matrix-docs.test.ts
@@ -45,6 +45,20 @@ describe("connector capability matrix docs", () => {
       expect(matrix).toContain(requiredText);
     }
 
+    for (const requiredText of [
+      "Controlled Pilot Input Boundary",
+      "Track A controlled pilot candidates are dry-run-first",
+      "schedule trigger | Dry-run/local only",
+      "webhook intake | Fake/local only",
+      "local file connector | Local fixture only",
+      "HTTP notification connector | Fake/dry-run/local only",
+      "human-controlled override",
+      "Customer data, ERPNext live connectors, regulated data, Pharma/GxP workflow",
+      "compliance-readiness claims remain"
+    ]) {
+      expect(matrix).toContain(requiredText);
+    }
+
     expect(matrix).not.toMatch(posixHomeRootPattern);
     expect(matrix).not.toMatch(linuxHomeRootPattern);
     expect(matrix).not.toMatch(windowsHomeRootPattern);

--- a/test/controlled-pilot-input-boundary.test.ts
+++ b/test/controlled-pilot-input-boundary.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { explainControlledPilotBoundaryRejection } from "../src/index.js";
+import type { ControlledPilotInputBoundary } from "../src/index.js";
+
+describe("controlled pilot input boundary", () => {
+  const malformedRealBoundary = (
+    patch: Record<string, unknown>
+  ): ControlledPilotInputBoundary =>
+    ({
+      mode: "real",
+      dryRunFirstEvidence: {
+        mode: "dry-run",
+        reference: "docs/connector-capability-matrix.md"
+      },
+      override: {
+        approvedBy: "owner",
+        approvedAt: "2026-05-03T00:00:00.000Z",
+        reason: "controlled owner pilot"
+      },
+      ...patch
+    }) as unknown as ControlledPilotInputBoundary;
+
+  it("rejects malformed missing boundary input without throwing", () => {
+    expect(() =>
+      explainControlledPilotBoundaryRejection({
+        surface: "HTTP notification transport",
+        boundary: null as unknown as ControlledPilotInputBoundary
+      })
+    ).not.toThrow();
+    expect(
+      explainControlledPilotBoundaryRejection({
+        surface: "HTTP notification transport",
+        boundary: null as unknown as ControlledPilotInputBoundary
+      })
+    ).toBe(
+      "HTTP notification transport must declare a fake, local, or dry-run input boundary before controlled pilot use"
+    );
+  });
+
+  it("rejects malformed real input evidence and override fields without throwing", () => {
+    const expectedReason =
+      "HTTP notification transport real input requires explicit dry-run-first evidence and a human-controlled override";
+    const boundaries = [
+      malformedRealBoundary({
+        dryRunFirstEvidence: null
+      }),
+      malformedRealBoundary({
+        override: null
+      }),
+      malformedRealBoundary({
+        dryRunFirstEvidence: { mode: "dry-run", reference: 42 }
+      }),
+      malformedRealBoundary({
+        override: {
+          approvedBy: ["owner"],
+          approvedAt: "2026-05-03T00:00:00.000Z",
+          reason: "controlled owner pilot"
+        }
+      }),
+      malformedRealBoundary({
+        override: {
+          approvedBy: "owner",
+          approvedAt: null,
+          reason: "controlled owner pilot"
+        }
+      }),
+      malformedRealBoundary({
+        override: {
+          approvedBy: "owner",
+          approvedAt: "2026-05-03T00:00:00.000Z",
+          reason: { ticket: "pilot-approval" }
+        }
+      })
+    ];
+
+    for (const boundary of boundaries) {
+      expect(() =>
+        explainControlledPilotBoundaryRejection({
+          surface: "HTTP notification transport",
+          boundary
+        })
+      ).not.toThrow();
+      expect(
+        explainControlledPilotBoundaryRejection({
+          surface: "HTTP notification transport",
+          boundary
+        })
+      ).toBe(expectedReason);
+    }
+  });
+});

--- a/test/http-notification-connector.test.ts
+++ b/test/http-notification-connector.test.ts
@@ -116,6 +116,7 @@ describe("HTTP notification connector skeleton", () => {
     const delivery = createDeferred<HttpNotificationOutcome>();
     const connector = createHttpNotificationConnector({
       transport: {
+        inputBoundary: { mode: "dry-run" },
         deliver(request) {
           deliveries.push(request);
           return delivery.promise;
@@ -148,6 +149,7 @@ describe("HTTP notification connector skeleton", () => {
 
     connector = createHttpNotificationConnector({
       transport: {
+        inputBoundary: { mode: "dry-run" },
         deliver(request) {
           deliveries.push(request);
           reentrant = connector.submit(notifyRequest);
@@ -175,6 +177,7 @@ describe("HTTP notification connector skeleton", () => {
     const delivery = createDeferred<HttpNotificationOutcome>();
     const connector = createHttpNotificationConnector({
       transport: {
+        inputBoundary: { mode: "dry-run" },
         deliver(request) {
           deliveries.push(request);
           return delivery.promise;
@@ -380,6 +383,31 @@ describe("HTTP notification connector skeleton", () => {
         code: "unsupported-operation",
         retryable: false,
         reason: "real outbound HTTP is not enabled"
+      }
+    });
+  });
+
+  it("fails closed when a custom transport has no dry-run-first input boundary", async () => {
+    const connector = createHttpNotificationConnector({
+      transport: {
+        deliver() {
+          return {
+            status: "succeeded",
+            summary: "custom transport accepted notification"
+          };
+        }
+      }
+    });
+
+    await expect(connector.submit(notifyRequest)).resolves.toMatchObject({
+      ok: false,
+      connectorId: "http-notification",
+      operation: "submit",
+      error: {
+        code: "unsupported-operation",
+        retryable: false,
+        reason:
+          "HTTP notification transport must declare a fake, local, or dry-run input boundary before controlled pilot use"
       }
     });
   });

--- a/test/webhook-trigger.test.ts
+++ b/test/webhook-trigger.test.ts
@@ -1,0 +1,82 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  consumeWebhookInput,
+  readWorkflowRunState
+} from "../src/index.js";
+import type { WebhookInput, WorkflowDefinition } from "../src/index.js";
+
+const tempRoots: string[] = [];
+
+const readFixture = <T>(...parts: string[]): T =>
+  JSON.parse(readFileSync(join(process.cwd(), "fixtures", ...parts), "utf8")) as T;
+
+const createWebhookWorkflow = (): WorkflowDefinition =>
+  readFixture("workflow-definitions", "simple-webhook.valid.json");
+
+const createWebhookInput = (): WebhookInput =>
+  readFixture("webhook-inputs", "local-demo.valid.json");
+
+const createExpectedWebhookRunId = (workflowId: string, requestId: string): string => {
+  const slug =
+    requestId
+      .toLowerCase()
+      .replaceAll(/[^a-z0-9-]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "request";
+  const fingerprint = createHash("sha256").update(requestId).digest("hex").slice(0, 12);
+  return `${workflowId}-webhook-${slug}-${fingerprint}`;
+};
+
+const createTempRoot = async () => {
+  const root = await mkdtemp(join(tmpdir(), "ensen-flow-webhook-trigger-"));
+  tempRoots.push(root);
+  return root;
+};
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
+  );
+});
+
+describe("webhook trigger controlled pilot boundary", () => {
+  it("keeps webhook intake fake/local and rejects changed requestId replays without extra state", async () => {
+    const definition = createWebhookWorkflow();
+    const root = await createTempRoot();
+    const stateRoot = join(root, "runs");
+    const firstInput = createWebhookInput();
+    const changedInput = createWebhookInput();
+    changedInput.payload = {
+      eventType: "local-demo.updated",
+      subject: "placeholder-subject"
+    };
+
+    const first = await consumeWebhookInput({
+      definition,
+      stateRoot,
+      input: firstInput
+    });
+    const expectedRunId = createExpectedWebhookRunId(definition.id, firstInput.requestId);
+    const beforeReplay = await readFile(join(stateRoot, `${expectedRunId}.jsonl`), "utf8");
+
+    await expect(
+      consumeWebhookInput({
+        definition,
+        stateRoot,
+        input: changedInput
+      })
+    ).rejects.toThrow("webhook requestId reuse must keep normalized input unchanged");
+
+    expect(first.run.runId).toBe(expectedRunId);
+    expect(await readWorkflowRunState(join(stateRoot, `${expectedRunId}.jsonl`))).toEqual(first);
+    await expect(readFile(join(stateRoot, `${expectedRunId}.jsonl`), "utf8")).resolves.toBe(
+      beforeReplay
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- enforce a dry-run-first controlled pilot boundary on HTTP notification transports
- document schedule, webhook, local file, and HTTP notification pilot input boundaries
- add focused tests for missing transport boundary rejection, webhook replay cleanliness, and boundary docs

## Verification
- npm run build
- npm test -- test/schedule-trigger.test.ts test/webhook-trigger.test.ts test/file-connector.test.ts test/http-notification-connector.test.ts test/connector-capability-matrix-docs.test.ts
- npm test
- node dist/index.js issue-lint 82 --config supervisor.config.coderabbit.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Controlled Pilot Input Boundary" guidance mapping scheduled, webhook, local-file and HTTP intake behaviors and clarifying dry-run vs real input requirements and human-controlled overrides.

* **New Features**
  * Added input-boundary validation distinguishing fake/local/dry-run vs real modes and requiring dry-run evidence + explicit override for real inputs.
  * Made notification transport behavior boundary-aware.

* **Tests**
  * Added/updated tests covering boundary validation across webhooks and notification transports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->