### PR TITLE
Adopt Protocol v0.3.0 evidence profile snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ authority, and no premature compliance claims.
 - `docs/loop-flow-protocol-v0.2.0-connection-smoke.md`: pre-Phase 5
   Protocol v0.2.0 Loop-Flow connection smoke, capability checks, focused
   commands, and failure routing.
+- `protocol-snapshots/ensen-protocol/v0.3.0/README.md`: copied Protocol
+  v0.3.0 operational evidence profile snapshot for X-Gate 3 Track A artifact
+  hygiene, with the source release tag and release URL recorded locally.
 
 ## Workflow Definition Schema
 
@@ -181,6 +184,24 @@ The older v0.1.0 snapshot remains in this repository as historical fixture data
 for compatibility review only. New connector conformance and Phase 5 planning
 should use the v0.2.0 snapshot boundary unless a test explicitly documents a
 retained compatibility behavior.
+
+The copied Ensen-protocol v0.3.0 operational evidence profile snapshot is
+documented in `protocol-snapshots/ensen-protocol/v0.3.0/README.md`, with the
+profile doc at
+`protocol-snapshots/ensen-protocol/v0.3.0/docs/integration/operational-evidence-profile.md`
+and the public fixture-safe example at
+`protocol-snapshots/ensen-protocol/v0.3.0/fixtures/operational-evidence-profile/v1/valid/public-fixture-safe-profile.json`.
+It records source release tag `v0.3.0` and release URL
+`https://github.com/TommyKammy/Ensen-protocol/releases/tag/v0.3.0`. This
+snapshot is a local contract reference for X-Gate 3 Track A evidence work; it
+does not introduce a runtime dependency, production evidence archive, customer
+data export, credential source, retention system, cleanup workflow, recovery
+workflow, or compliance evidence claim.
+
+Future Protocol profile updates should be adopted by adding a new versioned
+snapshot directory from a tagged Ensen-protocol release, recording the release
+tag and release URL in that directory's manifest, and updating this navigation
+without pointing Flow runtime code or tests at a sibling checkout.
 
 ## Local Sequential Runner
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,5 +16,6 @@ Start here:
 - [Controlled Pilot Rollback and Recovery Runbook](./controlled-pilot-rollback-recovery-runbook.md): Track A / Flow Phase 5 operator choices for retry, re-run, abandon, manual repair, JSONL state recovery, notification misfire, webhook replay handling, Loop connector failure routing, and cleanup boundaries that preserve audit/evidence history.
 - [Loop-Flow Protocol v0.2.0 Connection Smoke](./loop-flow-protocol-v0.2.0-connection-smoke.md): pre-Phase 5 local/fake/dry-run smoke, capability variant checks, focused commands, and `protocol-gap` / `loop-gap` / `flow-gap` routing.
 - [Ensen-protocol v0.2.0 Snapshot](../protocol-snapshots/ensen-protocol/v0.2.0/README.md): active copied protocol schemas, conformance fixtures, capability variant examples, and contract docs for pre-Phase 5 connector tests.
+- [Ensen-protocol v0.3.0 Operational Evidence Profile Snapshot](../protocol-snapshots/ensen-protocol/v0.3.0/README.md): copied operational evidence profile docs and public fixture-safe example for X-Gate 3 Track A artifact hygiene. Profile doc: `../protocol-snapshots/ensen-protocol/v0.3.0/docs/integration/operational-evidence-profile.md`.
 
 Ensen-flow documentation should preserve the product boundary: lightweight explainable workflow orchestration, no shared runtime dependency with Ensen-loop, and no premature Pharma/GxP compliance claims.

--- a/protocol-snapshots/ensen-protocol/v0.3.0/README.md
+++ b/protocol-snapshots/ensen-protocol/v0.3.0/README.md
@@ -1,0 +1,57 @@
+# Ensen-protocol v0.3.0 Operational Evidence Profile Snapshot
+
+This directory is a copied snapshot of public Ensen Interop Protocol
+operational evidence profile artifacts from `TommyKammy/Ensen-protocol`
+release tag `v0.3.0`, release URL
+`https://github.com/TommyKammy/Ensen-protocol/releases/tag/v0.3.0`, protocol
+version `0.3.0`.
+
+It is intentionally repo-owned by Ensen-flow. Ensen-flow must not require an
+Ensen-protocol checkout, package, service, fixture path, or runtime dependency
+to build, test, or operate.
+
+## Contents
+
+- `docs/integration/operational-evidence-profile.md`: Protocol guidance for
+  X-Gate 3 Track A artifact hygiene before owner-controlled real input.
+- `fixtures/operational-evidence-profile/v1/valid/public-fixture-safe-profile.json`:
+  public fixture-safe synthetic example for local Track A hygiene tests.
+- `manifest.json`: source release tag, release URL, copied artifact list,
+  validation evidence, update policy, and intentional exclusions.
+
+The v0.3.0 snapshot does not replace the v0.2.0 copied schema and connector
+contract snapshot. Flow keeps v0.2.0 as the active EIP schema boundary while
+using this v0.3.0 directory as a local, auditable reference for operational
+evidence profile work.
+
+## Validation Evidence
+
+The v0.3.0 source release recorded these protocol validation commands:
+
+```sh
+npm test
+npm run check:fixtures
+npm run check:public-fixtures
+npm run check:schema-ids
+npm run check:spec-boundary
+```
+
+Flow records these commands as source-release evidence for this copied
+snapshot. This issue does not require rerunning sibling-repo protocol commands
+from the Flow worktree.
+
+## Update Policy
+
+Treat this directory as read-only protocol fixture data. Runtime code should
+access it only through explicit test or protocol helper boundaries.
+
+To update the operational evidence profile snapshot, replace this versioned
+directory from a tagged Ensen-protocol release and update `manifest.json` in
+the same change. Do not point tests or runtime code at a sibling checkout as a
+mutable shared dependency.
+
+Copied protocol artifacts should normally remain unchanged from the tagged
+release. If Flow must correct consumer-facing snapshot provenance without
+redefining schema, runtime, or behavior contracts, record the correction in
+`manifest.json` through a local correction entry and set the copied artifact
+policy accordingly.

--- a/protocol-snapshots/ensen-protocol/v0.3.0/docs/integration/operational-evidence-profile.md
+++ b/protocol-snapshots/ensen-protocol/v0.3.0/docs/integration/operational-evidence-profile.md
@@ -1,0 +1,118 @@
+# Operational Evidence Profile
+
+The operational evidence profile is contract guidance for Loop and Flow X-Gate
+3 Track A artifact hygiene checks before owner-controlled real input. It
+describes how evidence and audit artifacts should label publishable examples,
+local references, and producer facts without turning Ensen-protocol into a
+runtime implementation.
+
+This profile preserves the Ensen development charter: protocol over shared
+implementation, bounded execution, evidence before authority, and no premature
+compliance claims.
+
+## Track A Boundary
+
+Track A is owner-controlled repo / solo dogfood only. It is for synthetic and
+owner-controlled protocol evidence while Loop and Flow harden artifact safety
+checks.
+
+Track A non-goals are customer repo input, ERPNext live connector input,
+regulated data, electronic signature workflows, batch release workflows, final
+disposition decisions, and any compliance guarantee.
+
+Ensen-protocol defines this profile as contract text and public conformance
+examples only. It is not a runtime implementation, not artifact storage, not
+cleanup, not recovery, not a credential service, not a retention system, and
+not a compliance guarantee. Loop and Flow remain responsible for their own
+runtime behavior, artifact storage, cleanup, recovery, customer data handling,
+and operational enforcement.
+
+The short boundary rule is: not artifact storage, not cleanup, not recovery.
+
+## Profile Fields
+
+Use these terms when Loop or Flow records, exports, or tests operational
+evidence references:
+
+- `dataClassification`: required handling label for the evidence or audit
+  surface. Public fixture-safe artifacts use `public`. Local real-input
+  artifacts must use `internal`, `confidential`, or `restricted` as appropriate
+  and must not be copied into this repository as fixtures.
+- `checksum`: digest for the referenced evidence body when a stable body exists.
+  EvidenceBundleRef v1 supports `sha256` with a lowercase hexadecimal value.
+  Missing checksums are allowed only when the producing boundary explicitly
+  records why no stable body is available.
+- `producer metadata`: bounded public facts about the producer boundary, such as
+  `producer`, `producerVersion`, `protocolVersion`, `command`, `boundary`, and
+  `createdBy`. Producer metadata must not contain credentials, private repo
+  details, customer identifiers, or workstation-local absolute paths.
+- `retention hint`: advisory handling label such as `publicFixture`,
+  `localEphemeral`, `localRetained`, or `externalControlled`. A retention hint
+  is not a deletion guarantee, archive promise, legal hold, or final disposition
+  decision.
+- `confidential reference`: a local or external pointer to non-public evidence.
+  Confidential references may be recorded in Loop or Flow local artifacts, but
+  they are not public fixtures and must not be published as protocol examples.
+- `public fixture-safe artifact`: synthetic, publishable JSON or Markdown that
+  contains no raw secrets, tokens, customer data, private repository details,
+  regulated data, workstation-local absolute paths, or live credential-bearing
+  URIs.
+
+## Public Fixtures And Local References
+
+Loop and Flow should distinguish public fixture-safe artifacts from local
+confidential reference values at the boundary where evidence is emitted or
+copied:
+
+| Surface | Expected use | Publishable in Ensen-protocol |
+| --- | --- | --- |
+| Public fixture-safe artifact | Synthetic conformance row for parser, audit, or EvidenceBundleRef hygiene tests | Yes |
+| Local confidential reference | Owner-controlled real-input pointer retained in Loop or Flow local state | No |
+| Redacted summary | Public statement that a private artifact exists without exposing the value | Yes, when synthetic |
+
+Public examples should use repo-relative paths, neutral `file:///` examples, or
+placeholders such as `<evidence-root>`, `<credential-ref>`,
+`<repository-ref>`, and `<supervisor-config-path>`. They must not include raw
+workstation-local paths, real repository private details, or values that look
+like credentials.
+
+Local confidential reference values should stay in the implementation
+repository or evidence system that owns them. Protocol examples may describe
+the shape of a confidential reference with placeholders, but must not publish
+the real reference.
+
+## Evidence And Audit Mapping
+
+EvidenceBundleRef should carry the reference location, checksum when available,
+content type, and bounded producer metadata. It should not embed evidence
+bodies, test logs, screenshots, customer data, or secrets.
+
+AuditEvent should record append-only facts about evidence production,
+validation, rejection, or redaction. The audit payload may include
+`dataClassification`, `retentionHint`, redacted `referenceKind`, producer
+boundary, and checksum presence. It must not infer authorization, tenant,
+repository, account, or environment linkage from path shape or operator-facing
+summaries.
+
+Consumers must fail closed when data classification, provenance, scope,
+authorization context, or boundary signals are missing, malformed, or only
+partially trusted. A syntactically valid EvidenceBundleRef or AuditEvent is not
+proof that the referenced evidence is trusted or authorized.
+
+## Conformance Example
+
+The public conformance example lives at
+`fixtures/operational-evidence-profile/v1/valid/public-fixture-safe-profile.json`.
+It is fixture-like guidance, not a new EIP schema family.
+
+Loop and Flow may copy that example into local Track A artifact hygiene tests to
+verify that:
+
+- public examples remain `public` and synthetic;
+- checksum values use the supported `sha256` form;
+- producer metadata remains bounded and public;
+- retention hint values are advisory only;
+- confidential reference shape is represented with placeholders instead of real
+  local values;
+- public fixture-safe artifacts and local confidential references are not
+  treated as interchangeable.

--- a/protocol-snapshots/ensen-protocol/v0.3.0/fixtures/operational-evidence-profile/v1/valid/public-fixture-safe-profile.json
+++ b/protocol-snapshots/ensen-protocol/v0.3.0/fixtures/operational-evidence-profile/v1/valid/public-fixture-safe-profile.json
@@ -1,0 +1,38 @@
+{
+  "profile": "operational-evidence-profile.v1",
+  "scenario": "public-fixture-safe-artifact",
+  "track": "X-Gate 3 Track A",
+  "boundary": "owner-controlled repo / solo dogfood",
+  "evidence": {
+    "dataClassification": "public",
+    "referenceKind": "publicFixtureSafeArtifact",
+    "uri": "artifacts/evidence/synthetic-run/bundle.json",
+    "contentType": "application/json",
+    "checksum": {
+      "algorithm": "sha256",
+      "value": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    }
+  },
+  "producerMetadata": {
+    "producer": "ensen-loop",
+    "producerVersion": "example-snapshot",
+    "protocolVersion": "example-protocol-snapshot",
+    "command": "npm test",
+    "boundary": "parser"
+  },
+  "retentionHint": "publicFixture",
+  "confidentialReferencePolicy": {
+    "allowedInPublicFixture": false,
+    "placeholder": "<evidence-root>/private-run/bundle.json",
+    "guidance": "Keep local confidential reference values in the owning Loop or Flow evidence boundary."
+  },
+  "nonGoals": [
+    "external repository input",
+    "ERPNext live connector",
+    "regulated data",
+    "electronic signature",
+    "batch release",
+    "final disposition",
+    "compliance guarantee"
+  ]
+}

--- a/protocol-snapshots/ensen-protocol/v0.3.0/manifest.json
+++ b/protocol-snapshots/ensen-protocol/v0.3.0/manifest.json
@@ -1,0 +1,41 @@
+{
+  "source": {
+    "repository": "TommyKammy/Ensen-protocol",
+    "releaseTag": "v0.3.0",
+    "releaseUrl": "https://github.com/TommyKammy/Ensen-protocol/releases/tag/v0.3.0",
+    "protocolVersion": "0.3.0",
+    "tagObjectSha": "080c46471e02d666367b1a18413beb46ebbc2f5b",
+    "targetCommit": "bb7a3fe06dc09bc0675fca0de44194b2eb17dc9b"
+  },
+  "policy": {
+    "updatePolicy": "Copied snapshot. Update only by replacing this directory from a tagged Ensen-protocol release.",
+    "runtimeDependency": false,
+    "copiedArtifactsUnmodified": true
+  },
+  "includes": {
+    "profileDocs": [
+      "docs/integration/operational-evidence-profile.md"
+    ],
+    "fixtureFamilies": [
+      "operational-evidence-profile"
+    ],
+    "publicFixtureSafeExamples": [
+      "fixtures/operational-evidence-profile/v1/valid/public-fixture-safe-profile.json"
+    ]
+  },
+  "validationEvidence": {
+    "recordedFromSourceRelease": true,
+    "commands": [
+      "npm test",
+      "npm run check:fixtures",
+      "npm run check:public-fixtures",
+      "npm run check:schema-ids",
+      "npm run check:spec-boundary"
+    ]
+  },
+  "intentionalExclusions": [
+    "No Ensen-protocol runtime package, SDK, generated client, server, OpenAPI client, scripts, node_modules, tests, or implementation code is vendored into Ensen-flow.",
+    "No production evidence archive, credential source, customer data export, retention system, cleanup workflow, recovery workflow, or compliance evidence claim is introduced by this snapshot.",
+    "The v0.2.0 schema snapshot remains Flow's active EIP schema and connector-contract boundary; v0.3.0 adds only operational evidence profile docs and a public fixture-safe example."
+  ]
+}

--- a/test/docs-navigation.test.ts
+++ b/test/docs-navigation.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, it } from "vitest";
 const runbookPath = "docs/controlled-pilot-rollback-recovery-runbook.md";
 const readmePath = "README.md";
 const docsIndexPath = "docs/README.md";
+const operationalEvidenceSnapshotReadmePath =
+  "protocol-snapshots/ensen-protocol/v0.3.0/README.md";
 const posixHomeRootPattern = new RegExp(["", "Users", "[A-Za-z0-9._-]+"].join("\\/"));
 const linuxHomeRootPattern = new RegExp(["", "home", "[A-Za-z0-9._-]+"].join("\\/"));
 const windowsHomeRootPattern = new RegExp(["[A-Za-z]:", "Users", ""].join("\\\\"));
@@ -18,6 +20,31 @@ describe("documentation navigation", () => {
 
     expect(readme).toContain("docs/controlled-pilot-rollback-recovery-runbook.md");
     expect(docsIndex).toContain("controlled-pilot-rollback-recovery-runbook.md");
+  });
+
+  it("links the Protocol v0.3.0 operational evidence profile snapshot from public docs", async () => {
+    const [readme, docsIndex, snapshotReadme] = await Promise.all([
+      readFile(readmePath, "utf8"),
+      readFile(docsIndexPath, "utf8"),
+      readFile(operationalEvidenceSnapshotReadmePath, "utf8")
+    ]);
+
+    expect(readme).toContain(
+      "protocol-snapshots/ensen-protocol/v0.3.0/README.md"
+    );
+    expect(readme).toContain(
+      "protocol-snapshots/ensen-protocol/v0.3.0/docs/integration/operational-evidence-profile.md"
+    );
+    expect(docsIndex).toContain(
+      "../protocol-snapshots/ensen-protocol/v0.3.0/README.md"
+    );
+    expect(docsIndex).toContain(
+      "../protocol-snapshots/ensen-protocol/v0.3.0/docs/integration/operational-evidence-profile.md"
+    );
+    expect(snapshotReadme).toContain("release tag `v0.3.0`");
+    expect(snapshotReadme).toContain(
+      "https://github.com/TommyKammy/Ensen-protocol/releases/tag/v0.3.0"
+    );
   });
 
   it("documents controlled pilot recovery decisions without host-local paths", async () => {

--- a/test/protocol-snapshot.test.ts
+++ b/test/protocol-snapshot.test.ts
@@ -14,6 +14,21 @@ const snapshotRoot = join(
   "ensen-protocol",
   "v0.2.0"
 );
+const operationalEvidenceSnapshotRoot = join(
+  process.cwd(),
+  "protocol-snapshots",
+  "ensen-protocol",
+  "v0.3.0"
+);
+const unsafeSnapshotTextPatterns = [
+  new RegExp(["", "Users", "[A-Za-z0-9._-]+"].join("\\/")),
+  new RegExp(["", "home", "[A-Za-z0-9._-]+"].join("\\/")),
+  new RegExp(["[A-Za-z]:", "Users", ""].join("\\\\")),
+  /AKIA[0-9A-Z]{16}/,
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
+  /\b(?:password|secret|token|api[_-]?key)=\S+/i,
+  /\b(?:postgres|mysql|mongodb):\/\/[^<\s]+:[^<\s]+@/i
+];
 
 const expectedSchemas = [
   "schemas/eip.audit-event.v1.schema.json",
@@ -42,6 +57,13 @@ const fixtureFamiliesWithInvalidFixtures = expectedFixtureFamilies.filter(
 
 const readJson = async (relativePath: string): Promise<unknown> =>
   JSON.parse(await readFile(join(snapshotRoot, relativePath), "utf8")) as unknown;
+
+const readOperationalEvidenceJson = async (
+  relativePath: string
+): Promise<unknown> =>
+  JSON.parse(
+    await readFile(join(operationalEvidenceSnapshotRoot, relativePath), "utf8")
+  ) as unknown;
 
 const listJsonFixtures = async (relativePath: string): Promise<string[]> => {
   const entries = await readdir(join(snapshotRoot, relativePath), {
@@ -199,5 +221,100 @@ describe("Ensen-protocol snapshot boundary", () => {
     expect(isSupportedEipProtocolVersion("0.2.0")).toBe(true);
     expect(isSupportedEipProtocolVersion("1.0.0")).toBe(false);
     expect(isSupportedEipProtocolVersion("bad-version")).toBe(false);
+  });
+
+  it("vendors the Ensen-protocol v0.3.0 operational evidence profile snapshot", async () => {
+    await expect(
+      readOperationalEvidenceJson("manifest.json")
+    ).resolves.toEqual({
+      source: {
+        repository: "TommyKammy/Ensen-protocol",
+        releaseTag: "v0.3.0",
+        releaseUrl:
+          "https://github.com/TommyKammy/Ensen-protocol/releases/tag/v0.3.0",
+        protocolVersion: "0.3.0",
+        tagObjectSha: "080c46471e02d666367b1a18413beb46ebbc2f5b",
+        targetCommit: "bb7a3fe06dc09bc0675fca0de44194b2eb17dc9b"
+      },
+      policy: {
+        updatePolicy:
+          "Copied snapshot. Update only by replacing this directory from a tagged Ensen-protocol release.",
+        runtimeDependency: false,
+        copiedArtifactsUnmodified: true
+      },
+      includes: {
+        profileDocs: ["docs/integration/operational-evidence-profile.md"],
+        fixtureFamilies: ["operational-evidence-profile"],
+        publicFixtureSafeExamples: [
+          "fixtures/operational-evidence-profile/v1/valid/public-fixture-safe-profile.json"
+        ]
+      },
+      validationEvidence: {
+        recordedFromSourceRelease: true,
+        commands: [
+          "npm test",
+          "npm run check:fixtures",
+          "npm run check:public-fixtures",
+          "npm run check:schema-ids",
+          "npm run check:spec-boundary"
+        ]
+      },
+      intentionalExclusions: expect.arrayContaining([
+        expect.stringContaining("No Ensen-protocol runtime"),
+        expect.stringContaining("No production evidence archive"),
+        expect.stringContaining("v0.2.0 schema snapshot remains")
+      ])
+    });
+
+    const profileDoc = await readFile(
+      join(
+        operationalEvidenceSnapshotRoot,
+        "docs/integration/operational-evidence-profile.md"
+      ),
+      "utf8"
+    );
+    const publicExample = (await readOperationalEvidenceJson(
+      "fixtures/operational-evidence-profile/v1/valid/public-fixture-safe-profile.json"
+    )) as {
+      evidence?: { dataClassification?: unknown; checksum?: unknown };
+      producerMetadata?: Record<string, unknown>;
+      confidentialReferencePolicy?: { allowedInPublicFixture?: unknown };
+      retentionHint?: unknown;
+    };
+
+    expect(profileDoc).toContain("Operational Evidence Profile");
+    expect(profileDoc).toContain("not artifact storage, not cleanup, not recovery");
+    expect(publicExample.evidence?.dataClassification).toBe("public");
+    expect(publicExample.evidence?.checksum).toEqual({
+      algorithm: "sha256",
+      value: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    });
+    expect(publicExample.producerMetadata).toEqual(
+      expect.objectContaining({
+        command: "npm test",
+        boundary: "parser"
+      })
+    );
+    expect(publicExample.retentionHint).toBe("publicFixture");
+    expect(publicExample.confidentialReferencePolicy?.allowedInPublicFixture).toBe(
+      false
+    );
+
+    for (const snapshotText of [
+      await readFile(
+        join(operationalEvidenceSnapshotRoot, "README.md"),
+        "utf8"
+      ),
+      await readFile(
+        join(operationalEvidenceSnapshotRoot, "manifest.json"),
+        "utf8"
+      ),
+      profileDoc,
+      JSON.stringify(publicExample, null, 2)
+    ]) {
+      for (const unsafePattern of unsafeSnapshotTextPatterns) {
+        expect(snapshotText).not.toMatch(unsafePattern);
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary
- copy the Protocol v0.3.0 operational evidence profile doc and public fixture-safe example into Flow
- add local snapshot manifest/README provenance with release tag and release URL
- link the snapshot from Flow docs navigation and add regression coverage for discoverability and unsafe literal checks

## Verification
- npm ci
- npm test -- test/protocol-snapshot.test.ts test/docs-navigation.test.ts
- npm run build
- npm test
- node dist/index.js issue-lint 101 --config supervisor.config.coderabbit.json (from companion codex-supervisor checkout)

Closes #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Ensen-protocol v0.3.0 operational evidence profile snapshot with integration guidance
  * Updated navigation to include new protocol snapshot entry
  * Included operational evidence profile specification and public fixture reference example
  * Added snapshot manifest documenting source, validation evidence, and maintenance policy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->