### PR TITLE
FLOW-X3A-003: Add controlled pilot rollback runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ authority, and no premature compliance claims.
   boundary, Loop local fake lane command shape, stdout contract, failure
   routing, focused Flow smoke coverage, local cleanup limits, and
   non-production limits.
+- `docs/controlled-pilot-rollback-recovery-runbook.md`: controlled pilot
+  rollback and recovery choices for retry, re-run, abandon, manual repair,
+  JSONL state recovery, approval/retry/idempotency recovery, notification
+  misfire and webhook replay handling, and cleanup boundaries that preserve
+  audit/evidence history.
 - `docs/loop-flow-protocol-v0.2.0-connection-smoke.md`: pre-Phase 5
   Protocol v0.2.0 Loop-Flow connection smoke, capability checks, focused
   commands, and failure routing.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Start here:
 - [X-Gate 2 Loop-Flow Smoke Runbook](./x-gate2-loop-flow-smoke-runbook.md): local smoke commands, artifacts, failure routing, and non-production boundaries.
 - [X-Gate 3 Flow Caller Boundary Runbook](./x-gate3-flow-caller-boundary-runbook.md): Flow-owned caller boundary for Loop local fake lane smoke input, stdout output, artifacts, and failure routing.
 - Focused Flow X-Gate 3 smoke coverage: `npm test -- test/x-gate3-flow-smoke.test.ts`.
+- [Controlled Pilot Rollback and Recovery Runbook](./controlled-pilot-rollback-recovery-runbook.md): Track A / Flow Phase 5 operator choices for retry, re-run, abandon, manual repair, JSONL state recovery, notification misfire, webhook replay handling, Loop connector failure routing, and cleanup boundaries that preserve audit/evidence history.
 - [Loop-Flow Protocol v0.2.0 Connection Smoke](./loop-flow-protocol-v0.2.0-connection-smoke.md): pre-Phase 5 local/fake/dry-run smoke, capability variant checks, focused commands, and `protocol-gap` / `loop-gap` / `flow-gap` routing.
 - [Ensen-protocol v0.2.0 Snapshot](../protocol-snapshots/ensen-protocol/v0.2.0/README.md): active copied protocol schemas, conformance fixtures, capability variant examples, and contract docs for pre-Phase 5 connector tests.
 

--- a/docs/controlled-pilot-rollback-recovery-runbook.md
+++ b/docs/controlled-pilot-rollback-recovery-runbook.md
@@ -1,0 +1,148 @@
+# Controlled Pilot Rollback and Recovery Runbook
+
+This runbook documents the Flow-owned controlled pilot recovery boundary for
+Track A safety and Flow Phase 5 planning. It is an operator guide for local and
+controlled pilot candidates only. It is not a production runbook, not customer
+repo guidance, not ERPNext behavior, not regulated data handling, not an
+electronic signature or batch-release process, and not a compliance claim.
+
+Related planning references:
+
+- Ensen-general `Roadmap/X-Gate 3 Track A safety tracker.md`, especially
+  `FLOW-X3A-003`;
+- Flow Phase 5 roadmap items for verification, review, evidence, recovery, and
+  controlled pilot readiness;
+- `docs/x-gate3-flow-caller-boundary-runbook.md` for the Flow caller boundary;
+- `docs/loop-flow-protocol-v0.2.0-connection-smoke.md` for the pre-Phase 5
+  Loop connector boundary.
+
+## Recovery Boundary
+
+Flow owns the local workflow definition, JSONL run state, neutral audit JSONL
+events, public-safe audit/evidence export, trigger idempotency checks, and local
+connector result recording. Flow does not own Ensen-loop internal lane state,
+provider sessions, repository mutation, customer artifacts, ERPNext records, or
+Pharma/GxP workflow packs.
+
+Use the implemented JSONL recovery boundary first:
+
+```sh
+npm run build
+node dist/cli.js run fixtures/workflow-definitions/simple-manual.valid.json <state-jsonl-path> '{"requestId":"manual-001"}'
+```
+
+Programmatic callers should inspect the state with
+`inspectWorkflowRunRecovery(<state-jsonl-path>)` before choosing retry, re-run,
+abandon, or manual repair. Safe stop is explicit:
+`stopWorkflowRunRecovery` appends a `canceled` terminal event. Operators must
+not recover by deleting, editing, truncating, or rewriting the JSONL history.
+The controlled pilot choices are retry, re-run, abandon, or manual repair.
+
+## Decision Table
+
+| Observed state | Default choice | Operator action | Preserved records | Do not do |
+| --- | --- | --- | --- | --- |
+| `recoverable` JSONL state with no active attempt | Retry or resume | Continue from projected JSONL state with the same run ID, trigger context, and idempotency key. | Existing run JSONL, neutral audit JSONL, local evidence references, completed step attempts. | Do not create a second run for the same logical request only because a summary looked stale. |
+| Terminal `succeeded`, `failed`, or `canceled` run | Re-run only with a new explicit request | Start a new state path and new request ID when the operator intentionally wants another attempt. | Prior terminal run, audit events, exported evidence metadata. | Do not replay active work into a terminal run. |
+| `approval-required` step | Manual approval recovery | Keep the run non-terminal until a human records the next choice: retry after approval, re-run, abandon, or manual repair. | Approval-required step result, neutral audit event, review notes. | Do not infer approval from Loop status, notification delivery, issue text, naming, or nearby metadata. |
+| Active step attempt or contradictory step order | Manual repair | Stop and inspect the JSONL file, connector receipt, and audit events; repair only through an explicit follow-up patch or documented operator note. | All JSONL lines and local evidence references. | Do not assume external side effects are absent. |
+| Retryable connector or notification failure | Retry | Reuse the same idempotency binding and step retry policy. Preserve the failed attempt and retry metadata. | Failed attempt, retry reason, next attempt time, connector evidence. | Do not change payload, endpoint alias, headers, request ID, or idempotency key during replay. |
+| `blocked` connector outcome | Abandon or manual repair | Treat the blocked result as an explicit connector outcome and route the owner-specific follow-up. | Blocked step result and terminal failed run record when present. | Do not wrap a Loop connector failure as Flow-owned lane state. |
+| Corrupt JSONL state or unsafe artifact diagnostic | Manual repair | Reject automated recovery and repair JSONL/artifact hygiene with a focused follow-up. | Original corrupt file and sanitized diagnostic. | Do not fabricate success, evidence, or approval to get past the guard. |
+
+## Partial Failure Classification
+
+Classify from the boundary that produced the authoritative failure:
+
+| Class | Owner | Use when |
+| --- | --- | --- |
+| `flow-gap` | TommyKammy/Ensen-flow | Flow writes unsafe run/audit artifacts, accepts changed replay input, loses idempotency binding, misprojects JSONL state, or deletes history during cleanup. |
+| `loop-gap` | TommyKammy/Ensen-loop | The Loop connector boundary returns a malformed, missing, blocked, or failed aggregate for Loop-owned reasons. Keep the result as connector evidence. |
+| `protocol-gap` | TommyKammy/Ensen-protocol | The copied protocol snapshot cannot represent the needed RunRequest, RunStatusSnapshot, RunResult, capability, retryability, or evidence shape. |
+
+Fail closed when ownership is unclear. Do not infer tenant, repository, run,
+approval, or environment binding from path shape, branch names, issue text,
+comments, forwarded headers, placeholder credentials, or human-readable
+summaries.
+
+## Specific Recovery Cases
+
+JSONL state recovery starts from `inspectWorkflowRunRecovery`. `recoverable`
+means Flow can continue from projected local state. `terminal` means no replay.
+`approval-required`, `blocked`, `corrupt`, and `manual-repair-needed` require an
+operator decision before new state or audit records are appended.
+
+Approval recovery remains human-controlled. An `approval-required` result keeps
+the run non-terminal; retry, re-run, abandon, and manual repair are explicit
+operator choices. Notification delivery, Loop status text, or issue comments do
+not count as approval.
+
+Retry and idempotency recovery must preserve request binding. Replays use the
+same request ID, trigger idempotency key, step idempotency key, normalized
+webhook input, notification endpoint alias, method, headers, and payload. If
+any replay input changes, Flow rejects before writing new state or audit events.
+
+Notification misfires are connector outcomes. Retryable fake/local notification
+failures may retry through the configured step retry policy. Terminal failures
+record the failed attempt and, when retries are exhausted, a terminal failed
+run. Operators should re-run only with a new explicit request when the payload
+or destination must change.
+
+Webhook replay handling is fail-closed. Reusing a `requestId` is allowed only
+when the normalized webhook input is unchanged. Changed payload, headers, path,
+or received timestamp must be rejected before partial run state or audit output
+is written.
+
+Loop connector failures stay at the connector boundary. Flow records the
+executor status/result/evidence in the step attempt and routes `loop-gap`
+follow-ups to Ensen-loop. Flow must not translate Loop failures into internal
+Flow wrapper state or claim that Loop work was recovered by Flow alone.
+
+## Cleanup Boundary
+
+Cleanup is allowed only for scratch data created for the current local or
+controlled pilot attempt:
+
+```sh
+rm -f <temporary-input-json-file>
+rm -rf <local-scratch-artifact-root>
+```
+
+Preserve these by default:
+
+- workflow run JSONL files and every appended line;
+- neutral audit JSONL files;
+- public-safe audit/evidence exports;
+- local confidential reference indexes;
+- connector receipts, blocked outcomes, retry metadata, approval-required
+  outcomes, and manual repair notes;
+- issue journals, supervisor state, repository checkouts, branches, and
+  worktrees.
+
+Do not automatically clean repository checkouts, supervisor state, sibling
+repos, Ensen-loop lane state, production evidence stores, customer artifacts,
+ERPNext records, or any path not created for the current scratch attempt.
+
+## Verification
+
+Run focused local verification first:
+
+```sh
+npm test -- test/workflow-runner.test.ts test/docs-navigation.test.ts
+```
+
+Then run the repo-owned checks:
+
+```sh
+npm run build
+npm test
+```
+
+Manual docs review should compare this runbook against
+Ensen-general `Roadmap/X-Gate 3 Track A safety tracker.md` and the Flow Phase 5
+roadmap boundary. From the companion supervisor checkout, issue readiness can
+be checked with a placeholder config path:
+
+```sh
+CODEX_SUPERVISOR_CONFIG=<supervisor-config-path> node dist/index.js issue-lint <this-issue-number> --config "$CODEX_SUPERVISOR_CONFIG"
+```

--- a/test/docs-navigation.test.ts
+++ b/test/docs-navigation.test.ts
@@ -1,0 +1,59 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+const runbookPath = "docs/controlled-pilot-rollback-recovery-runbook.md";
+const readmePath = "README.md";
+const docsIndexPath = "docs/README.md";
+const posixHomeRootPattern = new RegExp(["", "Users", "[A-Za-z0-9._-]+"].join("\\/"));
+const linuxHomeRootPattern = new RegExp(["", "home", "[A-Za-z0-9._-]+"].join("\\/"));
+const windowsHomeRootPattern = new RegExp(["[A-Za-z]:", "Users", ""].join("\\\\"));
+
+describe("documentation navigation", () => {
+  it("links the controlled pilot rollback and recovery runbook from public docs", async () => {
+    const [readme, docsIndex] = await Promise.all([
+      readFile(readmePath, "utf8"),
+      readFile(docsIndexPath, "utf8")
+    ]);
+
+    expect(readme).toContain("docs/controlled-pilot-rollback-recovery-runbook.md");
+    expect(docsIndex).toContain("controlled-pilot-rollback-recovery-runbook.md");
+  });
+
+  it("documents controlled pilot recovery decisions without host-local paths", async () => {
+    const runbook = await readFile(runbookPath, "utf8");
+
+    for (const requiredText of [
+      "Controlled Pilot Rollback and Recovery Runbook",
+      "X-Gate 3 Track A safety tracker.md",
+      "Flow Phase 5",
+      "retry, re-run, abandon, or manual repair",
+      "inspectWorkflowRunRecovery(<state-jsonl-path>)",
+      "stopWorkflowRunRecovery",
+      "Decision Table",
+      "recoverable",
+      "approval-required",
+      "manual-repair-needed",
+      "blocked",
+      "corrupt",
+      "JSONL state recovery",
+      "Approval recovery",
+      "Retry and idempotency recovery",
+      "Notification misfires",
+      "Webhook replay handling",
+      "Loop connector failures stay at the connector boundary",
+      "workflow run JSONL files",
+      "neutral audit JSONL files",
+      "public-safe audit/evidence exports",
+      "Do not automatically clean repository checkouts",
+      "CODEX_SUPERVISOR_CONFIG=<supervisor-config-path>",
+      "node dist/index.js issue-lint <this-issue-number>"
+    ]) {
+      expect(runbook).toContain(requiredText);
+    }
+
+    expect(runbook).not.toMatch(posixHomeRootPattern);
+    expect(runbook).not.toMatch(linuxHomeRootPattern);
+    expect(runbook).not.toMatch(windowsHomeRootPattern);
+  });
+});


### PR DESCRIPTION
## Summary
- add the controlled pilot rollback and recovery runbook for FLOW-X3A-003
- document retry, re-run, abandon, manual repair, JSONL recovery, approval/retry/idempotency recovery, notification misfire, webhook replay, Loop connector failure routing, and cleanup boundaries
- link the runbook from README and docs navigation and add a focused docs-navigation test

## Verification
- npm ci
- npm test -- test/workflow-runner.test.ts test/docs-navigation.test.ts
- npm run build
- npm test
- manual docs check against Ensen-general Roadmap/X-Gate 3 Track A safety tracker.md
- CODEX_SUPERVISOR_CONFIG=supervisor.config.coderabbit.json node dist/index.js issue-lint 88 --config supervisor.config.coderabbit.json

Part of #81
Closes #88

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added a comprehensive runbook for controlled pilot rollback and recovery procedures
* Includes operator decision flows for handling failures and state recovery
* Covers webhook replay, notification handling, and failure classification guidance
* Details cleanup constraints and audit history preservation boundaries
* Added documentation index entries and validation tests to ensure content discoverability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->