### PR TITLE
FLOW-052: Add partial failure recovery tests

### DIFF
--- a/test/http-notification-connector.test.ts
+++ b/test/http-notification-connector.test.ts
@@ -578,6 +578,119 @@ describe("HTTP notification connector skeleton", () => {
       await rm(tempRoot, { recursive: true, force: true });
     }
   });
+
+  it("records terminal notification failure without replaying side effects", async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), "ensen-flow-http-notification-terminal-"));
+    const statePath = join(tempRoot, "runs", "http-notification.jsonl");
+    const auditPath = join(tempRoot, "audit", "http-notification.jsonl");
+    const transport = createFakeHttpNotificationTransport({
+      outcomes: [
+        {
+          status: "failed",
+          summary: "local fake endpoint rejected notification permanently",
+          retryable: false
+        },
+        {
+          status: "succeeded",
+          summary: "unexpected replay should not be consumed"
+        }
+      ]
+    });
+    const connector = createHttpNotificationConnector({ transport });
+
+    try {
+      const result = await runWorkflow({
+        definition: {
+          ...notificationWorkflow,
+          steps: [
+            {
+              ...notificationWorkflow.steps[0],
+              retry: {
+                maxAttempts: 1,
+                backoff: {
+                  strategy: "none"
+                }
+              }
+            }
+          ]
+        },
+        statePath,
+        auditPath,
+        runId: "notification-terminal-run",
+        now: createClock([
+          "2026-05-03T01:10:00.000Z",
+          "2026-05-03T01:10:00.000Z",
+          "2026-05-03T01:10:01.000Z",
+          "2026-05-03T01:10:02.000Z",
+          "2026-05-03T01:10:03.000Z"
+        ]),
+        stepHandler: async ({ attempt, runState, step }) => {
+          const submitted = await connector.submit({
+            workflowId: runState.run.workflowId,
+            runId: runState.run.runId,
+            stepId: step.id,
+            idempotencyKey: `${runState.run.runId}:${step.id}`,
+            attempt,
+            notification: {
+              endpointAlias: "local-operator-notification",
+              method: "POST",
+              payload: {
+                subject: "placeholder-subject"
+              }
+            }
+          });
+
+          if (!submitted.ok) {
+            throw new Error(submitted.error.message);
+          }
+
+          return {
+            executor: {
+              requestId: submitted.value.requestId,
+              status: "succeeded",
+              observedAt: submitted.value.acceptedAt,
+              result: {
+                status: "succeeded",
+                summary: submitted.value.notification.summary,
+                evidence: submitted.value.evidence
+              }
+            }
+          };
+        }
+      });
+
+      expect(result.run.terminalState).toBe("failed");
+      expect(result.stepAttempts["notify-operator"]).toMatchObject([
+        {
+          attempt: 1,
+          status: "failed",
+          retry: {
+            retryable: false,
+            reason: "local fake endpoint rejected notification permanently"
+          }
+        }
+      ]);
+      expect(transport.deliveries).toHaveLength(1);
+
+      const replay = await runWorkflow({
+        definition: notificationWorkflow,
+        statePath,
+        auditPath,
+        runId: "notification-terminal-run",
+        triggerContext: {
+          requestId: "notification-terminal-replay"
+        }
+      });
+
+      expect(replay).toEqual(result);
+      expect(transport.deliveries).toHaveLength(1);
+      await expect(readFile(auditPath, "utf8")).resolves.not.toContain(
+        "unexpected replay should not be consumed"
+      );
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 const notificationWorkflow: WorkflowDefinition = {

--- a/test/webhook-trigger.test.ts
+++ b/test/webhook-trigger.test.ts
@@ -46,6 +46,45 @@ afterEach(async () => {
 });
 
 describe("webhook trigger controlled pilot boundary", () => {
+  it("replays identical webhook input deterministically without appending recovery noise", async () => {
+    const definition = createWebhookWorkflow();
+    const root = await createTempRoot();
+    const stateRoot = join(root, "runs");
+    const auditPath = join(root, "audit", "webhook.audit.jsonl");
+    const input = createWebhookInput();
+
+    const first = await consumeWebhookInput({
+      definition,
+      stateRoot,
+      auditPath,
+      input,
+      now: createClock([
+        "2026-05-03T01:00:00.000Z",
+        "2026-05-03T01:00:00.000Z",
+        "2026-05-03T01:00:01.000Z",
+        "2026-05-03T01:00:02.000Z",
+        "2026-05-03T01:00:03.000Z",
+        "2026-05-03T01:00:04.000Z"
+      ])
+    });
+    const expectedRunId = createExpectedWebhookRunId(definition.id, input.requestId);
+    const statePath = join(stateRoot, `${expectedRunId}.jsonl`);
+    const stateBeforeReplay = await readFile(statePath, "utf8");
+    const auditBeforeReplay = await readFile(auditPath, "utf8");
+
+    const replay = await consumeWebhookInput({
+      definition,
+      stateRoot,
+      auditPath,
+      input,
+      now: createClock(["2026-05-03T01:01:00.000Z"])
+    });
+
+    expect(replay).toEqual(first);
+    await expect(readFile(statePath, "utf8")).resolves.toBe(stateBeforeReplay);
+    await expect(readFile(auditPath, "utf8")).resolves.toBe(auditBeforeReplay);
+  });
+
   it("keeps webhook intake fake/local and rejects changed requestId replays without extra state", async () => {
     const definition = createWebhookWorkflow();
     const root = await createTempRoot();
@@ -80,3 +119,9 @@ describe("webhook trigger controlled pilot boundary", () => {
     );
   });
 });
+
+const createClock = (timestamps: string[]): (() => string) => {
+  let index = 0;
+
+  return () => timestamps[Math.min(index++, timestamps.length - 1)];
+};

--- a/test/workflow-runner.test.ts
+++ b/test/workflow-runner.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   appendWorkflowRunEvent,
   createWorkflowRun,
+  inspectWorkflowRunRecovery,
   readWorkflowRunState,
   runWorkflow
 } from "../src/index.js";
@@ -471,6 +472,128 @@ describe("sequential workflow runner", () => {
     });
   });
 
+  it("classifies a partial connector failure as retryable and preserves recovery evidence", async () => {
+    const definition = readWorkflowFixture("simple-manual.valid.json");
+    definition.id = "connector-partial-recovery-demo";
+    definition.steps = [
+      {
+        id: "dispatch-local-connector",
+        action: {
+          type: "local",
+          name: "partial_failure_connector"
+        },
+        retry: {
+          maxAttempts: 2,
+          backoff: {
+            strategy: "fixed",
+            delayMs: 1000
+          }
+        }
+      }
+    ];
+    const statePath = await createTempStatePath();
+    const auditPath = await createTempAuditPath();
+
+    const result = await runWorkflow({
+      definition,
+      statePath,
+      auditPath,
+      triggerContext: {
+        requestId: "connector-partial-recovery"
+      },
+      now: createClock([
+        "2026-05-03T00:00:00.000Z",
+        "2026-05-03T00:00:00.000Z",
+        "2026-05-03T00:00:01.000Z",
+        "2026-05-03T00:00:02.000Z",
+        "2026-05-03T00:00:03.000Z",
+        "2026-05-03T00:00:04.000Z",
+        "2026-05-03T00:00:05.000Z"
+      ]),
+      stepHandler: ({ attempt }) =>
+        attempt === 1
+          ? ({
+              requestId: "req_connector_partial_recovery_1",
+              status: "failed",
+              observedAt: "2026-05-03T00:00:02.000Z",
+              result: {
+                status: "failed",
+                summary: "local connector accepted the request but lost the completion receipt",
+                evidence: {
+                  connectorId: "partial-failure-connector",
+                  recoveryClass: "retryable",
+                  localReceiptRef: "evidence/partial-failure/receipt.json"
+                }
+              }
+            } satisfies ExecutorConnectorStatusSnapshot)
+          : ({
+              requestId: "req_connector_partial_recovery_2",
+              status: "succeeded",
+              observedAt: "2026-05-03T00:00:04.000Z",
+              result: {
+                status: "succeeded",
+                summary: "local connector replay observed the prior receipt",
+                evidence: {
+                  connectorId: "partial-failure-connector",
+                  recoveryClass: "recovered",
+                  localReceiptRef: "evidence/partial-failure/receipt.json"
+                }
+              }
+            } satisfies ExecutorConnectorStatusSnapshot)
+    });
+
+    expect(result.run.status).toBe("succeeded");
+    expect(result.stepAttempts["dispatch-local-connector"]).toMatchObject([
+      {
+        attempt: 1,
+        status: "retryable-failed",
+        retry: {
+          retryable: true,
+          nextAttemptAt: "2026-05-03T00:00:03.000Z",
+          reason: "local connector accepted the request but lost the completion receipt"
+        },
+        result: {
+          executor: {
+            requestId: "req_connector_partial_recovery_1",
+            status: "failed",
+            result: {
+              evidence: {
+                recoveryClass: "retryable",
+                localReceiptRef: "evidence/partial-failure/receipt.json"
+              }
+            }
+          }
+        }
+      },
+      {
+        attempt: 2,
+        status: "succeeded",
+        result: {
+          executor: {
+            status: "succeeded",
+            result: {
+              evidence: {
+                recoveryClass: "recovered"
+              }
+            }
+          }
+        }
+      }
+    ]);
+
+    const auditEvents = await readAuditEvents(auditPath);
+    expect(auditEvents.map((event) => event.type)).toEqual([
+      "workflow.started",
+      "step.started",
+      "step.failed",
+      "step.retry.scheduled",
+      "step.started",
+      "step.completed",
+      "workflow.completed"
+    ]);
+    expect(JSON.stringify(result)).not.toContain(tmpdir());
+  });
+
   it("records failed steps with diagnostic retry metadata", async () => {
     const definition = readWorkflowFixture("simple-manual.valid.json");
     const statePath = await createTempStatePath();
@@ -702,6 +825,93 @@ describe("sequential workflow runner", () => {
     }
   );
 
+  it("keeps Loop executor connector failure as executor evidence, not Flow-owned lane state", async () => {
+    const definition = readWorkflowFixture("simple-manual.valid.json");
+    definition.id = "loop-executor-partial-failure-demo";
+    definition.steps = [
+      {
+        id: "loop-executor-dispatch",
+        action: {
+          type: "local",
+          name: "ensen_loop_eip_executor"
+        }
+      }
+    ];
+    const statePath = await createTempStatePath();
+
+    const result = await runWorkflow({
+      definition,
+      statePath,
+      triggerContext: {
+        requestId: "loop-executor-partial-failure"
+      },
+      now: createClock([
+        "2026-05-03T00:10:00.000Z",
+        "2026-05-03T00:10:00.000Z",
+        "2026-05-03T00:10:01.000Z",
+        "2026-05-03T00:10:02.000Z",
+        "2026-05-03T00:10:03.000Z"
+      ]),
+      stepHandler: () =>
+        ({
+          requestId: "req_loop_executor_partial_failure",
+          status: "failed",
+          observedAt: "2026-05-03T00:10:02.000Z",
+          result: {
+            status: "failed",
+            summary: "Ensen-loop executor connector returned a loop-gap failure",
+            evidence: {
+              connectorId: "ensen-loop-eip",
+              failureClass: "loop-gap",
+              operation: "status",
+              localArtifactSemantics: "local-development-references-only"
+            }
+          }
+        }) satisfies ExecutorConnectorStatusSnapshot
+    });
+
+    expect(result.run.status).toBe("failed");
+    expect(result.stepAttempts["loop-executor-dispatch"]).toMatchObject([
+      {
+        attempt: 1,
+        status: "failed",
+        retry: {
+          retryable: false,
+          reason: "Ensen-loop executor connector returned a loop-gap failure"
+        },
+        result: {
+          executor: {
+            requestId: "req_loop_executor_partial_failure",
+            status: "failed",
+            result: {
+              evidence: {
+                connectorId: "ensen-loop-eip",
+                failureClass: "loop-gap",
+                operation: "status",
+                localArtifactSemantics: "local-development-references-only"
+              }
+            }
+          }
+        }
+      }
+    ]);
+    expect(JSON.stringify(result.stepAttempts["loop-executor-dispatch"][0].result)).not.toContain(
+      "laneState"
+    );
+    expect(JSON.stringify(result.stepAttempts["loop-executor-dispatch"][0].result)).not.toContain(
+      "flowOwnedLane"
+    );
+
+    await expect(inspectWorkflowRunRecovery(statePath)).resolves.toMatchObject({
+      classification: "terminal",
+      action: "do-not-replay",
+      run: {
+        status: "failed",
+        terminalState: "failed"
+      }
+    });
+  });
+
   it("returns the existing terminal run when the idempotency key matches", async () => {
     const definition = readWorkflowFixture("simple-manual.valid.json");
     const statePath = await createTempStatePath();
@@ -751,3 +961,9 @@ describe("sequential workflow runner", () => {
     ).rejects.toThrow("existing workflow run state has a different idempotency key");
   });
 });
+
+const createClock = (timestamps: string[]): (() => string) => {
+  let index = 0;
+
+  return () => timestamps[Math.min(index++, timestamps.length - 1)];
+};


### PR DESCRIPTION
## Summary
- add retryable partial connector failure coverage with preserved local recovery evidence
- add terminal HTTP notification failure coverage that proves no side-effect replay after terminal state
- add deterministic webhook replay coverage and Loop executor connector failure coverage as executor evidence

## Verification
- npm run build
- npm test -- test/workflow-runner.test.ts test/webhook-trigger.test.ts test/http-notification-connector.test.ts test/cli-loop-executor-smoke.test.ts
- npm test
- node dist/index.js issue-lint 86 --config supervisor.config.coderabbit.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for workflow failure and recovery scenarios, including verification of terminal states in notification workflows.
  * Added deterministic replay testing for webhook inputs to ensure consistent execution behavior across reruns.
  * Improved testing for recovery classification and executor failure handling in retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->