### PR TITLE
Guard evidence profile public exports

### DIFF
--- a/src/audit-evidence-export.ts
+++ b/src/audit-evidence-export.ts
@@ -116,6 +116,16 @@ export interface AuditEvidenceExportEvidenceRef {
   checksumPresence: "present" | "absent";
 }
 
+type EvidenceDataClassification = "public" | "internal" | "confidential" | "restricted";
+
+type NormalizedEvidenceRef = Omit<
+  AuditEvidenceExportEvidenceRef,
+  "dataClassification" | "referenceKind"
+> & {
+  dataClassification: EvidenceDataClassification;
+  referenceKind: "publicSafeArtifactReference" | "localConfidentialReference";
+};
+
 export interface AuditEvidenceExportLocalConfidentialReferences {
   statePath: AuditEvidenceExportLocalReference;
   auditPath?: AuditEvidenceExportLocalReference;
@@ -381,7 +391,7 @@ const collectEvidenceRefsFromValue = (
 
 const normalizeEvidenceRef = (
   value: Record<string, unknown>
-): AuditEvidenceExportEvidenceRef | undefined => {
+): NormalizedEvidenceRef | undefined => {
   if (value.schemaVersion !== EVIDENCE_REF_SCHEMA_VERSION) {
     return undefined;
   }
@@ -397,6 +407,7 @@ const normalizeEvidenceRef = (
   }
 
   const checksum = normalizeChecksum(value.checksum);
+  const dataClassification = normalizeDataClassification(value.dataClassification);
   return {
     schemaVersion: EVIDENCE_REF_SCHEMA_VERSION,
     id: value.id,
@@ -406,10 +417,25 @@ const normalizeEvidenceRef = (
     createdAt: value.createdAt,
     ...(typeof value.contentType === "string" ? { contentType: value.contentType } : {}),
     ...(checksum === undefined ? {} : { checksum }),
-    dataClassification: "public",
-    referenceKind: "publicSafeArtifactReference",
+    dataClassification,
+    referenceKind:
+      dataClassification === "public"
+        ? "publicSafeArtifactReference"
+        : "localConfidentialReference",
     checksumPresence: checksum === undefined ? "absent" : "present"
   };
+};
+
+const normalizeDataClassification = (value: unknown): EvidenceDataClassification => {
+  if (
+    value === "internal" ||
+    value === "confidential" ||
+    value === "restricted"
+  ) {
+    return value;
+  }
+
+  return "public";
 };
 
 const normalizeChecksum = (
@@ -433,7 +459,13 @@ const normalizeChecksum = (
   };
 };
 
-const isPublicSafeEvidenceRef = (ref: AuditEvidenceExportEvidenceRef): boolean => {
+const isPublicSafeEvidenceRef = (
+  ref: NormalizedEvidenceRef
+): ref is AuditEvidenceExportEvidenceRef => {
+  if (ref.dataClassification !== "public") {
+    return false;
+  }
+
   if (classifyUnsafeWorkflowArtifactString(ref.uri) !== undefined) {
     return false;
   }
@@ -457,7 +489,11 @@ const isSafeRelativePath = (value: string): boolean => {
   );
 };
 
-const createUnsafeEvidenceRefDiagnostic = (ref: AuditEvidenceExportEvidenceRef): string => {
+const createUnsafeEvidenceRefDiagnostic = (ref: NormalizedEvidenceRef): string => {
+  if (ref.dataClassification !== "public") {
+    return "omitted an evidence reference because its data classification is not public-safe";
+  }
+
   const category = classifyUnsafeWorkflowArtifactString(ref.uri) ?? "non-public-uri";
   return `omitted an evidence reference because its URI is not public-safe (category: ${category})`;
 };

--- a/src/audit-evidence-export.ts
+++ b/src/audit-evidence-export.ts
@@ -407,7 +407,10 @@ const normalizeEvidenceRef = (
   }
 
   const checksum = normalizeChecksum(value.checksum);
-  const dataClassification = normalizeDataClassification(value.dataClassification);
+  const dataClassification = normalizeDataClassification(
+    value.dataClassification,
+    typeof value.id === "string" ? value.id : "<unknown-evidence-ref>"
+  );
   return {
     schemaVersion: EVIDENCE_REF_SCHEMA_VERSION,
     id: value.id,
@@ -426,7 +429,14 @@ const normalizeEvidenceRef = (
   };
 };
 
-const normalizeDataClassification = (value: unknown): EvidenceDataClassification => {
+const normalizeDataClassification = (
+  value: unknown,
+  evidenceRefId: string
+): EvidenceDataClassification => {
+  if (value === undefined || value === "public") {
+    return "public";
+  }
+
   if (
     value === "internal" ||
     value === "confidential" ||
@@ -435,7 +445,21 @@ const normalizeDataClassification = (value: unknown): EvidenceDataClassification
     return value;
   }
 
-  return "public";
+  throw new Error(
+    `evidence ref ${safeErrorMessage(evidenceRefId)} has unsupported dataClassification ${formatUnknownEnumValue(value)}`
+  );
+};
+
+const formatUnknownEnumValue = (value: unknown): string => {
+  if (typeof value === "string") {
+    return JSON.stringify(safeErrorMessage(value).slice(0, 64));
+  }
+
+  if (value === null) {
+    return "null";
+  }
+
+  return typeof value;
 };
 
 const normalizeChecksum = (

--- a/test/audit-event-writer.test.ts
+++ b/test/audit-event-writer.test.ts
@@ -375,6 +375,56 @@ describe("neutral audit event writer", () => {
     expect(JSON.stringify(exported.publicSafe)).not.toContain("evb_internal_export");
   });
 
+  it("rejects unknown evidence data classifications before writing an export artifact", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
+    const exportRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
+    tempRoots.push(stateRoot, exportRoot);
+    const statePath = join(stateRoot, "runs", "manual-run.jsonl");
+    const outputPath = join(exportRoot, "exports", "audit-evidence.json");
+
+    await createWorkflowRun(statePath, {
+      runId: "local-manual-demo-export",
+      workflowId: "local-manual-demo",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z",
+        context: {}
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "local-manual-demo-export",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:02.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.completed",
+      runId: "local-manual-demo-export",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:03.000Z",
+      result: {
+        evidenceBundleRef: {
+          schemaVersion: "eip.evidence-bundle-ref.v1",
+          id: "evb_unknown_classification_export",
+          correlationId: "corr_manual_export",
+          type: "local_path",
+          uri: "artifacts/evidence/public/bundle.json",
+          createdAt: "2026-04-29T00:00:03.000Z",
+          dataClassification: "partner-private"
+        }
+      }
+    });
+
+    await expect(createAuditEvidenceExport({ statePath, outputPath })).rejects.toThrow(
+      'evidence ref evb_unknown_classification_export has unsupported dataClassification "partner-private"'
+    );
+    await expect(readFile(outputPath, "utf8")).rejects.toThrow();
+  });
+
   it("rejects extra export-audit-evidence CLI arguments", async () => {
     const originalError = console.error;
     const errors: string[] = [];

--- a/test/audit-event-writer.test.ts
+++ b/test/audit-event-writer.test.ts
@@ -324,6 +324,57 @@ describe("neutral audit event writer", () => {
     expect(serialized).not.toContain(posixHostFileUri);
   });
 
+  it("omits non-public evidence classifications instead of relabeling them as public-safe", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
+    tempRoots.push(stateRoot);
+    const statePath = join(stateRoot, "runs", "manual-run.jsonl");
+
+    await createWorkflowRun(statePath, {
+      runId: "local-manual-demo-export",
+      workflowId: "local-manual-demo",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z",
+        context: {}
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "local-manual-demo-export",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:02.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.completed",
+      runId: "local-manual-demo-export",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:03.000Z",
+      result: {
+        evidenceBundleRef: {
+          schemaVersion: "eip.evidence-bundle-ref.v1",
+          id: "evb_internal_export",
+          correlationId: "corr_manual_export",
+          type: "local_path",
+          uri: "artifacts/evidence/internal/bundle.json",
+          createdAt: "2026-04-29T00:00:03.000Z",
+          dataClassification: "restricted"
+        }
+      }
+    });
+
+    const exported = await createAuditEvidenceExport({ statePath });
+
+    expect(exported.publicSafe.evidenceRefs).toEqual([]);
+    expect(exported.publicSafe.diagnostics).toEqual([
+      "omitted an evidence reference because its data classification is not public-safe"
+    ]);
+    expect(JSON.stringify(exported.publicSafe)).not.toContain("evb_internal_export");
+  });
+
   it("rejects extra export-audit-evidence CLI arguments", async () => {
     const originalError = console.error;
     const errors: string[] = [];

--- a/test/protocol-snapshot.test.ts
+++ b/test/protocol-snapshot.test.ts
@@ -21,13 +21,56 @@ const operationalEvidenceSnapshotRoot = join(
   "v0.3.0"
 );
 const unsafeSnapshotTextPatterns = [
-  new RegExp(["", "Users", "[A-Za-z0-9._-]+"].join("\\/")),
-  new RegExp(["", "home", "[A-Za-z0-9._-]+"].join("\\/")),
-  new RegExp(["[A-Za-z]:", "Users", ""].join("\\\\")),
-  /AKIA[0-9A-Z]{16}/,
-  /-----BEGIN [A-Z ]*PRIVATE KEY-----/,
-  /\b(?:password|secret|token|api[_-]?key)=\S+/i,
-  /\b(?:postgres|mysql|mongodb):\/\/[^<\s]+:[^<\s]+@/i
+  {
+    name: "posix user-home path",
+    pattern: new RegExp(["", "Users", "[A-Za-z0-9._-]+"].join("\\/"))
+  },
+  {
+    name: "linux user-home path",
+    pattern: new RegExp(["", "home", "[A-Za-z0-9._-]+"].join("\\/"))
+  },
+  {
+    name: "windows user-home path",
+    pattern: new RegExp(["[A-Za-z]:", "Users", ""].join("\\\\"))
+  },
+  {
+    name: "unsafe local file URI",
+    pattern: new RegExp(
+      [
+        "file:",
+        "",
+        "",
+        "(?:Users|home|private|tmp|var|opt|etc|srv|mnt|root|Volumes|usr|[A-Za-z]:)"
+      ].join("\\/")
+    )
+  },
+  { name: "network file URI", pattern: /file:\/\/[^/<>\s]+\/[^<>\s]+/i },
+  { name: "AWS access key", pattern: /AKIA[0-9A-Z]{16}/ },
+  { name: "private key block", pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----/ },
+  {
+    name: "raw secret assignment",
+    pattern: /\b(?:password|passwd|secret|api[_-]?key|access[_-]?key)=\S+/i
+  },
+  {
+    name: "raw token assignment",
+    pattern: /\btoken=\S+/i
+  },
+  {
+    name: "token-shaped value",
+    pattern: /\b(?:ghp|github_pat|glpat|xox[abprs]|sk)[-_][A-Za-z0-9_-]{8,}\b/i
+  },
+  {
+    name: "session cookie",
+    pattern: /\b(?:cookie|set-cookie)\s*:\s*[^;\n]*(?:session|sid)=|\b(?:sessionid|session_id|sid)=/i
+  },
+  {
+    name: "customer data literal",
+    pattern: /\b(?:customer(?:Id|Name|Email)|accountNumber|ssn)\s*[:=]\s*["']?[^"',\s]+/i
+  },
+  {
+    name: "credential-bearing database URI",
+    pattern: /\b(?:postgres|mysql|mongodb):\/\/[^<\s]+:[^<\s]+@/i
+  }
 ];
 
 const expectedSchemas = [
@@ -312,8 +355,10 @@ describe("Ensen-protocol snapshot boundary", () => {
       profileDoc,
       JSON.stringify(publicExample, null, 2)
     ]) {
-      for (const unsafePattern of unsafeSnapshotTextPatterns) {
-        expect(snapshotText).not.toMatch(unsafePattern);
+      for (const { name, pattern } of unsafeSnapshotTextPatterns) {
+        expect(snapshotText, `snapshot text must not contain ${name}`).not.toMatch(
+          pattern
+        );
       }
     }
   });


### PR DESCRIPTION
## Summary
- omit non-public evidence classifications from public-safe audit/evidence exports instead of relabeling them as public
- add a focused regression for restricted evidence refs with sanitized diagnostics
- expand Protocol v0.3.0 snapshot hygiene checks across explicit unsafe categories

## Verification
- npm run build
- npm test -- test/protocol-snapshot.test.ts test/audit-event-writer.test.ts test/docs-navigation.test.ts
- npm test
- node dist/index.js issue-lint 103 --config supervisor.config.coderabbit.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evidence reference normalization and classification so only public‑safe references are included in exports; non‑public references are filtered with clear diagnostics.
* **Tests**
  * Added a test asserting restricted evidence refs are omitted and a diagnostic is emitted.
  * Expanded snapshot safety checks with named patterns covering more unsafe content types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->