### PR TITLE
FLOW-X3A-002: Add workflow artifact hygiene checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ workstation-local evidence paths, secrets, customer data, production evidence
 locations, and unsupported Protocol Phase 4 evidence profile fields are not
 exported into the public-safe section.
 
+Workflow artifact hygiene is fail-closed at the local JSONL boundary and at
+public export boundaries. Raw secrets, token-shaped strings, private key blocks,
+session cookie strings, and workstation-local absolute paths are rejected before
+new run state or notification artifacts are written. Public audit/evidence
+exports omit unsafe evidence references and report only the failing category in
+diagnostics; the matched value stays out of public-safe output. The
+`localConfidentialReferences` section is the placeholder boundary for local-only
+state, audit, and export file references until a later Protocol evidence profile
+defines a formal mapping.
+
 This internal shape is intended to support a later mapping to EIP AuditEvent,
 but it does not claim EIP conformance and does not import Ensen-protocol runtime
 packages. Formal protocol mapping belongs to a later protocol or connector

--- a/src/audit-evidence-export.ts
+++ b/src/audit-evidence-export.ts
@@ -7,6 +7,7 @@ import type {
   WorkflowStepAttemptEvent
 } from "./workflow-run-state.js";
 import type { NeutralAuditEvent } from "./audit-event-writer.js";
+import { classifyUnsafeWorkflowArtifactString } from "./workflow-artifact-hygiene.js";
 
 export interface CreateAuditEvidenceExportInput {
   statePath: string;
@@ -328,7 +329,7 @@ const collectEvidenceRefsFromValue = (
     if (isPublicSafeEvidenceRef(evidenceRef)) {
       refs.push(evidenceRef);
     } else {
-      diagnostics.push("omitted an evidence reference because its URI is not public-safe");
+      diagnostics.push(createUnsafeEvidenceRefDiagnostic(evidenceRef));
     }
     return;
   }
@@ -390,7 +391,7 @@ const normalizeChecksum = (
 };
 
 const isPublicSafeEvidenceRef = (ref: AuditEvidenceExportEvidenceRef): boolean => {
-  if (containsCredentialShape(ref.uri) || containsWorkstationLocalPath(ref.uri)) {
+  if (classifyUnsafeWorkflowArtifactString(ref.uri) !== undefined) {
     return false;
   }
 
@@ -411,6 +412,11 @@ const isSafeRelativePath = (value: string): boolean => {
     !trimmed.includes("://") &&
     !trimmed.split(/[\\/]+/u).includes("..")
   );
+};
+
+const createUnsafeEvidenceRefDiagnostic = (ref: AuditEvidenceExportEvidenceRef): string => {
+  const category = classifyUnsafeWorkflowArtifactString(ref.uri) ?? "non-public-uri";
+  return `omitted an evidence reference because its URI is not public-safe (category: ${category})`;
 };
 
 const isSafeFileUri = (value: string): boolean => {
@@ -434,21 +440,8 @@ const isSafeFileUri = (value: string): boolean => {
     return false;
   }
 
-  return (
-    !parsed.pathname.split("/").includes("..") &&
-    !containsWorkstationLocalPath(parsed.pathname)
-  );
+  return !parsed.pathname.split("/").includes("..");
 };
-
-const containsCredentialShape = (value: string): boolean =>
-  /(?:token|secret|password|passwd|apikey|api_key|access_key)=/iu.test(value) ||
-  /:\/\/[^/\s:@]+:[^/\s@]+@/u.test(value);
-
-const containsWorkstationLocalPath = (value: string): boolean =>
-  /(^|[/\\])Users[/\\][^/\\]+/u.test(value) ||
-  /(^|[/\\])home[/\\][^/\\]+/u.test(value) ||
-  isWindowsDriveAbsolutePath(value) ||
-  /(^|\/)[A-Za-z]:\//u.test(value);
 
 const isWindowsDriveAbsolutePath = (value: string): boolean =>
   /^[A-Za-z]:[/\\]/u.test(value);

--- a/src/http-notification-connector.ts
+++ b/src/http-notification-connector.ts
@@ -13,6 +13,10 @@ import type {
 import type {
   ControlledPilotInputBoundary
 } from "./controlled-pilot-input-boundary.js";
+import {
+  findUnsafeWorkflowArtifactValue,
+  formatUnsafeWorkflowArtifactDiagnostic
+} from "./workflow-artifact-hygiene.js";
 
 export type HttpNotificationMethod = "POST" | "PUT" | "PATCH";
 export type HttpNotificationOutcomeStatus = "succeeded" | "failed";
@@ -395,6 +399,17 @@ const validateSubmitRequest = (request: HttpNotificationSubmitRequest): string |
   const credentialKey = findCredentialShapedKey(request.notification);
   if (credentialKey !== undefined) {
     return `HTTP notification fixture must not include credential-shaped field ${credentialKey}`;
+  }
+
+  const unsafeArtifact = findUnsafeWorkflowArtifactValue(
+    {
+      idempotencyKey: request.idempotencyKey,
+      notification: request.notification
+    },
+    "notificationRequest"
+  );
+  if (unsafeArtifact !== undefined) {
+    return `HTTP notification fixture ${formatUnsafeWorkflowArtifactDiagnostic(unsafeArtifact)}`;
   }
 
   return undefined;

--- a/src/workflow-artifact-hygiene.ts
+++ b/src/workflow-artifact-hygiene.ts
@@ -1,0 +1,87 @@
+export type UnsafeWorkflowArtifactCategory =
+  | "secret"
+  | "token"
+  | "private-key"
+  | "session-cookie"
+  | "workstation-local-path";
+
+export interface UnsafeWorkflowArtifactFinding {
+  path: string;
+  category: UnsafeWorkflowArtifactCategory;
+}
+
+const TOKEN_VALUE_PATTERN =
+  /\b(?:ghp|github_pat|glpat|xox[abprs]|sk)[-_][A-Za-z0-9_-]{8,}\b/u;
+const PRIVATE_KEY_BLOCK_PATTERN = /-----BEGIN [A-Z ]*PRIVATE KEY[A-Z ]*-----/u;
+const SECRET_ASSIGNMENT_PATTERN =
+  /(?:^|\b)(?:password|passwd|secret|api[_-]?key|access[_-]?key)\s*[:=]/iu;
+const TOKEN_ASSIGNMENT_PATTERN = /(?:^|\b)token\s*[:=]/iu;
+const SESSION_COOKIE_PATTERN =
+  /(?:^|\b)(?:cookie|set-cookie)\s*:\s*[^;\n]*(?:session|sid)=|(?:^|\b)(?:sessionid|session_id|sid)\s*=/iu;
+const WORKSTATION_LOCAL_PATH_PATTERN =
+  /(?:^|["'\s])(?:\/Users\/[^/\\\s]+|\/home\/[^/\\\s]+|[A-Za-z]:[\\/][^/\\\s]+|file:\/\/\/[A-Za-z]:\/[^/\\\s]+)/u;
+
+export const findUnsafeWorkflowArtifactValue = (
+  value: unknown,
+  path: string
+): UnsafeWorkflowArtifactFinding | undefined => {
+  if (typeof value === "string") {
+    const category = classifyUnsafeWorkflowArtifactString(value);
+    return category === undefined ? undefined : { path, category };
+  }
+
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      const nested = findUnsafeWorkflowArtifactValue(value[index], `${path}[${index}]`);
+      if (nested !== undefined) {
+        return nested;
+      }
+    }
+    return undefined;
+  }
+
+  if (isRecord(value)) {
+    for (const [key, nestedValue] of Object.entries(value)) {
+      const nested = findUnsafeWorkflowArtifactValue(nestedValue, `${path}.${key}`);
+      if (nested !== undefined) {
+        return nested;
+      }
+    }
+  }
+
+  return undefined;
+};
+
+export const classifyUnsafeWorkflowArtifactString = (
+  value: string
+): UnsafeWorkflowArtifactCategory | undefined => {
+  if (PRIVATE_KEY_BLOCK_PATTERN.test(value)) {
+    return "private-key";
+  }
+
+  if (TOKEN_VALUE_PATTERN.test(value) || TOKEN_ASSIGNMENT_PATTERN.test(value)) {
+    return "token";
+  }
+
+  if (SESSION_COOKIE_PATTERN.test(value)) {
+    return "session-cookie";
+  }
+
+  if (SECRET_ASSIGNMENT_PATTERN.test(value)) {
+    return "secret";
+  }
+
+  if (WORKSTATION_LOCAL_PATH_PATTERN.test(value)) {
+    return "workstation-local-path";
+  }
+
+  return undefined;
+};
+
+export const formatUnsafeWorkflowArtifactDiagnostic = (
+  finding: UnsafeWorkflowArtifactFinding
+): string =>
+  `${finding.path} must not contain unsafe workflow artifact values (category: ${finding.category})`;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);

--- a/src/workflow-artifact-hygiene.ts
+++ b/src/workflow-artifact-hygiene.ts
@@ -19,7 +19,7 @@ const TOKEN_ASSIGNMENT_PATTERN = /(?:^|\b)token\s*[:=]/iu;
 const SESSION_COOKIE_PATTERN =
   /(?:^|\b)(?:cookie|set-cookie)\s*:\s*[^;\n]*(?:session|sid)=|(?:^|\b)(?:sessionid|session_id|sid)\s*=/iu;
 const WORKSTATION_LOCAL_PATH_PATTERN =
-  /(?:^|["'\s])(?:\/Users\/[^/\\\s]+|\/home\/[^/\\\s]+|[A-Za-z]:[\\/][^/\\\s]+|file:\/\/\/[A-Za-z]:\/[^/\\\s]+)/u;
+  /(?:^|["'\s])(?:\/(?:Users|home|var|tmp|opt|etc|srv|mnt|root|Volumes|usr)\/[^/\\\s]+|[A-Za-z]:[\\/][^/\\\s]+|file:\/\/\/(?:[A-Za-z]:\/|(?:Users|home|var|tmp|opt|etc|srv|mnt|root|Volumes|usr)\/)[^/\\\s]+)/u;
 
 export const findUnsafeWorkflowArtifactValue = (
   value: unknown,

--- a/src/workflow-run-state.ts
+++ b/src/workflow-run-state.ts
@@ -2,6 +2,11 @@ import { constants } from "node:fs";
 import { mkdir, open, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 
+import {
+  findUnsafeWorkflowArtifactValue,
+  formatUnsafeWorkflowArtifactDiagnostic
+} from "./workflow-artifact-hygiene.js";
+
 const ISO_TIMESTAMP_PATTERN =
   /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
 const TERMINAL_STATES = new Set([
@@ -611,6 +616,7 @@ const validateTrigger = (value: unknown, lineNumber: number): void => {
 
   if ("context" in value) {
     validateJsonSerializableValue(value.context, lineNumber, "trigger.context");
+    rejectUnsafeWorkflowArtifactValues(value.context, lineNumber, "trigger.context");
   }
 
   if ("idempotencyKey" in value) {
@@ -633,6 +639,7 @@ const validateIdempotencyMetadata = (value: unknown, lineNumber: number): void =
   }
 
   requireNonEmptyString(value, "key", lineNumber);
+  rejectUnsafeWorkflowArtifactValues(value.key, lineNumber, "idempotencyKey.key");
 };
 
 const validateRetryMetadata = (value: unknown, lineNumber: number): void => {
@@ -653,6 +660,10 @@ const validateRetryMetadata = (value: unknown, lineNumber: number): void => {
   if ("reason" in value && (typeof value.reason !== "string" || value.reason.trim() === "")) {
     throw stateError(lineNumber, "retry.reason must be a non-empty string");
   }
+
+  if ("reason" in value) {
+    rejectUnsafeWorkflowArtifactValues(value.reason, lineNumber, "retry.reason");
+  }
 };
 
 const validateResultMetadata = (value: unknown, lineNumber: number): void => {
@@ -661,7 +672,7 @@ const validateResultMetadata = (value: unknown, lineNumber: number): void => {
   }
 
   validateJsonSerializableValue(value, lineNumber, "result");
-  rejectCredentialShapedStrings(value, lineNumber, "result");
+  rejectUnsafeWorkflowArtifactValues(value, lineNumber, "result");
 };
 
 const rejectUnknownKeys = (
@@ -827,29 +838,14 @@ const validateJsonSerializableValue = (
   throw stateError(lineNumber, `${path} must contain only JSON-serializable values`);
 };
 
-const rejectCredentialShapedStrings = (
+const rejectUnsafeWorkflowArtifactValues = (
   value: unknown,
   lineNumber: number,
   path: string
 ): void => {
-  if (typeof value === "string") {
-    if (containsCredentialShapedValue(value)) {
-      throw stateError(lineNumber, `${path} must not contain credential-shaped values`);
-    }
-    return;
-  }
-
-  if (Array.isArray(value)) {
-    value.forEach((item, index) => {
-      rejectCredentialShapedStrings(item, lineNumber, `${path}[${index}]`);
-    });
-    return;
-  }
-
-  if (isRecord(value)) {
-    Object.entries(value).forEach(([key, item]) => {
-      rejectCredentialShapedStrings(item, lineNumber, `${path}.${key}`);
-    });
+  const finding = findUnsafeWorkflowArtifactValue(value, path);
+  if (finding !== undefined) {
+    throw stateError(lineNumber, formatUnsafeWorkflowArtifactDiagnostic(finding));
   }
 };
 
@@ -904,10 +900,3 @@ const isStrictIsoTimestamp = (value: string): boolean => {
 
 const isNodeError = (error: unknown): error is NodeJS.ErrnoException =>
   error instanceof Error && "code" in error;
-
-const containsCredentialShapedValue = (value: string): boolean =>
-  /(?:^|\b)(?:password|passwd|token|secret|api[_-]?key|access[_-]?key|private[_-]?key)\s*[:=]/i.test(
-    value
-  ) ||
-  /\b(?:ghp|github_pat|glpat|xox[abprs]|sk)[-_][A-Za-z0-9_-]{8,}\b/.test(value) ||
-  /-----BEGIN [A-Z ]*(?:PRIVATE KEY|TOKEN|SECRET)[A-Z ]*-----/.test(value);

--- a/test/audit-event-writer.test.ts
+++ b/test/audit-event-writer.test.ts
@@ -217,11 +217,10 @@ describe("neutral audit event writer", () => {
     );
   });
 
-  it("omits Windows-style local evidence paths from public-safe exports", async () => {
+  it("omits non-public evidence paths from public-safe exports", async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
     tempRoots.push(stateRoot);
     const statePath = join(stateRoot, "runs", "manual-run.jsonl");
-    const windowsDrivePath = ["C:", "tmp", "bundle.json"].join("\\");
     const windowsNetworkPath = ["", "", "server", "share", "bundle.json"].join("\\");
 
     await createWorkflowRun(statePath, {
@@ -260,26 +259,10 @@ describe("neutral audit event writer", () => {
           },
           {
             schemaVersion: "eip.evidence-bundle-ref.v1",
-            id: "evb_windows_drive_export",
-            correlationId: "corr_manual_export",
-            type: "local_path",
-            uri: windowsDrivePath,
-            createdAt: "2026-04-29T00:00:02.000Z"
-          },
-          {
-            schemaVersion: "eip.evidence-bundle-ref.v1",
             id: "evb_windows_network_export",
             correlationId: "corr_manual_export",
             type: "local_path",
             uri: windowsNetworkPath,
-            createdAt: "2026-04-29T00:00:02.000Z"
-          },
-          {
-            schemaVersion: "eip.evidence-bundle-ref.v1",
-            id: "evb_windows_file_uri_export",
-            correlationId: "corr_manual_export",
-            type: "file_uri",
-            uri: "file:///C:/tmp/bundle.json",
             createdAt: "2026-04-29T00:00:02.000Z"
           },
           {
@@ -300,12 +283,9 @@ describe("neutral audit event writer", () => {
       "artifacts/evidence/public/bundle.json"
     ]);
     expect(exported.publicSafe.diagnostics).toEqual([
-      "omitted an evidence reference because its URI is not public-safe",
-      "omitted an evidence reference because its URI is not public-safe",
-      "omitted an evidence reference because its URI is not public-safe",
-      "omitted an evidence reference because its URI is not public-safe"
+      "omitted an evidence reference because its URI is not public-safe (category: non-public-uri)",
+      "omitted an evidence reference because its URI is not public-safe (category: non-public-uri)"
     ]);
-    expect(JSON.stringify(exported)).not.toContain(windowsDrivePath);
     expect(JSON.stringify(exported)).not.toContain(windowsNetworkPath);
   });
 

--- a/test/http-notification-connector.test.ts
+++ b/test/http-notification-connector.test.ts
@@ -111,6 +111,31 @@ describe("HTTP notification connector skeleton", () => {
     expect(transport.deliveries).toHaveLength(1);
   });
 
+  it("rejects unsafe notification artifact values with sanitized diagnostics", async () => {
+    const transport = createFakeHttpNotificationTransport();
+    const connector = createHttpNotificationConnector({ transport });
+    const submitted = await connector.submit({
+      ...notifyRequest,
+      notification: {
+        endpointAlias: "local-operator-notification",
+        payload: {
+          message: "session_id=placeholderUnsafeSession"
+        }
+      }
+    });
+
+    expect(submitted).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid-request",
+        message:
+          "HTTP notification fixture notificationRequest.notification.payload.message must not contain unsafe workflow artifact values (category: session-cookie)"
+      }
+    });
+    expect(JSON.stringify(submitted)).not.toContain("placeholderUnsafeSession");
+    expect(transport.deliveries).toHaveLength(0);
+  });
+
   it("serializes concurrent same-key submits before transport delivery completes", async () => {
     const deliveries: HttpNotificationTransportDelivery[] = [];
     const delivery = createDeferred<HttpNotificationOutcome>();

--- a/test/workflow-run-state.test.ts
+++ b/test/workflow-run-state.test.ts
@@ -438,6 +438,33 @@ describe("workflow run JSONL state", () => {
       context: { evidencePath: ["", "home", "operator", "flow", "state.jsonl"].join("/") },
       message:
         "trigger.context.evidencePath must not contain unsafe workflow artifact values (category: workstation-local-path)"
+    },
+    {
+      context: { evidencePath: ["", "tmp", "flow", "state.jsonl"].join("/") },
+      message:
+        "trigger.context.evidencePath must not contain unsafe workflow artifact values (category: workstation-local-path)"
+    },
+    {
+      context: { evidencePath: ["", "var", "log", "flow.log"].join("/") },
+      message:
+        "trigger.context.evidencePath must not contain unsafe workflow artifact values (category: workstation-local-path)"
+    },
+    {
+      context: { evidenceUri: ["file:", "", "", "Users", "operator", "flow", "state.jsonl"].join("/") },
+      message:
+        "trigger.context.evidenceUri must not contain unsafe workflow artifact values (category: workstation-local-path)"
+    },
+    {
+      context: { evidenceUri: ["file:", "", "", "home", "operator", "flow", "state.jsonl"].join("/") },
+      message:
+        "trigger.context.evidenceUri must not contain unsafe workflow artifact values (category: workstation-local-path)"
+    },
+    {
+      context: {
+        evidenceUri: ["file:", "", "", "C:", "Users", "operator", "flow", "state.jsonl"].join("/")
+      },
+      message:
+        "trigger.context.evidenceUri must not contain unsafe workflow artifact values (category: workstation-local-path)"
     }
   ])(
     "rejects unsafe trigger context artifact values before writing %#",

--- a/test/workflow-run-state.test.ts
+++ b/test/workflow-run-state.test.ts
@@ -428,6 +428,40 @@ describe("workflow run JSONL state", () => {
     await expect(readFile(statePath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it.each([
+    {
+      context: { authorization: "Bearer ghp_placeholderUnsafeToken123" },
+      message:
+        "trigger.context.authorization must not contain unsafe workflow artifact values (category: token)"
+    },
+    {
+      context: { evidencePath: ["", "home", "operator", "flow", "state.jsonl"].join("/") },
+      message:
+        "trigger.context.evidencePath must not contain unsafe workflow artifact values (category: workstation-local-path)"
+    }
+  ])(
+    "rejects unsafe trigger context artifact values before writing %#",
+    async ({ context, message }) => {
+      const statePath = await createTempStatePath();
+
+      await expect(
+        createWorkflowRun(statePath, {
+          runId: "run-unsafe-trigger-context",
+          workflowId: "operator-review",
+          workflowVersion: "flow.workflow.v1",
+          trigger: {
+            type: "manual",
+            receivedAt: "2026-04-29T00:00:00.000Z",
+            context
+          },
+          createdAt: "2026-04-29T00:00:01.000Z"
+        })
+      ).rejects.toThrow(`workflow run state line 1: ${message}`);
+
+      await expect(readFile(statePath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    }
+  );
+
   it.each(["succeeded", "failed", "canceled", "retryable-failed"] as const)(
     "represents %s as a distinct terminal state",
     async (terminalState) => {
@@ -854,6 +888,57 @@ describe("workflow run JSONL state", () => {
 
     const persisted = await readWorkflowRunState(statePath);
     expect(persisted.events.map((event) => event.type)).toEqual(["run.created"]);
+  });
+
+  it("rejects unsafe terminal result artifact values before appending", async () => {
+    const statePath = await createTempStatePath();
+    const privateKeyBlock = [
+      "-----BEGIN PRIVATE KEY-----",
+      "placeholderUnsafeKey",
+      "-----END PRIVATE KEY-----"
+    ].join("\n");
+
+    await createWorkflowRun(statePath, {
+      runId: "run-unsafe-result",
+      workflowId: "operator-review",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z"
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "run-unsafe-result",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:02.000Z"
+    });
+
+    await expect(
+      appendWorkflowRunEvent(statePath, {
+        type: "step.attempt.completed",
+        runId: "run-unsafe-result",
+        stepId: "collect-input",
+        attempt: 1,
+        occurredAt: "2026-04-29T00:00:03.000Z",
+        result: {
+          evidence: {
+            keyMaterial: privateKeyBlock
+          }
+        }
+      })
+    ).rejects.toThrow(
+      "workflow run state line 1: result.evidence.keyMaterial must not contain unsafe workflow artifact values (category: private-key)"
+    );
+
+    const persisted = await readWorkflowRunState(statePath);
+    expect(persisted.events.map((event) => event.type)).toEqual([
+      "run.created",
+      "step.attempt.started"
+    ]);
+    expect(JSON.stringify(persisted)).not.toContain("placeholderUnsafeKey");
   });
 
   it("fails closed on duplicate terminal step attempt transitions", async () => {


### PR DESCRIPTION
## Summary
- add shared workflow artifact hygiene classification for secret/token/private-key/session-cookie/workstation-local-path values
- fail closed before unsafe trigger context, idempotency, retry, result, or notification artifact values are written
- keep public audit/evidence export diagnostics category-only and document the public-safe vs local confidential boundary

## Verification
- npm run build
- npm test -- test/workflow-run-state.test.ts test/audit-event-writer.test.ts test/http-notification-connector.test.ts
- npm test -- test/audit-event-writer.test.ts test/cli-loop-executor-smoke.test.ts test/x-gate3-flow-smoke.test.ts
- npm test
- node dist/index.js issue-lint 85 --config supervisor.config.coderabbit.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced validation to detect and reject unsafe workflow artifacts (secrets, tokens, private keys, session cookies, local/workstation paths) and surface category-specific diagnostics.

* **Documentation**
  * Added guidance on artifact hygiene, fail-closed handling at local vs. public export boundaries, and omission of unsafe evidence in public-safe exports.

* **Tests**
  * Added and adjusted tests to verify detection, rejection, and omission behavior across workflow runs and notification submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->