### PR TITLE
Fail closed on malformed controlled pilot boundaries

### DIFF
--- a/src/controlled-pilot-input-boundary.ts
+++ b/src/controlled-pilot-input-boundary.ts
@@ -21,6 +21,28 @@ export interface ControlledPilotInputBoundary {
 const isNonEmptyString = (value: unknown): value is string =>
   typeof value === "string" && value.trim() !== "";
 
+const maxBoundaryMetadataStringLength = 256;
+const strictIsoTimestampPattern =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+const isBoundedString = (value: unknown): value is string =>
+  isNonEmptyString(value) && value.length <= maxBoundaryMetadataStringLength;
+
+const isDryRunFirstInputBoundaryMode = (
+  value: unknown
+): value is DryRunFirstInputBoundaryMode =>
+  value === "fake" || value === "local" || value === "dry-run";
+
+const isStrictIsoTimestamp = (value: unknown): value is string => {
+  if (!isBoundedString(value) || !strictIsoTimestampPattern.test(value)) {
+    return false;
+  }
+
+  const parsed = new Date(value);
+
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString() === value;
+};
+
 export const explainControlledPilotBoundaryRejection = (
   input: {
     surface: string;
@@ -32,19 +54,24 @@ export const explainControlledPilotBoundaryRejection = (
     return `${prefix} before controlled pilot use`;
   }
 
-  if (input.boundary.mode === "fake" || input.boundary.mode === "local" || input.boundary.mode === "dry-run") {
+  if (isDryRunFirstInputBoundaryMode(input.boundary.mode)) {
     return undefined;
+  }
+
+  if (input.boundary.mode !== "real") {
+    return `${input.surface} must declare a fake, local, dry-run, or explicitly approved real input boundary before controlled pilot use`;
   }
 
   const evidence = input.boundary.dryRunFirstEvidence;
   const override = input.boundary.override;
   if (
     evidence === undefined ||
-    !isNonEmptyString(evidence?.reference) ||
+    !isDryRunFirstInputBoundaryMode(evidence?.mode) ||
+    !isBoundedString(evidence?.reference) ||
     override === undefined ||
-    !isNonEmptyString(override?.approvedBy) ||
-    !isNonEmptyString(override?.approvedAt) ||
-    !isNonEmptyString(override?.reason)
+    !isBoundedString(override?.approvedBy) ||
+    !isStrictIsoTimestamp(override?.approvedAt) ||
+    !isBoundedString(override?.reason)
   ) {
     return `${input.surface} real input requires explicit dry-run-first evidence and a human-controlled override`;
   }

--- a/test/controlled-pilot-input-boundary.test.ts
+++ b/test/controlled-pilot-input-boundary.test.ts
@@ -89,4 +89,59 @@ describe("controlled pilot input boundary", () => {
       ).toBe(expectedReason);
     }
   });
+
+  it("rejects unknown input boundary modes instead of treating them as real input", () => {
+    expect(
+      explainControlledPilotBoundaryRejection({
+        surface: "HTTP notification transport",
+        boundary: malformedRealBoundary({
+          mode: "customer-live"
+        })
+      })
+    ).toBe(
+      "HTTP notification transport must declare a fake, local, dry-run, or explicitly approved real input boundary before controlled pilot use"
+    );
+  });
+
+  it("rejects malformed dry-run-first evidence modes for real input", () => {
+    expect(
+      explainControlledPilotBoundaryRejection({
+        surface: "HTTP notification transport",
+        boundary: malformedRealBoundary({
+          dryRunFirstEvidence: {
+            mode: "production",
+            reference: "docs/connector-capability-matrix.md"
+          }
+        })
+      })
+    ).toBe(
+      "HTTP notification transport real input requires explicit dry-run-first evidence and a human-controlled override"
+    );
+  });
+
+  it("rejects malformed real input approval timestamps", () => {
+    expect(
+      explainControlledPilotBoundaryRejection({
+        surface: "HTTP notification transport",
+        boundary: malformedRealBoundary({
+          override: {
+            approvedBy: "owner",
+            approvedAt: "2026-05-03 00:00:00",
+            reason: "controlled owner pilot"
+          }
+        })
+      })
+    ).toBe(
+      "HTTP notification transport real input requires explicit dry-run-first evidence and a human-controlled override"
+    );
+  });
+
+  it("allows real input only with dry-run-first evidence and a human override", () => {
+    expect(
+      explainControlledPilotBoundaryRejection({
+        surface: "HTTP notification transport",
+        boundary: malformedRealBoundary({})
+      })
+    ).toBeUndefined();
+  });
 });

--- a/test/http-notification-connector.test.ts
+++ b/test/http-notification-connector.test.ts
@@ -11,6 +11,7 @@ import {
   runWorkflow
 } from "../src/index.js";
 import type {
+  ControlledPilotInputBoundary,
   HttpNotificationOutcome,
   HttpNotificationSubmitRequest,
   HttpNotificationTransportDelivery,
@@ -435,6 +436,75 @@ describe("HTTP notification connector skeleton", () => {
           "HTTP notification transport must declare a fake, local, or dry-run input boundary before controlled pilot use"
       }
     });
+  });
+
+  it("keeps notify unsupported for malformed real-input boundary metadata", async () => {
+    const connector = createHttpNotificationConnector({
+      transport: {
+        inputBoundary: {
+          mode: "real",
+          dryRunFirstEvidence: {
+            mode: "production",
+            reference: "docs/connector-capability-matrix.md"
+          },
+          override: {
+            approvedBy: "owner",
+            approvedAt: "not-an-iso-timestamp",
+            reason: "controlled owner pilot"
+          }
+        } as unknown as ControlledPilotInputBoundary,
+        deliver() {
+          return {
+            status: "succeeded",
+            summary: "custom transport accepted notification"
+          };
+        }
+      }
+    });
+
+    expect(connector.capabilities.notify).toEqual({
+      supported: false,
+      reason:
+        "HTTP notification transport real input requires explicit dry-run-first evidence and a human-controlled override"
+    });
+    await expect(connector.submit(notifyRequest)).resolves.toMatchObject({
+      ok: false,
+      connectorId: "http-notification",
+      operation: "submit",
+      error: {
+        code: "unsupported-operation",
+        retryable: false,
+        reason:
+          "HTTP notification transport real input requires explicit dry-run-first evidence and a human-controlled override"
+      }
+    });
+  });
+
+  it("supports notify for a valid real-input override boundary", () => {
+    const connector = createHttpNotificationConnector({
+      transport: {
+        inputBoundary: {
+          mode: "real",
+          dryRunFirstEvidence: {
+            mode: "dry-run",
+            reference: "docs/connector-capability-matrix.md"
+          },
+          override: {
+            approvedBy: "owner",
+            approvedAt: "2026-05-03T00:00:00.000Z",
+            reason: "controlled owner pilot"
+          }
+        },
+        deliver() {
+          return {
+            status: "succeeded",
+            summary: "custom transport accepted notification"
+          };
+        }
+      }
+    });
+
+    expect(connector.capabilities.notify).toEqual({ supported: true });
   });
 
   it("rejects invalid retry attempt values", async () => {


### PR DESCRIPTION
## Summary
- reject unknown controlled pilot input boundary modes before the real-input override path
- validate real-input dry-run-first evidence mode, bounded metadata strings, and strict ISO approval timestamps
- add focused boundary and HTTP notification capability regressions for malformed and valid real-input metadata

## Verification
- npm run build
- npm test -- test/controlled-pilot-input-boundary.test.ts test/http-notification-connector.test.ts
- npm test
- node dist/index.js issue-lint 97 --config supervisor.config.coderabbit.json

Closes #97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for boundary metadata by enforcing stricter timestamp formats and length constraints to prevent invalid configurations.

* **Tests**
  * Added comprehensive test coverage for boundary validation scenarios, including timestamp validation, mode validation, and HTTP connector interactions with real input boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->