### PR TITLE
FLOW-050: Add JSONL workflow run recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ The model records trigger context, idempotency metadata, step attempts, retry
 metadata, timestamps, and explicit terminal states while remaining independent
 from Ensen-loop and external connector contracts.
 
+Recovery uses the same Flow-owned JSONL boundary. `inspectWorkflowRunRecovery`
+classifies an existing state file as `recoverable`, `terminal`, `corrupt`, or
+`manual-repair-needed` without mutating the file, and returns an explainable
+diagnostic instead of trusting connector-specific authority. `runWorkflow` can
+continue a projected non-terminal local run only when completed steps and
+retryable attempts make the next step unambiguous; active or contradictory
+attempt state fails closed for operator review. `stopWorkflowRunRecovery`
+performs an explicit safe stop by appending a `canceled` terminal event, never by
+deleting or rewriting prior run evidence.
+
 ## Neutral Audit JSONL Events
 
 The local runner can also write append-only JSONL audit events when callers pass

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,9 @@ export type { EipVersionBoundary } from "./eip-version.js";
 export {
   appendWorkflowRunEvent,
   createWorkflowRun,
-  readWorkflowRunState
+  inspectWorkflowRunRecovery,
+  readWorkflowRunState,
+  stopWorkflowRunRecovery
 } from "./workflow-run-state.js";
 
 export { createLocalAuditEventWriter } from "./audit-event-writer.js";
@@ -164,12 +166,18 @@ export type {
   WorkflowRunCreatedEvent,
   WorkflowRunEvent,
   WorkflowRunIdempotencyMetadata,
+  WorkflowRunRecoveryAction,
+  WorkflowRunRecoveryClassification,
+  WorkflowRunRecoveryReport,
+  WorkflowRunRecoveryRunSummary,
+  WorkflowRunRecoveryStepAttemptSummary,
   WorkflowRunRecord,
   WorkflowRunRetryMetadata,
   WorkflowRunState,
   WorkflowRunStatus,
   WorkflowRunTerminalState,
   WorkflowRunTriggerContext,
+  StopWorkflowRunRecoveryInput,
   WorkflowStepAttemptEvent,
   WorkflowStepAttemptResultMetadata,
   WorkflowStepAttemptState

--- a/src/workflow-run-state.ts
+++ b/src/workflow-run-state.ts
@@ -160,6 +160,51 @@ export interface WorkflowRunState {
 
 export type WorkflowStepAttemptResultMetadata = Record<string, unknown>;
 
+export type WorkflowRunRecoveryClassification =
+  | "recoverable"
+  | "terminal"
+  | "corrupt"
+  | "manual-repair-needed";
+
+export type WorkflowRunRecoveryAction =
+  | "resume-from-projected-state"
+  | "do-not-replay"
+  | "repair-jsonl-before-recovery"
+  | "operator-review-required";
+
+export interface WorkflowRunRecoveryReport {
+  classification: WorkflowRunRecoveryClassification;
+  action: WorkflowRunRecoveryAction;
+  diagnostic: string;
+  historyPreserved: true;
+  run?: WorkflowRunRecoveryRunSummary;
+  eventCount?: number;
+  activeStepAttempts?: WorkflowRunRecoveryStepAttemptSummary[];
+}
+
+export interface WorkflowRunRecoveryRunSummary {
+  runId: string;
+  workflowId: string;
+  workflowVersion: string;
+  status: WorkflowRunStatus;
+  terminalState?: WorkflowRunTerminalState;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WorkflowRunRecoveryStepAttemptSummary {
+  stepId: string;
+  attempt: number;
+  status: WorkflowStepAttemptState["status"];
+  startedAt?: string;
+}
+
+export interface StopWorkflowRunRecoveryInput {
+  statePath: string;
+  runId: string;
+  stoppedAt: string;
+}
+
 export const createWorkflowRun = async (
   statePath: string,
   input: CreateWorkflowRunInput
@@ -230,6 +275,109 @@ export const readWorkflowRunState = async (
   const events = parseWorkflowRunEvents(contents);
 
   return projectWorkflowRunEvents(events);
+};
+
+export const inspectWorkflowRunRecovery = async (
+  statePath: string
+): Promise<WorkflowRunRecoveryReport> => {
+  let state: WorkflowRunState;
+  try {
+    state = await readWorkflowRunState(statePath);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return {
+        classification: "manual-repair-needed",
+        action: "operator-review-required",
+        diagnostic: "workflow run state file is missing; recovery requires existing JSONL state",
+        historyPreserved: true
+      };
+    }
+
+    return {
+      classification: "corrupt",
+      action: "repair-jsonl-before-recovery",
+      diagnostic: sanitizeRecoveryDiagnostic(error),
+      historyPreserved: true
+    };
+  }
+
+  const run = summarizeRecoveryRun(state.run);
+  if (state.run.terminalState !== undefined) {
+    return {
+      classification: "terminal",
+      action: "do-not-replay",
+      diagnostic: `workflow run ${state.run.runId} is terminal (${state.run.terminalState}); recovery must not replay active work`,
+      historyPreserved: true,
+      run,
+      eventCount: state.events.length
+    };
+  }
+
+  const activeStepAttempts = summarizeActiveStepAttempts(state.stepAttempts);
+  if (activeStepAttempts.length > 0) {
+    return {
+      classification: "manual-repair-needed",
+      action: "operator-review-required",
+      diagnostic:
+        "workflow run has active step attempts; operator review is required before stop or retry because local state cannot prove external side effects",
+      historyPreserved: true,
+      run,
+      eventCount: state.events.length,
+      activeStepAttempts
+    };
+  }
+
+  if (hasFailedNonTerminalStepAttempt(state.stepAttempts)) {
+    return {
+      classification: "manual-repair-needed",
+      action: "operator-review-required",
+      diagnostic:
+        "workflow run has failed non-terminal step attempts; operator review is required before recovery because the run should have recorded a terminal state",
+      historyPreserved: true,
+      run,
+      eventCount: state.events.length
+    };
+  }
+
+  return {
+    classification: "recoverable",
+    action: "resume-from-projected-state",
+    diagnostic:
+      "workflow run is non-terminal and has no active step attempt; recovery can continue from projected JSONL state",
+    historyPreserved: true,
+    run,
+    eventCount: state.events.length
+  };
+};
+
+export const stopWorkflowRunRecovery = async (
+  input: StopWorkflowRunRecoveryInput
+): Promise<WorkflowRunRecoveryReport> => {
+  const report = await inspectWorkflowRunRecovery(input.statePath);
+  if (report.classification === "corrupt") {
+    throw new Error(`cannot stop corrupt workflow run state: ${report.diagnostic}`);
+  }
+
+  if (report.run === undefined) {
+    throw new Error(`cannot stop workflow run state: ${report.diagnostic}`);
+  }
+
+  if (report.run.runId !== input.runId) {
+    throw new Error("cannot stop workflow run state: runId must match projected JSONL state");
+  }
+
+  if (report.classification === "terminal") {
+    return report;
+  }
+
+  await appendWorkflowRunEvent(input.statePath, {
+    type: "run.completed",
+    runId: input.runId,
+    terminalState: "canceled",
+    occurredAt: input.stoppedAt
+  });
+
+  return inspectWorkflowRunRecovery(input.statePath);
 };
 
 const projectWorkflowRunEvents = (events: WorkflowRunEvent[]): WorkflowRunState => {
@@ -593,6 +741,48 @@ const missingWorkflowRunStateError = (): Error =>
   new Error(
     "appendWorkflowRunEvent requires an existing workflow run state file; call createWorkflowRun before appendWorkflowRunEvent so readWorkflowRunState can project a stream with run.created"
   );
+
+const summarizeRecoveryRun = (run: WorkflowRunRecord): WorkflowRunRecoveryRunSummary => ({
+  runId: run.runId,
+  workflowId: run.workflowId,
+  workflowVersion: run.workflowVersion,
+  status: run.status,
+  terminalState: run.terminalState,
+  createdAt: run.createdAt,
+  updatedAt: run.updatedAt
+});
+
+const summarizeActiveStepAttempts = (
+  stepAttempts: Record<string, WorkflowStepAttemptState[]>
+): WorkflowRunRecoveryStepAttemptSummary[] =>
+  Object.entries(stepAttempts).flatMap(([stepId, attempts]) =>
+    attempts
+      .filter((attempt) => attempt.status === "running")
+      .map((attempt) => ({
+        stepId,
+        attempt: attempt.attempt,
+        status: attempt.status,
+        startedAt: attempt.startedAt
+      }))
+  );
+
+const hasFailedNonTerminalStepAttempt = (
+  stepAttempts: Record<string, WorkflowStepAttemptState[]>
+): boolean =>
+  Object.values(stepAttempts).some((attempts) => attempts.at(-1)?.status === "failed");
+
+const sanitizeRecoveryDiagnostic = (error: unknown): string => {
+  const message = error instanceof Error ? error.message : String(error);
+  const trimmed = message.trim();
+  if (trimmed === "") {
+    return "workflow run state could not be inspected";
+  }
+
+  return trimmed
+    .replaceAll(/"[^"]*(?:\/Users\/|\/home\/|\\Users\\)[^"]*"/g, '"<path>"')
+    .replaceAll(/(?:\/Users\/|\/home\/)[^\s)]+/g, "<path>")
+    .replaceAll(/[A-Za-z]:\\Users\\[^\s)]+/g, "<path>");
+};
 
 const validateJsonSerializableValue = (
   value: unknown,

--- a/src/workflow-runner.ts
+++ b/src/workflow-runner.ts
@@ -113,6 +113,7 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
   } else {
     const triggerReceivedAt = now();
     const createdAt = now();
+    let createdNewRun = false;
     try {
       await createWorkflowRun(input.statePath, {
         runId,
@@ -126,6 +127,7 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
         },
         createdAt
       });
+      createdNewRun = true;
     } catch (error) {
       if (!isNodeError(error) || error.code !== "EEXIST") {
         throw error;
@@ -139,10 +141,12 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
       }
       assertExistingRunRecoverable(competingState, orderedSteps);
     }
-    await auditWriter?.write({
-      type: "workflow.started",
-      occurredAt: createdAt
-    });
+    if (createdNewRun) {
+      await auditWriter?.write({
+        type: "workflow.started",
+        occurredAt: createdAt
+      });
+    }
   }
 
   for (const step of orderedSteps) {
@@ -437,6 +441,28 @@ const assertExistingRunRecoverable = (
   existingState: WorkflowRunState,
   orderedSteps: WorkflowStep[]
 ): void => {
+  let sawIncompleteStep = false;
+
+  for (const step of orderedSteps) {
+    const latestAttempt = latestStepAttempt(existingState.stepAttempts[step.id]);
+    if (latestAttempt?.status === "succeeded") {
+      if (sawIncompleteStep) {
+        throw new Error(
+          `existing workflow run state references step ${step.id} after an incomplete earlier step; manual repair is required before recovery`
+        );
+      }
+      continue;
+    }
+
+    if (latestAttempt !== undefined && sawIncompleteStep) {
+      throw new Error(
+        `existing workflow run state references step ${step.id} after an incomplete earlier step; manual repair is required before recovery`
+      );
+    }
+
+    sawIncompleteStep = true;
+  }
+
   for (const [stepId, attempts] of Object.entries(existingState.stepAttempts)) {
     if (!orderedSteps.some((step) => step.id === stepId)) {
       throw new Error(

--- a/src/workflow-runner.ts
+++ b/src/workflow-runner.ts
@@ -14,7 +14,8 @@ import type {
 import type {
   WorkflowRunIdempotencyMetadata,
   WorkflowStepAttemptResultMetadata,
-  WorkflowRunState
+  WorkflowRunState,
+  WorkflowStepAttemptState
 } from "./workflow-run-state.js";
 import {
   eipVersionBoundary,
@@ -108,46 +109,60 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
     if (existingState.run.terminalState !== undefined) {
       return existingState;
     }
-    throw new Error("workflow run state already exists but is not terminal; resume is out of scope");
-  }
+    assertExistingRunRecoverable(existingState, orderedSteps);
+  } else {
+    const triggerReceivedAt = now();
+    const createdAt = now();
+    try {
+      await createWorkflowRun(input.statePath, {
+        runId,
+        workflowId: input.definition.id,
+        workflowVersion: workflowDefinitionSchemaVersion,
+        trigger: {
+          type: input.definition.trigger.type,
+          receivedAt: triggerReceivedAt,
+          context: triggerContext,
+          ...(triggerIdempotencyKey === undefined ? {} : { idempotencyKey: triggerIdempotencyKey })
+        },
+        createdAt
+      });
+    } catch (error) {
+      if (!isNodeError(error) || error.code !== "EEXIST") {
+        throw error;
+      }
 
-  const triggerReceivedAt = now();
-  const createdAt = now();
-  try {
-    await createWorkflowRun(input.statePath, {
-      runId,
-      workflowId: input.definition.id,
-      workflowVersion: workflowDefinitionSchemaVersion,
-      trigger: {
-        type: input.definition.trigger.type,
-        receivedAt: triggerReceivedAt,
-        context: triggerContext,
-        ...(triggerIdempotencyKey === undefined ? {} : { idempotencyKey: triggerIdempotencyKey })
-      },
-      createdAt
+      const competingState = await readWorkflowRunState(input.statePath);
+      assertExistingRunMatches(competingState, input.definition, runId, triggerIdempotencyKey);
+      input.existingRunStateGuard?.(competingState);
+      if (competingState.run.terminalState !== undefined) {
+        return competingState;
+      }
+      assertExistingRunRecoverable(competingState, orderedSteps);
+    }
+    await auditWriter?.write({
+      type: "workflow.started",
+      occurredAt: createdAt
     });
-  } catch (error) {
-    if (!isNodeError(error) || error.code !== "EEXIST") {
-      throw error;
-    }
-
-    const competingState = await readWorkflowRunState(input.statePath);
-    assertExistingRunMatches(competingState, input.definition, runId, triggerIdempotencyKey);
-    input.existingRunStateGuard?.(competingState);
-    if (competingState.run.terminalState !== undefined) {
-      return competingState;
-    }
-    throw new Error("workflow run state already exists but is not terminal; resume is out of scope");
   }
-  await auditWriter?.write({
-    type: "workflow.started",
-    occurredAt: createdAt
-  });
 
   for (const step of orderedSteps) {
     const retryPolicy = step.retry ?? { maxAttempts: 1, backoff: { strategy: "none" as const } };
+    const latestAttempt = latestStepAttempt(
+      (await readWorkflowRunState(input.statePath)).stepAttempts[step.id]
+    );
+    if (latestAttempt?.status === "succeeded") {
+      continue;
+    }
 
-    for (let attempt = 1; attempt <= retryPolicy.maxAttempts; attempt += 1) {
+    const firstAttempt =
+      latestAttempt?.status === "retryable-failed" ? latestAttempt.attempt + 1 : 1;
+    if (firstAttempt > retryPolicy.maxAttempts) {
+      throw new Error(
+        `existing workflow run state cannot resume ${step.id}; retry policy has no remaining attempts`
+      );
+    }
+
+    for (let attempt = firstAttempt; attempt <= retryPolicy.maxAttempts; attempt += 1) {
       const startedAt = now();
       await appendWorkflowRunEvent(input.statePath, {
         type: "step.attempt.started",
@@ -417,6 +432,36 @@ const assertExistingRunMatches = (
     throw new Error("existing workflow run state has a different runId");
   }
 };
+
+const assertExistingRunRecoverable = (
+  existingState: WorkflowRunState,
+  orderedSteps: WorkflowStep[]
+): void => {
+  for (const [stepId, attempts] of Object.entries(existingState.stepAttempts)) {
+    if (!orderedSteps.some((step) => step.id === stepId)) {
+      throw new Error(
+        `existing workflow run state references unknown step ${stepId}; manual repair is required before recovery`
+      );
+    }
+
+    const latestAttempt = latestStepAttempt(attempts);
+    if (latestAttempt?.status === "running") {
+      throw new Error(
+        `existing workflow run state has active step attempt ${stepId}#${latestAttempt.attempt}; manual repair is required before recovery`
+      );
+    }
+
+    if (latestAttempt?.status === "failed") {
+      throw new Error(
+        `existing workflow run state has failed non-terminal step ${stepId}#${latestAttempt.attempt}; manual repair is required before recovery`
+      );
+    }
+  }
+};
+
+const latestStepAttempt = (
+  attempts: WorkflowStepAttemptState[] | undefined
+): WorkflowStepAttemptState | undefined => attempts?.at(-1);
 
 const orderSteps = (steps: WorkflowStep[]): WorkflowStep[] => {
   const remaining = new Map(steps.map((step) => [step.id, step]));

--- a/test/workflow-run-state.test.ts
+++ b/test/workflow-run-state.test.ts
@@ -7,7 +7,9 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   appendWorkflowRunEvent,
   createWorkflowRun,
-  readWorkflowRunState
+  inspectWorkflowRunRecovery,
+  readWorkflowRunState,
+  stopWorkflowRunRecovery
 } from "../src/index.js";
 
 const tempRoots: string[] = [];
@@ -27,6 +29,233 @@ afterEach(async () => {
 });
 
 describe("workflow run JSONL state", () => {
+  it("classifies an existing terminal run as recovery-terminal without replaying work", async () => {
+    const statePath = await createTempStatePath();
+
+    await createWorkflowRun(statePath, {
+      runId: "run-terminal-001",
+      workflowId: "operator-review",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z"
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+
+    await appendWorkflowRunEvent(statePath, {
+      type: "run.completed",
+      runId: "run-terminal-001",
+      terminalState: "succeeded",
+      occurredAt: "2026-04-29T00:00:02.000Z"
+    });
+
+    const contentsBeforeRecovery = await readFile(statePath, "utf8");
+
+    await expect(inspectWorkflowRunRecovery(statePath)).resolves.toMatchObject({
+      classification: "terminal",
+      action: "do-not-replay",
+      historyPreserved: true,
+      run: {
+        runId: "run-terminal-001",
+        workflowId: "operator-review",
+        status: "succeeded",
+        terminalState: "succeeded"
+      },
+      eventCount: 2
+    });
+    await expect(readFile(statePath, "utf8")).resolves.toBe(contentsBeforeRecovery);
+  });
+
+  it("classifies corrupt JSONL as fail-closed recovery-corrupt with a sanitized diagnostic", async () => {
+    const statePath = await createTempStatePath();
+    await writeFile(
+      statePath,
+      [
+        JSON.stringify({
+          type: "run.created",
+          runId: "run-corrupt-001",
+          workflowId: "operator-review",
+          workflowVersion: "flow.workflow.v1",
+          trigger: { type: "manual", receivedAt: "2026-04-29T00:00:00.000Z" },
+          occurredAt: "2026-04-29T00:00:01.000Z"
+        }),
+        "{not-json"
+      ].join("\n"),
+      "utf8"
+    );
+
+    const report = await inspectWorkflowRunRecovery(statePath);
+
+    expect(report).toMatchObject({
+      classification: "corrupt",
+      action: "repair-jsonl-before-recovery",
+      historyPreserved: true
+    });
+    expect(report.diagnostic).toContain("workflow run state line 2: invalid JSON");
+    expect(report.diagnostic).not.toContain(tmpdir());
+  });
+
+  it("classifies active step attempts as manual-repair-needed before recovery", async () => {
+    const statePath = await createTempStatePath();
+
+    await createWorkflowRun(statePath, {
+      runId: "run-active-001",
+      workflowId: "operator-review",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z"
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "run-active-001",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:02.000Z"
+    });
+
+    await expect(inspectWorkflowRunRecovery(statePath)).resolves.toMatchObject({
+      classification: "manual-repair-needed",
+      action: "operator-review-required",
+      historyPreserved: true,
+      run: {
+        runId: "run-active-001",
+        status: "running"
+      },
+      activeStepAttempts: [
+        {
+          stepId: "collect-input",
+          attempt: 1,
+          status: "running",
+          startedAt: "2026-04-29T00:00:02.000Z"
+        }
+      ]
+    });
+  });
+
+  it("safely stops a non-terminal JSONL run by appending canceled without deleting history", async () => {
+    const statePath = await createTempStatePath();
+
+    await createWorkflowRun(statePath, {
+      runId: "run-stop-001",
+      workflowId: "operator-review",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z"
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "run-stop-001",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:02.000Z"
+    });
+    const contentsBeforeStop = await readFile(statePath, "utf8");
+
+    const report = await stopWorkflowRunRecovery({
+      statePath,
+      runId: "run-stop-001",
+      stoppedAt: "2026-04-29T00:00:03.000Z"
+    });
+
+    expect(report).toMatchObject({
+      classification: "terminal",
+      action: "do-not-replay",
+      historyPreserved: true,
+      run: {
+        runId: "run-stop-001",
+        status: "canceled",
+        terminalState: "canceled"
+      },
+      eventCount: 3
+    });
+    await expect(readFile(statePath, "utf8")).resolves.toBe(
+      `${contentsBeforeStop}${JSON.stringify({
+        type: "run.completed",
+        runId: "run-stop-001",
+        terminalState: "canceled",
+        occurredAt: "2026-04-29T00:00:03.000Z"
+      })}\n`
+    );
+  });
+
+  it("classifies failed non-terminal step attempts as manual-repair-needed", async () => {
+    const statePath = await createTempStatePath();
+
+    await createWorkflowRun(statePath, {
+      runId: "run-failed-open-001",
+      workflowId: "operator-review",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z"
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "run-failed-open-001",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:02.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.failed",
+      runId: "run-failed-open-001",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:03.000Z",
+      retry: {
+        retryable: false,
+        reason: "manual input rejected"
+      }
+    });
+
+    await expect(inspectWorkflowRunRecovery(statePath)).resolves.toMatchObject({
+      classification: "manual-repair-needed",
+      action: "operator-review-required",
+      historyPreserved: true,
+      run: {
+        runId: "run-failed-open-001",
+        status: "running"
+      },
+      eventCount: 3
+    });
+  });
+
+  it("classifies non-terminal state without active attempts as recoverable", async () => {
+    const statePath = await createTempStatePath();
+
+    await createWorkflowRun(statePath, {
+      runId: "run-recoverable-001",
+      workflowId: "operator-review",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z"
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+
+    await expect(inspectWorkflowRunRecovery(statePath)).resolves.toMatchObject({
+      classification: "recoverable",
+      action: "resume-from-projected-state",
+      historyPreserved: true,
+      run: {
+        runId: "run-recoverable-001",
+        status: "created"
+      },
+      eventCount: 1
+    });
+  });
+
   it("persists and reads workflow run events in append order", async () => {
     const statePath = await createTempStatePath();
 

--- a/test/workflow-runner.test.ts
+++ b/test/workflow-runner.test.ts
@@ -51,6 +51,7 @@ describe("sequential workflow runner", () => {
   it("recovers a non-terminal JSONL run state from the next incomplete step", async () => {
     const definition = readWorkflowFixture("simple-manual.valid.json");
     const statePath = await createTempStatePath();
+    const auditPath = await createTempAuditPath();
     const calls: string[] = [];
 
     await createWorkflowRun(statePath, {
@@ -88,6 +89,7 @@ describe("sequential workflow runner", () => {
     const result = await runWorkflow({
       definition,
       statePath,
+      auditPath,
       triggerContext: {
         requestId: "manual-recover"
       },
@@ -124,6 +126,71 @@ describe("sequential workflow runner", () => {
         status: "succeeded"
       }
     ]);
+
+    expect((await readAuditEvents(auditPath)).map((event) => event.type)).toEqual([
+      "step.started",
+      "step.completed",
+      "workflow.completed"
+    ]);
+  });
+
+  it("fails closed when persisted step history is not an ordered prefix", async () => {
+    const definition = readWorkflowFixture("simple-manual.valid.json");
+    const statePath = await createTempStatePath();
+    const auditPath = await createTempAuditPath();
+
+    await createWorkflowRun(statePath, {
+      runId: "local-manual-demo-manual-prefix",
+      workflowId: "local-manual-demo",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:07:00.000Z",
+        context: {
+          requestId: "manual-prefix"
+        },
+        idempotencyKey: {
+          source: "input",
+          key: "manual-prefix"
+        }
+      },
+      createdAt: "2026-04-29T00:07:01.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "local-manual-demo-manual-prefix",
+      stepId: "notify-operator",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:07:02.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.completed",
+      runId: "local-manual-demo-manual-prefix",
+      stepId: "notify-operator",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:07:03.000Z"
+    });
+
+    await expect(
+      runWorkflow({
+        definition,
+        statePath,
+        auditPath,
+        triggerContext: {
+          requestId: "manual-prefix"
+        }
+      })
+    ).rejects.toThrow(
+      "existing workflow run state references step notify-operator after an incomplete earlier step; manual repair is required before recovery"
+    );
+
+    const persisted = await readWorkflowRunState(statePath);
+    expect(persisted.events.map((event) => event.type)).toEqual([
+      "run.created",
+      "step.attempt.started",
+      "step.attempt.completed"
+    ]);
+    await expect(readFile(auditPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("emits deterministic neutral audit events for a successful run", async () => {

--- a/test/workflow-runner.test.ts
+++ b/test/workflow-runner.test.ts
@@ -5,7 +5,12 @@ import { tmpdir } from "node:os";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { readWorkflowRunState, runWorkflow } from "../src/index.js";
+import {
+  appendWorkflowRunEvent,
+  createWorkflowRun,
+  readWorkflowRunState,
+  runWorkflow
+} from "../src/index.js";
 import type {
   ExecutorConnectorStatusSnapshot,
   WorkflowDefinition
@@ -43,6 +48,84 @@ afterEach(async () => {
 });
 
 describe("sequential workflow runner", () => {
+  it("recovers a non-terminal JSONL run state from the next incomplete step", async () => {
+    const definition = readWorkflowFixture("simple-manual.valid.json");
+    const statePath = await createTempStatePath();
+    const calls: string[] = [];
+
+    await createWorkflowRun(statePath, {
+      runId: "local-manual-demo-manual-recover",
+      workflowId: "local-manual-demo",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:06:00.000Z",
+        context: {
+          requestId: "manual-recover"
+        },
+        idempotencyKey: {
+          source: "input",
+          key: "manual-recover"
+        }
+      },
+      createdAt: "2026-04-29T00:06:01.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "local-manual-demo-manual-recover",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:06:02.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.completed",
+      runId: "local-manual-demo-manual-recover",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:06:03.000Z"
+    });
+
+    const result = await runWorkflow({
+      definition,
+      statePath,
+      triggerContext: {
+        requestId: "manual-recover"
+      },
+      now: (() => {
+        let index = 0;
+        const timestamps = [
+          "2026-04-29T00:06:04.000Z",
+          "2026-04-29T00:06:05.000Z",
+          "2026-04-29T00:06:06.000Z"
+        ];
+        return () => timestamps[index++] ?? "2026-04-29T00:06:07.000Z";
+      })(),
+      stepHandler: ({ step }) => {
+        calls.push(step.id);
+      }
+    });
+
+    expect(calls).toEqual(["notify-operator"]);
+    expect(result.run.status).toBe("succeeded");
+    expect(result.events.map((event) => event.type)).toEqual([
+      "run.created",
+      "step.attempt.started",
+      "step.attempt.completed",
+      "step.attempt.started",
+      "step.attempt.completed",
+      "run.completed"
+    ]);
+    expect(result.stepAttempts["collect-input"]).toHaveLength(1);
+    expect(result.stepAttempts["notify-operator"]).toMatchObject([
+      {
+        attempt: 1,
+        startedAt: "2026-04-29T00:06:04.000Z",
+        completedAt: "2026-04-29T00:06:05.000Z",
+        status: "succeeded"
+      }
+    ]);
+  });
+
   it("emits deterministic neutral audit events for a successful run", async () => {
     const definition = readWorkflowFixture("simple-manual.valid.json");
     const statePath = await createTempStatePath();


### PR DESCRIPTION
## Summary
- add Flow-owned JSONL recovery inspection with terminal, recoverable, corrupt, and manual-repair classifications
- allow the local runner to resume only from unambiguous projected non-terminal state
- add explicit safe-stop recovery by appending a canceled terminal event without rewriting prior history

## Verification
- npm run build
- npm test -- test/workflow-run-state.test.ts
- npm test -- test/workflow-runner.test.ts
- npm test
- node dist/index.js issue-lint 83 --config supervisor.config.coderabbit.json

Closes #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inspect workflow run state to determine recoverability status (recoverable, terminal, corrupt, or manual-repair-needed).
  * Safely stop active workflow runs by appending a canceled terminal event while preserving full execution history.
  * Resume logic enhanced to skip completed steps and resume with correct retry-attempt indexing.

* **Documentation**
  * Updated README with run-recovery behavior, inspection classifications, and safe-stop semantics.

* **Tests**
  * Added recovery-focused tests and runner scenarios covering resume, stop, corrupt-state handling, and fails-closed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->