### PR TITLE
FLOW-X3A-FU-001: Omit unsafe file URI evidence exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,10 @@ type, step attempts, neutral audit event summaries, and any public-safe
 context, idempotency key values, raw local state paths, raw audit paths,
 workstation-local evidence paths, secrets, customer data, production evidence
 locations, and unsupported Protocol Phase 4 evidence profile fields are not
-exported into the public-safe section.
+exported into the public-safe section. `file_uri` evidence references are
+omitted from public-safe exports until a later protocol evidence profile defines
+a deliberately public mapping; portable relative `local_path` references remain
+exportable.
 
 Workflow artifact hygiene is fail-closed at the local JSONL boundary and at
 public export boundaries. Raw secrets, token-shaped strings, private key blocks,

--- a/src/audit-evidence-export.ts
+++ b/src/audit-evidence-export.ts
@@ -399,7 +399,7 @@ const isPublicSafeEvidenceRef = (ref: AuditEvidenceExportEvidenceRef): boolean =
     return isSafeRelativePath(ref.uri);
   }
 
-  return isSafeFileUri(ref.uri);
+  return isPublicSafeFileUri(ref.uri);
 };
 
 const isSafeRelativePath = (value: string): boolean => {
@@ -419,29 +419,9 @@ const createUnsafeEvidenceRefDiagnostic = (ref: AuditEvidenceExportEvidenceRef):
   return `omitted an evidence reference because its URI is not public-safe (category: ${category})`;
 };
 
-const isSafeFileUri = (value: string): boolean => {
-  let parsed: URL;
-  try {
-    parsed = new URL(value);
-  } catch {
-    return false;
-  }
-
-  if (
-    parsed.protocol !== "file:" ||
-    parsed.username !== "" ||
-    parsed.password !== "" ||
-    parsed.hostname !== ""
-  ) {
-    return false;
-  }
-
-  if (parsed.search !== "" || parsed.hash !== "") {
-    return false;
-  }
-
-  return !parsed.pathname.split("/").includes("..");
-};
+const isPublicSafeFileUri = (_value: string): boolean =>
+  // Protocol Phase 4 has not defined a public evidence profile for file: URIs.
+  false;
 
 const isWindowsDriveAbsolutePath = (value: string): boolean =>
   /^[A-Za-z]:[/\\]/u.test(value);

--- a/test/audit-event-writer.test.ts
+++ b/test/audit-event-writer.test.ts
@@ -222,6 +222,7 @@ describe("neutral audit event writer", () => {
     tempRoots.push(stateRoot);
     const statePath = join(stateRoot, "runs", "manual-run.jsonl");
     const windowsNetworkPath = ["", "", "server", "share", "bundle.json"].join("\\");
+    const posixHostFileUri = ["file://", "private", "tmp", "secret-bundle.json"].join("/");
 
     await createWorkflowRun(statePath, {
       runId: "local-manual-demo-export",
@@ -272,6 +273,14 @@ describe("neutral audit event writer", () => {
             type: "file_uri",
             uri: "file://server/share/bundle.json",
             createdAt: "2026-04-29T00:00:02.000Z"
+          },
+          {
+            schemaVersion: "eip.evidence-bundle-ref.v1",
+            id: "evb_posix_host_file_uri_export",
+            correlationId: "corr_manual_export",
+            type: "file_uri",
+            uri: posixHostFileUri,
+            createdAt: "2026-04-29T00:00:02.000Z"
           }
         ]
       }
@@ -284,9 +293,12 @@ describe("neutral audit event writer", () => {
     ]);
     expect(exported.publicSafe.diagnostics).toEqual([
       "omitted an evidence reference because its URI is not public-safe (category: non-public-uri)",
+      "omitted an evidence reference because its URI is not public-safe (category: non-public-uri)",
       "omitted an evidence reference because its URI is not public-safe (category: non-public-uri)"
     ]);
-    expect(JSON.stringify(exported)).not.toContain(windowsNetworkPath);
+    const serialized = JSON.stringify(exported);
+    expect(serialized).not.toContain(windowsNetworkPath);
+    expect(serialized).not.toContain(posixHostFileUri);
   });
 
   it("rejects extra export-audit-evidence CLI arguments", async () => {


### PR DESCRIPTION
## Summary
- omit file_uri evidence references from public-safe audit/evidence exports until a public protocol evidence profile exists
- preserve portable relative local_path evidence refs
- add regression coverage for host-local file URI omission without serializing the raw URI
- clarify README public-safe versus local-confidential boundary

## Verification
- npm run build
- npm test -- test/audit-event-writer.test.ts
- npm test
- node dist/index.js issue-lint 96 --config supervisor.config.coderabbit.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `export-audit-evidence` CLI documentation clarifying that file URI references are omitted from public-safe exports while portable relative path references remain exportable.

* **Bug Fixes**
  * File URI evidence references are now correctly treated as non-public-safe and omitted from public-safe exports.

* **Tests**
  * Enhanced test coverage for file URI evidence reference handling in public-safe exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->