### PR TITLE
FLOW-X3A-P4-002: Align audit evidence export with Protocol evidence profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,13 @@ type, step attempts, neutral audit event summaries, and any public-safe
 `eip.evidence-bundle-ref.v1` references found in step result metadata. Trigger
 context, idempotency key values, raw local state paths, raw audit paths,
 workstation-local evidence paths, secrets, customer data, production evidence
-locations, and unsupported Protocol Phase 4 evidence profile fields are not
-exported into the public-safe section. `file_uri` evidence references are
-omitted from public-safe exports until a later protocol evidence profile defines
-a deliberately public mapping; portable relative `local_path` references remain
+locations, and local confidential reference values are not exported into the
+public-safe section. The export boundary uses the copied Protocol v0.3.0
+operational evidence profile vocabulary for public data classification,
+bounded producer metadata, retention hints, checksum presence, and confidential
+reference policy facts without claiming production evidence readiness. `file_uri`
+evidence references are omitted from public-safe exports until Flow adopts a
+deliberately public mapping; portable relative `local_path` references remain
 exportable.
 
 Workflow artifact hygiene is fail-closed at the local JSONL boundary and at

--- a/src/audit-evidence-export.ts
+++ b/src/audit-evidence-export.ts
@@ -26,13 +26,14 @@ export interface AuditEvidenceExportBoundary {
   productionEvidenceReady: false;
   protocolSnapshot: {
     name: "ensen-protocol";
-    version: "0.2.0";
+    version: "0.3.0";
   };
-  protocolEvidenceProfile: "pending-protocol-phase-4";
+  protocolEvidenceProfile: "operational-evidence-profile.v1";
   notes: string[];
 }
 
 export interface AuditEvidenceExportPublicSafe {
+  profile: AuditEvidenceExportPublicSafeProfile;
   run: {
     runId: string;
     workflowId: string;
@@ -55,6 +56,24 @@ export interface AuditEvidenceExportPublicSafe {
   auditEvents: AuditEvidenceExportAuditEventSummary[];
   evidenceRefs: AuditEvidenceExportEvidenceRef[];
   diagnostics: string[];
+}
+
+export interface AuditEvidenceExportPublicSafeProfile {
+  dataClassification: "public";
+  producerMetadata: {
+    producer: "ensen-flow";
+    producerVersion: "flow.audit-evidence-export.v1";
+    protocolVersion: "0.3.0";
+    command: "export-audit-evidence";
+    boundary: "local-audit-evidence-export";
+    createdBy: "ensen-flow";
+  };
+  retentionHint: "localEphemeral";
+  confidentialReferencePolicy: {
+    allowedInPublicSafe: false;
+    localConfidentialReferenceValuesExported: false;
+    guidance: string;
+  };
 }
 
 export interface AuditEvidenceExportStepSummary {
@@ -92,6 +111,9 @@ export interface AuditEvidenceExportEvidenceRef {
     algorithm: "sha256";
     value: string;
   };
+  dataClassification: "public";
+  referenceKind: "publicSafeArtifactReference";
+  checksumPresence: "present" | "absent";
 }
 
 export interface AuditEvidenceExportLocalConfidentialReferences {
@@ -126,16 +148,34 @@ export const createAuditEvidenceExport = async (
       productionEvidenceReady: false,
       protocolSnapshot: {
         name: "ensen-protocol",
-        version: "0.2.0"
+        version: "0.3.0"
       },
-      protocolEvidenceProfile: "pending-protocol-phase-4",
+      protocolEvidenceProfile: "operational-evidence-profile.v1",
       notes: [
         "This is a deterministic local metadata export skeleton.",
         "It is not a production evidence archive, compliance bundle, or customer data export.",
-        "Protocol Phase 4 evidence profile fields are not fabricated before a protocol snapshot exists."
+        "It uses the copied Protocol v0.3.0 operational evidence profile vocabulary without claiming protocol conformance or production evidence readiness."
       ]
     },
     publicSafe: {
+      profile: {
+        dataClassification: "public",
+        producerMetadata: {
+          producer: "ensen-flow",
+          producerVersion: EXPORT_SCHEMA_VERSION,
+          protocolVersion: "0.3.0",
+          command: "export-audit-evidence",
+          boundary: "local-audit-evidence-export",
+          createdBy: "ensen-flow"
+        },
+        retentionHint: "localEphemeral",
+        confidentialReferencePolicy: {
+          allowedInPublicSafe: false,
+          localConfidentialReferenceValuesExported: false,
+          guidance:
+            "Local confidential reference values stay in localConfidentialReferences placeholders and are never emitted in publicSafe output."
+        }
+      },
       run: {
         runId: state.run.runId,
         workflowId: state.run.workflowId,
@@ -365,7 +405,10 @@ const normalizeEvidenceRef = (
     uri: value.uri,
     createdAt: value.createdAt,
     ...(typeof value.contentType === "string" ? { contentType: value.contentType } : {}),
-    ...(checksum === undefined ? {} : { checksum })
+    ...(checksum === undefined ? {} : { checksum }),
+    dataClassification: "public",
+    referenceKind: "publicSafeArtifactReference",
+    checksumPresence: checksum === undefined ? "absent" : "present"
   };
 };
 
@@ -420,7 +463,7 @@ const createUnsafeEvidenceRefDiagnostic = (ref: AuditEvidenceExportEvidenceRef):
 };
 
 const isPublicSafeFileUri = (_value: string): boolean =>
-  // Protocol Phase 4 has not defined a public evidence profile for file: URIs.
+  // Flow has not adopted a public-safe file: URI mapping for local exports.
   false;
 
 const isWindowsDriveAbsolutePath = (value: string): boolean =>

--- a/test/audit-event-writer.test.ts
+++ b/test/audit-event-writer.test.ts
@@ -107,9 +107,29 @@ describe("neutral audit event writer", () => {
       schemaVersion: "flow.audit-evidence-export.v1",
       boundary: {
         productionEvidenceReady: false,
-        protocolEvidenceProfile: "pending-protocol-phase-4"
+        protocolSnapshot: {
+          name: "ensen-protocol",
+          version: "0.3.0"
+        },
+        protocolEvidenceProfile: "operational-evidence-profile.v1"
       },
       publicSafe: {
+        profile: {
+          dataClassification: "public",
+          producerMetadata: {
+            producer: "ensen-flow",
+            producerVersion: "flow.audit-evidence-export.v1",
+            protocolVersion: "0.3.0",
+            command: "export-audit-evidence",
+            boundary: "local-audit-evidence-export",
+            createdBy: "ensen-flow"
+          },
+          retentionHint: "localEphemeral",
+          confidentialReferencePolicy: {
+            allowedInPublicSafe: false,
+            localConfidentialReferenceValuesExported: false
+          }
+        },
         run: {
           runId: "local-manual-demo-export",
           workflowId: "local-manual-demo",
@@ -130,7 +150,10 @@ describe("neutral audit event writer", () => {
             id: "evb_manual_export",
             correlationId: "corr_manual_export",
             type: "local_path",
-            uri: "artifacts/evidence/manual-export/bundle.json"
+            uri: "artifacts/evidence/manual-export/bundle.json",
+            dataClassification: "public",
+            referenceKind: "publicSafeArtifactReference",
+            checksumPresence: "absent"
           }
         ],
         auditEvents: [


### PR DESCRIPTION
## Summary
- update audit/evidence export boundary to the copied Protocol v0.3.0 operational evidence profile vocabulary
- add public-safe profile metadata and evidence-ref classification/checksum-presence facts without exposing local confidential reference values
- refresh README wording around the public-safe export boundary

## Verification
- npm ci
- npm run build
- npm test -- test/audit-event-writer.test.ts
- npm test
- node dist/index.js issue-lint 102 --config supervisor.config.coderabbit.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI `export-audit-evidence` documentation for public-safe boundary exclusions and file reference handling clarifications.

* **New Features**
  * Added Protocol v0.3.0 support with operational evidence profile.
  * Enhanced audit evidence export schema with dedicated public-safe profile structure, including producer metadata, retention hints, and confidential reference policies.
  * Extended evidence references with data classification and checksum presence tracking.

* **Tests**
  * Updated test expectations for revised audit evidence export schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->