### PR TITLE
FLOW-051: Add audit evidence export skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ minimal TypeScript scaffold plus the initial standalone workflow definition
 schema, append-only JSONL workflow run state helpers, a local sequential runner,
 neutral audit JSONL events, a bounded local schedule trigger evaluator, and a
 bounded local webhook intake helper, and a bounded local file connector
-skeleton for fixture read/write actions. It
-does not implement executor connectors, Ensen-loop integration, ERPNext
-behavior, or Pharma/GxP workflow packs yet.
+skeleton for fixture read/write actions. It also exposes a local audit and
+evidence metadata export skeleton for JSONL run state. It does not implement
+production evidence archives, compliance bundles, customer data exports,
+executor connectors, Ensen-loop integration, ERPNext behavior, or Pharma/GxP
+workflow packs yet.
 
 Use the same commands locally that CI runs:
 
@@ -107,6 +109,22 @@ shape for workflow start, step start, step completion, step failure, retry
 scheduling, and workflow completion or failure. Each record includes a stable
 event ID, timestamp, actor and source context, workflow and run references, and
 step references where applicable.
+
+The built CLI can export public-safe audit and evidence metadata from local run
+state after `npm run build`:
+
+```sh
+node dist/cli.js export-audit-evidence <state-jsonl-path> [audit-jsonl-path] [--output <export-json-path>]
+```
+
+The export intentionally separates `publicSafe` metadata from
+`localConfidentialReferences`. Public-safe fields summarize run status, trigger
+type, step attempts, neutral audit event summaries, and any public-safe
+`eip.evidence-bundle-ref.v1` references found in step result metadata. Trigger
+context, idempotency key values, raw local state paths, raw audit paths,
+workstation-local evidence paths, secrets, customer data, production evidence
+locations, and unsupported Protocol Phase 4 evidence profile fields are not
+exported into the public-safe section.
 
 This internal shape is intended to support a later mapping to EIP AuditEvent,
 but it does not claim EIP conformance and does not import Ensen-protocol runtime

--- a/src/audit-evidence-export.ts
+++ b/src/audit-evidence-export.ts
@@ -1,0 +1,434 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import { readWorkflowRunState } from "./workflow-run-state.js";
+import type {
+  WorkflowRunState,
+  WorkflowStepAttemptEvent
+} from "./workflow-run-state.js";
+import type { NeutralAuditEvent } from "./audit-event-writer.js";
+
+export interface CreateAuditEvidenceExportInput {
+  statePath: string;
+  auditPath?: string;
+  outputPath?: string;
+}
+
+export interface AuditEvidenceExport {
+  schemaVersion: "flow.audit-evidence-export.v1";
+  boundary: AuditEvidenceExportBoundary;
+  publicSafe: AuditEvidenceExportPublicSafe;
+  localConfidentialReferences: AuditEvidenceExportLocalConfidentialReferences;
+}
+
+export interface AuditEvidenceExportBoundary {
+  productionEvidenceReady: false;
+  protocolSnapshot: {
+    name: "ensen-protocol";
+    version: "0.2.0";
+  };
+  protocolEvidenceProfile: "pending-protocol-phase-4";
+  notes: string[];
+}
+
+export interface AuditEvidenceExportPublicSafe {
+  run: {
+    runId: string;
+    workflowId: string;
+    workflowVersion: string;
+    status: string;
+    terminalState?: string;
+    createdAt: string;
+    updatedAt: string;
+  };
+  trigger: {
+    type: string;
+    receivedAt: string;
+    contextExported: false;
+    idempotencyKey?: {
+      source: string;
+      keyExported: false;
+    };
+  };
+  steps: AuditEvidenceExportStepSummary[];
+  auditEvents: AuditEvidenceExportAuditEventSummary[];
+  evidenceRefs: AuditEvidenceExportEvidenceRef[];
+  diagnostics: string[];
+}
+
+export interface AuditEvidenceExportStepSummary {
+  stepId: string;
+  attempts: Array<{
+    attempt: number;
+    status: string;
+    startedAt?: string;
+    completedAt?: string;
+    failedAt?: string;
+    retryable?: boolean;
+  }>;
+}
+
+export interface AuditEvidenceExportAuditEventSummary {
+  id: string;
+  type: string;
+  occurredAt: string;
+  workflowId: string;
+  runId: string;
+  stepId?: string;
+  attempt?: number;
+  outcomeStatus?: string;
+}
+
+export interface AuditEvidenceExportEvidenceRef {
+  schemaVersion: "eip.evidence-bundle-ref.v1";
+  id: string;
+  correlationId: string;
+  type: "local_path" | "file_uri";
+  uri: string;
+  createdAt: string;
+  contentType?: string;
+  checksum?: {
+    algorithm: "sha256";
+    value: string;
+  };
+}
+
+export interface AuditEvidenceExportLocalConfidentialReferences {
+  statePath: AuditEvidenceExportLocalReference;
+  auditPath?: AuditEvidenceExportLocalReference;
+  outputPath?: AuditEvidenceExportLocalReference;
+}
+
+export interface AuditEvidenceExportLocalReference {
+  classification: "local-confidential-reference";
+  value: string;
+}
+
+const EXPORT_SCHEMA_VERSION = "flow.audit-evidence-export.v1";
+const EVIDENCE_REF_SCHEMA_VERSION = "eip.evidence-bundle-ref.v1";
+const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/;
+
+export const createAuditEvidenceExport = async (
+  input: CreateAuditEvidenceExportInput
+): Promise<AuditEvidenceExport> => {
+  const state = await readWorkflowRunState(input.statePath);
+  const diagnostics: string[] = [];
+  const auditEvents =
+    input.auditPath === undefined
+      ? []
+      : await readNeutralAuditEvents(input.auditPath).catch((error: unknown) => {
+          throw new Error(`audit event export failed: ${safeErrorMessage(error)}`);
+        });
+  const exportArtifact: AuditEvidenceExport = {
+    schemaVersion: EXPORT_SCHEMA_VERSION,
+    boundary: {
+      productionEvidenceReady: false,
+      protocolSnapshot: {
+        name: "ensen-protocol",
+        version: "0.2.0"
+      },
+      protocolEvidenceProfile: "pending-protocol-phase-4",
+      notes: [
+        "This is a deterministic local metadata export skeleton.",
+        "It is not a production evidence archive, compliance bundle, or customer data export.",
+        "Protocol Phase 4 evidence profile fields are not fabricated before a protocol snapshot exists."
+      ]
+    },
+    publicSafe: {
+      run: {
+        runId: state.run.runId,
+        workflowId: state.run.workflowId,
+        workflowVersion: state.run.workflowVersion,
+        status: state.run.status,
+        ...(state.run.terminalState === undefined
+          ? {}
+          : { terminalState: state.run.terminalState }),
+        createdAt: state.run.createdAt,
+        updatedAt: state.run.updatedAt
+      },
+      trigger: {
+        type: state.run.trigger.type,
+        receivedAt: state.run.trigger.receivedAt,
+        contextExported: false,
+        ...(state.run.trigger.idempotencyKey === undefined
+          ? {}
+          : {
+              idempotencyKey: {
+                source: state.run.trigger.idempotencyKey.source,
+                keyExported: false
+              }
+            })
+      },
+      steps: summarizeStepAttempts(state),
+      auditEvents: auditEvents.map(summarizeAuditEvent),
+      evidenceRefs: collectPublicEvidenceRefs(state, diagnostics),
+      diagnostics
+    },
+    localConfidentialReferences: {
+      statePath: {
+        classification: "local-confidential-reference",
+        value: "<local-workflow-run-state-jsonl>"
+      },
+      ...(input.auditPath === undefined
+        ? {}
+        : {
+            auditPath: {
+              classification: "local-confidential-reference",
+              value: "<local-audit-jsonl>"
+            }
+          }),
+      ...(input.outputPath === undefined
+        ? {}
+        : {
+            outputPath: {
+              classification: "local-confidential-reference",
+              value: "<local-export-json>"
+            }
+          })
+    }
+  };
+
+  if (input.outputPath !== undefined) {
+    await mkdir(dirname(input.outputPath), { recursive: true });
+    await writeFile(input.outputPath, `${JSON.stringify(exportArtifact, null, 2)}\n`, "utf8");
+  }
+
+  return exportArtifact;
+};
+
+const summarizeStepAttempts = (
+  state: WorkflowRunState
+): AuditEvidenceExportStepSummary[] =>
+  Object.entries(state.stepAttempts).map(([stepId, attempts]) => ({
+    stepId,
+    attempts: attempts.map((attempt) => ({
+      attempt: attempt.attempt,
+      status: attempt.status,
+      ...(attempt.startedAt === undefined ? {} : { startedAt: attempt.startedAt }),
+      ...(attempt.completedAt === undefined ? {} : { completedAt: attempt.completedAt }),
+      ...(attempt.failedAt === undefined ? {} : { failedAt: attempt.failedAt }),
+      ...(attempt.retry === undefined ? {} : { retryable: attempt.retry.retryable })
+    }))
+  }));
+
+const readNeutralAuditEvents = async (auditPath: string): Promise<NeutralAuditEvent[]> => {
+  const contents = await readFile(auditPath, "utf8");
+  const lines = contents.split("\n");
+  if (lines.at(-1) === "") {
+    lines.pop();
+  }
+
+  return lines.map((line, index) => {
+    if (line.trim() === "") {
+      throw new Error(`audit JSONL line ${index + 1}: record must not be blank`);
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line) as unknown;
+    } catch {
+      throw new Error(`audit JSONL line ${index + 1}: invalid JSON`);
+    }
+
+    if (!isRecord(parsed)) {
+      throw new Error(`audit JSONL line ${index + 1}: record must be an object`);
+    }
+
+    return validateNeutralAuditEventForExport(parsed, index + 1);
+  });
+};
+
+const validateNeutralAuditEventForExport = (
+  value: Record<string, unknown>,
+  lineNumber: number
+): NeutralAuditEvent => {
+  if (
+    typeof value.id !== "string" ||
+    typeof value.type !== "string" ||
+    typeof value.occurredAt !== "string" ||
+    !isRecord(value.workflow) ||
+    typeof value.workflow.id !== "string" ||
+    !isRecord(value.run) ||
+    typeof value.run.id !== "string"
+  ) {
+    throw new Error(`audit JSONL line ${lineNumber}: record is outside the audit export boundary`);
+  }
+
+  return value as unknown as NeutralAuditEvent;
+};
+
+const summarizeAuditEvent = (
+  event: NeutralAuditEvent
+): AuditEvidenceExportAuditEventSummary => ({
+  id: event.id,
+  type: event.type,
+  occurredAt: event.occurredAt,
+  workflowId: event.workflow.id,
+  runId: event.run.id,
+  ...(event.step === undefined
+    ? {}
+    : {
+        stepId: event.step.id,
+        attempt: event.step.attempt
+      }),
+  ...(event.outcome === undefined ? {} : { outcomeStatus: event.outcome.status })
+});
+
+const collectPublicEvidenceRefs = (
+  state: WorkflowRunState,
+  diagnostics: string[]
+): AuditEvidenceExportEvidenceRef[] => {
+  const refs: AuditEvidenceExportEvidenceRef[] = [];
+
+  for (const event of state.events) {
+    if (!isStepTerminalEvent(event) || event.result === undefined) {
+      continue;
+    }
+
+    collectEvidenceRefsFromValue(event.result, refs, diagnostics);
+  }
+
+  return refs;
+};
+
+const collectEvidenceRefsFromValue = (
+  value: unknown,
+  refs: AuditEvidenceExportEvidenceRef[],
+  diagnostics: string[]
+): void => {
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectEvidenceRefsFromValue(item, refs, diagnostics));
+    return;
+  }
+
+  if (!isRecord(value)) {
+    return;
+  }
+
+  const evidenceRef = normalizeEvidenceRef(value);
+  if (evidenceRef !== undefined) {
+    if (isPublicSafeEvidenceRef(evidenceRef)) {
+      refs.push(evidenceRef);
+    } else {
+      diagnostics.push("omitted an evidence reference because its URI is not public-safe");
+    }
+    return;
+  }
+
+  for (const nestedValue of Object.values(value)) {
+    collectEvidenceRefsFromValue(nestedValue, refs, diagnostics);
+  }
+};
+
+const normalizeEvidenceRef = (
+  value: Record<string, unknown>
+): AuditEvidenceExportEvidenceRef | undefined => {
+  if (value.schemaVersion !== EVIDENCE_REF_SCHEMA_VERSION) {
+    return undefined;
+  }
+
+  if (
+    typeof value.id !== "string" ||
+    typeof value.correlationId !== "string" ||
+    (value.type !== "local_path" && value.type !== "file_uri") ||
+    typeof value.uri !== "string" ||
+    typeof value.createdAt !== "string"
+  ) {
+    return undefined;
+  }
+
+  const checksum = normalizeChecksum(value.checksum);
+  return {
+    schemaVersion: EVIDENCE_REF_SCHEMA_VERSION,
+    id: value.id,
+    correlationId: value.correlationId,
+    type: value.type,
+    uri: value.uri,
+    createdAt: value.createdAt,
+    ...(typeof value.contentType === "string" ? { contentType: value.contentType } : {}),
+    ...(checksum === undefined ? {} : { checksum })
+  };
+};
+
+const normalizeChecksum = (
+  value: unknown
+): AuditEvidenceExportEvidenceRef["checksum"] | undefined => {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  if (value.algorithm !== "sha256" || typeof value.value !== "string") {
+    return undefined;
+  }
+
+  if (!SHA256_HEX_PATTERN.test(value.value)) {
+    return undefined;
+  }
+
+  return {
+    algorithm: "sha256",
+    value: value.value
+  };
+};
+
+const isPublicSafeEvidenceRef = (ref: AuditEvidenceExportEvidenceRef): boolean => {
+  if (containsCredentialShape(ref.uri) || containsWorkstationLocalPath(ref.uri)) {
+    return false;
+  }
+
+  if (ref.type === "local_path") {
+    return isSafeRelativePath(ref.uri);
+  }
+
+  return isSafeFileUri(ref.uri);
+};
+
+const isSafeRelativePath = (value: string): boolean =>
+  value.trim() !== "" &&
+  !value.startsWith("/") &&
+  !value.startsWith("\\") &&
+  !value.includes("://") &&
+  !value.split(/[\\/]+/u).includes("..");
+
+const isSafeFileUri = (value: string): boolean => {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== "file:" || parsed.username !== "" || parsed.password !== "") {
+    return false;
+  }
+
+  if (parsed.search !== "" || parsed.hash !== "") {
+    return false;
+  }
+
+  return (
+    !parsed.pathname.split("/").includes("..") &&
+    !containsWorkstationLocalPath(parsed.pathname)
+  );
+};
+
+const containsCredentialShape = (value: string): boolean =>
+  /(?:token|secret|password|passwd|apikey|api_key|access_key)=/iu.test(value) ||
+  /:\/\/[^/\s:@]+:[^/\s@]+@/u.test(value);
+
+const containsWorkstationLocalPath = (value: string): boolean =>
+  /(^|[/\\])Users[/\\][^/\\]+/u.test(value) ||
+  /(^|[/\\])home[/\\][^/\\]+/u.test(value) ||
+  /^[A-Za-z]:[/\\]Users[/\\][^/\\]+/u.test(value);
+
+const isStepTerminalEvent = (event: unknown): event is WorkflowStepAttemptEvent =>
+  isRecord(event) &&
+  (event.type === "step.attempt.completed" || event.type === "step.attempt.failed");
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const safeErrorMessage = (error: unknown): string => {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replaceAll(/(?:\/Users|\/home|[A-Za-z]:\\Users)[^\s'"]*/gu, "<local-path>");
+};

--- a/src/audit-evidence-export.ts
+++ b/src/audit-evidence-export.ts
@@ -242,6 +242,8 @@ const validateNeutralAuditEventForExport = (
   value: Record<string, unknown>,
   lineNumber: number
 ): NeutralAuditEvent => {
+  const boundaryMessage = `audit JSONL line ${lineNumber}: record is outside the audit export boundary`;
+
   if (
     typeof value.id !== "string" ||
     typeof value.type !== "string" ||
@@ -251,7 +253,23 @@ const validateNeutralAuditEventForExport = (
     !isRecord(value.run) ||
     typeof value.run.id !== "string"
   ) {
-    throw new Error(`audit JSONL line ${lineNumber}: record is outside the audit export boundary`);
+    throw new Error(boundaryMessage);
+  }
+
+  if (
+    value.step !== undefined &&
+    (!isRecord(value.step) ||
+      typeof value.step.id !== "string" ||
+      typeof value.step.attempt !== "number")
+  ) {
+    throw new Error(boundaryMessage);
+  }
+
+  if (
+    value.outcome !== undefined &&
+    (!isRecord(value.outcome) || typeof value.outcome.status !== "string")
+  ) {
+    throw new Error(boundaryMessage);
   }
 
   return value as unknown as NeutralAuditEvent;
@@ -383,12 +401,17 @@ const isPublicSafeEvidenceRef = (ref: AuditEvidenceExportEvidenceRef): boolean =
   return isSafeFileUri(ref.uri);
 };
 
-const isSafeRelativePath = (value: string): boolean =>
-  value.trim() !== "" &&
-  !value.startsWith("/") &&
-  !value.startsWith("\\") &&
-  !value.includes("://") &&
-  !value.split(/[\\/]+/u).includes("..");
+const isSafeRelativePath = (value: string): boolean => {
+  const trimmed = value.trim();
+  return (
+    trimmed !== "" &&
+    !trimmed.startsWith("/") &&
+    !trimmed.startsWith("\\") &&
+    !isWindowsDriveAbsolutePath(trimmed) &&
+    !trimmed.includes("://") &&
+    !trimmed.split(/[\\/]+/u).includes("..")
+  );
+};
 
 const isSafeFileUri = (value: string): boolean => {
   let parsed: URL;
@@ -398,7 +421,12 @@ const isSafeFileUri = (value: string): boolean => {
     return false;
   }
 
-  if (parsed.protocol !== "file:" || parsed.username !== "" || parsed.password !== "") {
+  if (
+    parsed.protocol !== "file:" ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.hostname !== ""
+  ) {
     return false;
   }
 
@@ -419,7 +447,11 @@ const containsCredentialShape = (value: string): boolean =>
 const containsWorkstationLocalPath = (value: string): boolean =>
   /(^|[/\\])Users[/\\][^/\\]+/u.test(value) ||
   /(^|[/\\])home[/\\][^/\\]+/u.test(value) ||
-  /^[A-Za-z]:[/\\]Users[/\\][^/\\]+/u.test(value);
+  isWindowsDriveAbsolutePath(value) ||
+  /(^|\/)[A-Za-z]:\//u.test(value);
+
+const isWindowsDriveAbsolutePath = (value: string): boolean =>
+  /^[A-Za-z]:[/\\]/u.test(value);
 
 const isStepTerminalEvent = (event: unknown): event is WorkflowStepAttemptEvent =>
   isRecord(event) &&

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -81,10 +81,11 @@ const runAuditEvidenceExportCommand = async (argv: string[]): Promise<number> =>
 const parseAuditEvidenceExportArgs = (
   argv: string[]
 ): { statePath: string; auditPath?: string; outputPath?: string } | undefined => {
-  const [statePath, maybeAuditPath, maybeOutputFlag, maybeOutputPath] = argv;
-  if (statePath === undefined) {
+  if (argv.length < 1 || argv.length > 4) {
     return undefined;
   }
+
+  const [statePath, maybeAuditPath, maybeOutputFlag, maybeOutputPath] = argv;
 
   if (maybeAuditPath === "--output") {
     if (maybeOutputFlag === undefined || maybeOutputPath !== undefined) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,18 +1,41 @@
 #!/usr/bin/env node
 import { fileURLToPath } from "node:url";
 
-import { loadWorkflowDefinitionFile, runWorkflow } from "./index.js";
+import {
+  createAuditEvidenceExport,
+  loadWorkflowDefinitionFile,
+  runWorkflow
+} from "./index.js";
 
 const printUsage = (): void => {
   console.error(
-    "Usage: node dist/cli.js run <workflow-definition.json> <state.jsonl> [trigger-context-json]"
+    [
+      "Usage:",
+      "  node dist/cli.js run <workflow-definition.json> <state.jsonl> [trigger-context-json]",
+      "  node dist/cli.js export-audit-evidence <state.jsonl> [audit.jsonl] [--output <export.json>]"
+    ].join("\n")
   );
 };
 
 export const runCli = async (argv: string[]): Promise<number> => {
-  const [command, definitionPath, statePath, triggerContextJson] = argv;
+  const [command] = argv;
 
-  if (command !== "run" || definitionPath === undefined || statePath === undefined) {
+  if (command === "run") {
+    return runWorkflowCommand(argv.slice(1));
+  }
+
+  if (command === "export-audit-evidence") {
+    return runAuditEvidenceExportCommand(argv.slice(1));
+  }
+
+  printUsage();
+  return 2;
+};
+
+const runWorkflowCommand = async (argv: string[]): Promise<number> => {
+  const [definitionPath, statePath, triggerContextJson] = argv;
+
+  if (definitionPath === undefined || statePath === undefined) {
     printUsage();
     return 2;
   }
@@ -40,6 +63,56 @@ export const runCli = async (argv: string[]): Promise<number> => {
   );
 
   return 0;
+};
+
+const runAuditEvidenceExportCommand = async (argv: string[]): Promise<number> => {
+  const parsed = parseAuditEvidenceExportArgs(argv);
+  if (parsed === undefined) {
+    printUsage();
+    return 2;
+  }
+
+  const exportArtifact = await createAuditEvidenceExport(parsed);
+  console.log(JSON.stringify(exportArtifact, null, 2));
+
+  return 0;
+};
+
+const parseAuditEvidenceExportArgs = (
+  argv: string[]
+): { statePath: string; auditPath?: string; outputPath?: string } | undefined => {
+  const [statePath, maybeAuditPath, maybeOutputFlag, maybeOutputPath] = argv;
+  if (statePath === undefined) {
+    return undefined;
+  }
+
+  if (maybeAuditPath === "--output") {
+    if (maybeOutputFlag === undefined || maybeOutputPath !== undefined) {
+      return undefined;
+    }
+
+    return {
+      statePath,
+      outputPath: maybeOutputFlag
+    };
+  }
+
+  if (maybeOutputFlag === undefined) {
+    return {
+      statePath,
+      ...(maybeAuditPath === undefined ? {} : { auditPath: maybeAuditPath })
+    };
+  }
+
+  if (maybeOutputFlag !== "--output" || maybeOutputPath === undefined) {
+    return undefined;
+  }
+
+  return {
+    statePath,
+    ...(maybeAuditPath === undefined ? {} : { auditPath: maybeAuditPath }),
+    outputPath: maybeOutputPath
+  };
 };
 
 const parseTriggerContext = (

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,6 +160,20 @@ export {
 
 export { createLocalAuditEventWriter } from "./audit-event-writer.js";
 
+export { createAuditEvidenceExport } from "./audit-evidence-export.js";
+
+export type {
+  AuditEvidenceExport,
+  AuditEvidenceExportAuditEventSummary,
+  AuditEvidenceExportBoundary,
+  AuditEvidenceExportEvidenceRef,
+  AuditEvidenceExportLocalConfidentialReferences,
+  AuditEvidenceExportLocalReference,
+  AuditEvidenceExportPublicSafe,
+  AuditEvidenceExportStepSummary,
+  CreateAuditEvidenceExportInput
+} from "./audit-evidence-export.js";
+
 export type {
   AppendableWorkflowRunEvent,
   CreateWorkflowRunInput,

--- a/test/audit-event-writer.test.ts
+++ b/test/audit-event-writer.test.ts
@@ -4,7 +4,12 @@ import { tmpdir } from "node:os";
 
 import { afterEach, describe, expect, it } from "vitest";
 
-import { createLocalAuditEventWriter } from "../src/index.js";
+import {
+  appendWorkflowRunEvent,
+  createAuditEvidenceExport,
+  createLocalAuditEventWriter,
+  createWorkflowRun
+} from "../src/index.js";
 import type { CreateNeutralAuditEventInput } from "../src/index.js";
 
 const tempRoots: string[] = [];
@@ -27,6 +32,131 @@ afterEach(async () => {
 });
 
 describe("neutral audit event writer", () => {
+  it("exports public-safe audit and evidence metadata without raw local paths or trigger context", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
+    const auditRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
+    tempRoots.push(stateRoot, auditRoot);
+    const statePath = join(stateRoot, "runs", "manual-run.jsonl");
+    const auditPath = join(auditRoot, "audit", "manual-run.audit.jsonl");
+
+    await createWorkflowRun(statePath, {
+      runId: "local-manual-demo-export",
+      workflowId: "local-manual-demo",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z",
+        context: {
+          requestId: "private-request-id",
+          customerName: "private-customer"
+        },
+        idempotencyKey: {
+          source: "input",
+          key: "private-idempotency-key"
+        }
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "local-manual-demo-export",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:02.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.completed",
+      runId: "local-manual-demo-export",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:03.000Z",
+      result: {
+        evidenceBundleRef: {
+          schemaVersion: "eip.evidence-bundle-ref.v1",
+          id: "evb_manual_export",
+          correlationId: "corr_manual_export",
+          type: "local_path",
+          uri: "artifacts/evidence/manual-export/bundle.json",
+          createdAt: "2026-04-29T00:00:03.000Z"
+        }
+      }
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "run.completed",
+      runId: "local-manual-demo-export",
+      terminalState: "succeeded",
+      occurredAt: "2026-04-29T00:00:04.000Z"
+    });
+
+    const writer = createLocalAuditEventWriter({
+      auditPath,
+      workflow: { id: "local-manual-demo", version: "flow.workflow.v1" },
+      run: { id: "local-manual-demo-export" }
+    });
+    await writer.write({
+      type: "workflow.completed",
+      occurredAt: "2026-04-29T00:00:04.000Z",
+      outcome: { status: "succeeded" }
+    });
+
+    const exported = await createAuditEvidenceExport({ statePath, auditPath });
+    const serialized = JSON.stringify(exported);
+
+    expect(exported).toMatchObject({
+      schemaVersion: "flow.audit-evidence-export.v1",
+      boundary: {
+        productionEvidenceReady: false,
+        protocolEvidenceProfile: "pending-protocol-phase-4"
+      },
+      publicSafe: {
+        run: {
+          runId: "local-manual-demo-export",
+          workflowId: "local-manual-demo",
+          status: "succeeded",
+          terminalState: "succeeded"
+        },
+        trigger: {
+          type: "manual",
+          contextExported: false,
+          idempotencyKey: {
+            source: "input",
+            keyExported: false
+          }
+        },
+        evidenceRefs: [
+          {
+            schemaVersion: "eip.evidence-bundle-ref.v1",
+            id: "evb_manual_export",
+            correlationId: "corr_manual_export",
+            type: "local_path",
+            uri: "artifacts/evidence/manual-export/bundle.json"
+          }
+        ],
+        auditEvents: [
+          {
+            id: "audit.local-manual-demo-export.000001",
+            type: "workflow.completed"
+          }
+        ]
+      },
+      localConfidentialReferences: {
+        statePath: {
+          classification: "local-confidential-reference",
+          value: "<local-workflow-run-state-jsonl>"
+        },
+        auditPath: {
+          classification: "local-confidential-reference",
+          value: "<local-audit-jsonl>"
+        }
+      }
+    });
+    expect(serialized).not.toContain(statePath);
+    expect(serialized).not.toContain(auditPath);
+    expect(serialized).not.toContain("private-customer");
+    expect(serialized).not.toContain("private-request-id");
+    expect(serialized).not.toContain("private-idempotency-key");
+  });
+
   it("freezes constructor context snapshots before later caller mutation", async () => {
     const auditPath = await createTempAuditPath();
     const workflow = { id: "trusted-workflow", version: "flow.workflow.v1" };

--- a/test/audit-event-writer.test.ts
+++ b/test/audit-event-writer.test.ts
@@ -1,9 +1,10 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
-import { join } from "node:path";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { afterEach, describe, expect, it } from "vitest";
 
+import { runCli } from "../src/cli.js";
 import {
   appendWorkflowRunEvent,
   createAuditEvidenceExport,
@@ -155,6 +156,184 @@ describe("neutral audit event writer", () => {
     expect(serialized).not.toContain("private-customer");
     expect(serialized).not.toContain("private-request-id");
     expect(serialized).not.toContain("private-idempotency-key");
+  });
+
+  it("rejects malformed optional audit event export fields before summarizing", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
+    const auditRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
+    tempRoots.push(stateRoot, auditRoot);
+    const statePath = join(stateRoot, "runs", "manual-run.jsonl");
+    const auditPath = join(auditRoot, "audit", "manual-run.audit.jsonl");
+
+    await createWorkflowRun(statePath, {
+      runId: "local-manual-demo-export",
+      workflowId: "local-manual-demo",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z",
+        context: {}
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+
+    await mkdir(dirname(auditPath), { recursive: true });
+    await writeFile(
+      auditPath,
+      `${JSON.stringify({
+        id: "audit.local-manual-demo-export.000001",
+        type: "step.completed",
+        occurredAt: "2026-04-29T00:00:02.000Z",
+        actor: { type: "system", id: "ensen-flow.local-runner" },
+        source: { type: "runner", id: "ensen-flow.local-runner" },
+        workflow: { id: "local-manual-demo", version: "flow.workflow.v1" },
+        run: { id: "local-manual-demo-export" },
+        step: null
+      })}\n`,
+      "utf8"
+    );
+
+    await expect(createAuditEvidenceExport({ statePath, auditPath })).rejects.toThrow(
+      "audit event export failed: audit JSONL line 1: record is outside the audit export boundary"
+    );
+
+    await writeFile(
+      auditPath,
+      `${JSON.stringify({
+        id: "audit.local-manual-demo-export.000001",
+        type: "workflow.completed",
+        occurredAt: "2026-04-29T00:00:02.000Z",
+        actor: { type: "system", id: "ensen-flow.local-runner" },
+        source: { type: "runner", id: "ensen-flow.local-runner" },
+        workflow: { id: "local-manual-demo", version: "flow.workflow.v1" },
+        run: { id: "local-manual-demo-export" },
+        outcome: null
+      })}\n`,
+      "utf8"
+    );
+
+    await expect(createAuditEvidenceExport({ statePath, auditPath })).rejects.toThrow(
+      "audit event export failed: audit JSONL line 1: record is outside the audit export boundary"
+    );
+  });
+
+  it("omits Windows-style local evidence paths from public-safe exports", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
+    tempRoots.push(stateRoot);
+    const statePath = join(stateRoot, "runs", "manual-run.jsonl");
+    const windowsDrivePath = ["C:", "tmp", "bundle.json"].join("\\");
+    const windowsNetworkPath = ["", "", "server", "share", "bundle.json"].join("\\");
+
+    await createWorkflowRun(statePath, {
+      runId: "local-manual-demo-export",
+      workflowId: "local-manual-demo",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z",
+        context: {}
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "local-manual-demo-export",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:02.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.completed",
+      runId: "local-manual-demo-export",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:03.000Z",
+      result: {
+        evidenceRefs: [
+          {
+            schemaVersion: "eip.evidence-bundle-ref.v1",
+            id: "evb_public_export",
+            correlationId: "corr_manual_export",
+            type: "local_path",
+            uri: "artifacts/evidence/public/bundle.json",
+            createdAt: "2026-04-29T00:00:02.000Z"
+          },
+          {
+            schemaVersion: "eip.evidence-bundle-ref.v1",
+            id: "evb_windows_drive_export",
+            correlationId: "corr_manual_export",
+            type: "local_path",
+            uri: windowsDrivePath,
+            createdAt: "2026-04-29T00:00:02.000Z"
+          },
+          {
+            schemaVersion: "eip.evidence-bundle-ref.v1",
+            id: "evb_windows_network_export",
+            correlationId: "corr_manual_export",
+            type: "local_path",
+            uri: windowsNetworkPath,
+            createdAt: "2026-04-29T00:00:02.000Z"
+          },
+          {
+            schemaVersion: "eip.evidence-bundle-ref.v1",
+            id: "evb_windows_file_uri_export",
+            correlationId: "corr_manual_export",
+            type: "file_uri",
+            uri: "file:///C:/tmp/bundle.json",
+            createdAt: "2026-04-29T00:00:02.000Z"
+          },
+          {
+            schemaVersion: "eip.evidence-bundle-ref.v1",
+            id: "evb_windows_network_file_uri_export",
+            correlationId: "corr_manual_export",
+            type: "file_uri",
+            uri: "file://server/share/bundle.json",
+            createdAt: "2026-04-29T00:00:02.000Z"
+          }
+        ]
+      }
+    });
+
+    const exported = await createAuditEvidenceExport({ statePath });
+
+    expect(exported.publicSafe.evidenceRefs.map((ref) => ref.uri)).toEqual([
+      "artifacts/evidence/public/bundle.json"
+    ]);
+    expect(exported.publicSafe.diagnostics).toEqual([
+      "omitted an evidence reference because its URI is not public-safe",
+      "omitted an evidence reference because its URI is not public-safe",
+      "omitted an evidence reference because its URI is not public-safe",
+      "omitted an evidence reference because its URI is not public-safe"
+    ]);
+    expect(JSON.stringify(exported)).not.toContain(windowsDrivePath);
+    expect(JSON.stringify(exported)).not.toContain(windowsNetworkPath);
+  });
+
+  it("rejects extra export-audit-evidence CLI arguments", async () => {
+    const originalError = console.error;
+    const errors: string[] = [];
+    console.error = (message?: unknown): void => {
+      errors.push(String(message));
+    };
+
+    try {
+      await expect(
+        runCli([
+          "export-audit-evidence",
+          "state.jsonl",
+          "audit.jsonl",
+          "--output",
+          "export.json",
+          "extra"
+        ])
+      ).resolves.toBe(2);
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(errors.join("\n")).toContain(
+      "node dist/cli.js export-audit-evidence <state.jsonl> [audit.jsonl] [--output <export.json>]"
+    );
   });
 
   it("freezes constructor context snapshots before later caller mutation", async () => {


### PR DESCRIPTION
## Summary
- add a Flow-owned audit/evidence metadata export skeleton for local JSONL run state
- expose the export through `node dist/cli.js export-audit-evidence <state-jsonl-path> [audit-jsonl-path] [--output <export-json-path>]`
- document the non-production boundary and public-safe vs local-confidential split

## Verification
- `npm run build`
- `npm test -- test/audit-event-writer.test.ts test/workflow-runner.test.ts`
- `npm test`
- CLI smoke for `node dist/cli.js export-audit-evidence <state-jsonl-path>`
- `node dist/index.js issue-lint 84 --config supervisor.config.coderabbit.json` from companion codex-supervisor checkout

Closes #84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an export-audit-evidence capability (CLI + programmatic API) to generate a public-safe JSON export of audit/evidence metadata from completed workflow runs, filtering out sensitive/confidential references.

* **Documentation**
  * README updated to document the export command and clarify excluded data types (secrets, customer data, local/production paths, credentials).

* **Tests**
  * End-to-end tests added to validate public-safe exports, URI filtering, diagnostics, and CLI argument handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->