### PR TITLE
FLOW-X3B-002 require workflow artifact classifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,10 @@ operational evidence and Track B classification vocabulary for public data
 classification, bounded producer metadata, retention hints, checksum presence,
 and confidential reference policy facts without claiming production evidence
 readiness or regulated workflow execution. Track B evidence references must
-carry an explicit `dataClassification`; missing or unknown values fail closed
-before an export artifact is written. `file_uri` evidence references are omitted
-from public-safe exports until Flow adopts a deliberately public mapping;
+carry an explicit `dataClassification` before entering public-safe output;
+missing values are omitted as unclassified references, and unknown values fail
+closed before an export artifact is written. `file_uri` evidence references are
+omitted from public-safe exports until Flow adopts a deliberately public mapping;
 portable relative `local_path` references remain exportable only when they are
 explicitly classified as `public`. Internal, customer-confidential, regulated,
 confidential, and restricted evidence references stay out of the public-safe

--- a/README.md
+++ b/README.md
@@ -156,11 +156,14 @@ public-safe section. The export boundary uses the copied Protocol v0.4.0
 operational evidence and Track B classification vocabulary for public data
 classification, bounded producer metadata, retention hints, checksum presence,
 and confidential reference policy facts without claiming production evidence
-readiness or regulated workflow execution. `file_uri` evidence references are
-omitted from public-safe exports until Flow adopts a deliberately public
-mapping; portable relative `local_path` references remain exportable. Internal,
-customer-confidential, regulated, confidential, and restricted evidence
-references stay out of the public-safe export surface.
+readiness or regulated workflow execution. Track B evidence references must
+carry an explicit `dataClassification`; missing or unknown values fail closed
+before an export artifact is written. `file_uri` evidence references are omitted
+from public-safe exports until Flow adopts a deliberately public mapping;
+portable relative `local_path` references remain exportable only when they are
+explicitly classified as `public`. Internal, customer-confidential, regulated,
+confidential, and restricted evidence references stay out of the public-safe
+export surface.
 
 Workflow artifact hygiene is fail-closed at the local JSONL boundary and at
 public export boundaries. Raw secrets, token-shaped strings, private key blocks,

--- a/src/audit-evidence-export.ts
+++ b/src/audit-evidence-export.ts
@@ -128,7 +128,7 @@ type NormalizedEvidenceRef = Omit<
   AuditEvidenceExportEvidenceRef,
   "dataClassification" | "referenceKind"
 > & {
-  dataClassification: EvidenceDataClassification;
+  dataClassification: EvidenceDataClassification | undefined;
   referenceKind: "publicSafeArtifactReference" | "localConfidentialReference";
 };
 
@@ -438,11 +438,9 @@ const normalizeEvidenceRef = (
 const normalizeDataClassification = (
   value: unknown,
   evidenceRefId: string
-): EvidenceDataClassification => {
+): EvidenceDataClassification | undefined => {
   if (value === undefined) {
-    throw new Error(
-      `evidence ref ${safeErrorMessage(evidenceRefId)} is missing required dataClassification`
-    );
+    return undefined;
   }
 
   if (value === "public") {
@@ -528,6 +526,10 @@ const isSafeRelativePath = (value: string): boolean => {
 };
 
 const createUnsafeEvidenceRefDiagnostic = (ref: NormalizedEvidenceRef): string => {
+  if (ref.dataClassification === undefined) {
+    return "omitted an evidence reference because its data classification is missing";
+  }
+
   if (ref.dataClassification !== "public") {
     return "omitted an evidence reference because its data classification is not public-safe";
   }

--- a/src/audit-evidence-export.ts
+++ b/src/audit-evidence-export.ts
@@ -439,7 +439,13 @@ const normalizeDataClassification = (
   value: unknown,
   evidenceRefId: string
 ): EvidenceDataClassification => {
-  if (value === undefined || value === "public") {
+  if (value === undefined) {
+    throw new Error(
+      `evidence ref ${safeErrorMessage(evidenceRefId)} is missing required dataClassification`
+    );
+  }
+
+  if (value === "public") {
     return "public";
   }
 

--- a/src/ensen-loop-eip-executor-connector.ts
+++ b/src/ensen-loop-eip-executor-connector.ts
@@ -1794,6 +1794,8 @@ const isDataClassification = (value: unknown): boolean =>
   value === "public" ||
   value === "internal" ||
   value === "confidential" ||
+  value === "customer-confidential" ||
+  value === "regulated" ||
   value === "restricted";
 
 const validateSourceRef = (

--- a/test/audit-event-writer.test.ts
+++ b/test/audit-event-writer.test.ts
@@ -456,7 +456,7 @@ describe("neutral audit event writer", () => {
     await expect(readFile(outputPath, "utf8")).rejects.toThrow();
   });
 
-  it("rejects missing evidence data classifications before writing an export artifact", async () => {
+  it("omits missing evidence data classifications from public-safe exports", async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
     const exportRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
     tempRoots.push(stateRoot, exportRoot);
@@ -499,10 +499,18 @@ describe("neutral audit event writer", () => {
       }
     });
 
-    await expect(createAuditEvidenceExport({ statePath, outputPath })).rejects.toThrow(
-      "evidence ref evb_missing_classification_export is missing required dataClassification"
+    const exported = await createAuditEvidenceExport({ statePath, outputPath });
+
+    expect(exported.publicSafe.evidenceRefs).toEqual([]);
+    expect(exported.publicSafe.diagnostics).toEqual([
+      "omitted an evidence reference because its data classification is missing"
+    ]);
+    expect(JSON.stringify(exported.publicSafe)).not.toContain(
+      "evb_missing_classification_export"
     );
-    await expect(readFile(outputPath, "utf8")).rejects.toThrow();
+    await expect(readFile(outputPath, "utf8")).resolves.toContain(
+      "omitted an evidence reference because its data classification is missing"
+    );
   });
 
   it("rejects extra export-audit-evidence CLI arguments", async () => {

--- a/test/audit-event-writer.test.ts
+++ b/test/audit-event-writer.test.ts
@@ -78,7 +78,8 @@ describe("neutral audit event writer", () => {
           correlationId: "corr_manual_export",
           type: "local_path",
           uri: "artifacts/evidence/manual-export/bundle.json",
-          createdAt: "2026-04-29T00:00:03.000Z"
+          createdAt: "2026-04-29T00:00:03.000Z",
+          dataClassification: "public"
         }
       }
     });
@@ -279,7 +280,8 @@ describe("neutral audit event writer", () => {
             correlationId: "corr_manual_export",
             type: "local_path",
             uri: "artifacts/evidence/public/bundle.json",
-            createdAt: "2026-04-29T00:00:02.000Z"
+            createdAt: "2026-04-29T00:00:02.000Z",
+            dataClassification: "public"
           },
           {
             schemaVersion: "eip.evidence-bundle-ref.v1",
@@ -287,7 +289,8 @@ describe("neutral audit event writer", () => {
             correlationId: "corr_manual_export",
             type: "local_path",
             uri: windowsNetworkPath,
-            createdAt: "2026-04-29T00:00:02.000Z"
+            createdAt: "2026-04-29T00:00:02.000Z",
+            dataClassification: "public"
           },
           {
             schemaVersion: "eip.evidence-bundle-ref.v1",
@@ -295,7 +298,8 @@ describe("neutral audit event writer", () => {
             correlationId: "corr_manual_export",
             type: "file_uri",
             uri: "file://server/share/bundle.json",
-            createdAt: "2026-04-29T00:00:02.000Z"
+            createdAt: "2026-04-29T00:00:02.000Z",
+            dataClassification: "public"
           },
           {
             schemaVersion: "eip.evidence-bundle-ref.v1",
@@ -303,7 +307,8 @@ describe("neutral audit event writer", () => {
             correlationId: "corr_manual_export",
             type: "file_uri",
             uri: posixHostFileUri,
-            createdAt: "2026-04-29T00:00:02.000Z"
+            createdAt: "2026-04-29T00:00:02.000Z",
+            dataClassification: "public"
           }
         ]
       }
@@ -447,6 +452,55 @@ describe("neutral audit event writer", () => {
 
     await expect(createAuditEvidenceExport({ statePath, outputPath })).rejects.toThrow(
       'evidence ref evb_unknown_classification_export has unsupported dataClassification "partner-private"'
+    );
+    await expect(readFile(outputPath, "utf8")).rejects.toThrow();
+  });
+
+  it("rejects missing evidence data classifications before writing an export artifact", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
+    const exportRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
+    tempRoots.push(stateRoot, exportRoot);
+    const statePath = join(stateRoot, "runs", "manual-run.jsonl");
+    const outputPath = join(exportRoot, "exports", "audit-evidence.json");
+
+    await createWorkflowRun(statePath, {
+      runId: "local-manual-demo-export",
+      workflowId: "local-manual-demo",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z",
+        context: {}
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "local-manual-demo-export",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:02.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.completed",
+      runId: "local-manual-demo-export",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:03.000Z",
+      result: {
+        evidenceBundleRef: {
+          schemaVersion: "eip.evidence-bundle-ref.v1",
+          id: "evb_missing_classification_export",
+          correlationId: "corr_manual_export",
+          type: "local_path",
+          uri: "artifacts/evidence/public/bundle.json",
+          createdAt: "2026-04-29T00:00:03.000Z"
+        }
+      }
+    });
+
+    await expect(createAuditEvidenceExport({ statePath, outputPath })).rejects.toThrow(
+      "evidence ref evb_missing_classification_export is missing required dataClassification"
     );
     await expect(readFile(outputPath, "utf8")).rejects.toThrow();
   });

--- a/test/executor-connector.test.ts
+++ b/test/executor-connector.test.ts
@@ -714,6 +714,54 @@ describe("Ensen-loop EIP executor connector", () => {
     });
   });
 
+  it("accepts Protocol v0.4.0 Track B data classifications in EIP RunRequest payloads", async () => {
+    const submittedPayloads: unknown[] = [];
+    const connector = createEnsenLoopEipExecutorConnector({
+      transport: {
+        submitRunRequest(payload) {
+          submittedPayloads.push(payload);
+          return { requestId: payload.id };
+        },
+        getRunStatusSnapshot() {
+          throw new Error("status should not be requested");
+        },
+        getRunResult() {
+          throw new Error("result should not be requested");
+        },
+        getEvidenceBundleRef() {
+          throw new Error("evidence should not be requested");
+        }
+      },
+      now: () => "2026-04-30T04:00:00.000Z"
+    });
+
+    await expect(
+      connector.submit({
+        ...submitRequest,
+        run: { id: "loop-eip-customer-confidential-run" },
+        dataClassification: "customer-confidential"
+      })
+    ).resolves.toMatchObject({
+      ok: true,
+      value: { requestId: "req_loop_eip_customer_confidential_run_loop_executor_step_1" }
+    });
+    await expect(
+      connector.submit({
+        ...submitRequest,
+        run: { id: "loop-eip-regulated-run" },
+        dataClassification: "regulated"
+      })
+    ).resolves.toMatchObject({
+      ok: true,
+      value: { requestId: "req_loop_eip_regulated_run_loop_executor_step_1" }
+    });
+
+    expect(submittedPayloads).toMatchObject([
+      { dataClassification: "customer-confidential" },
+      { dataClassification: "regulated" }
+    ]);
+  });
+
   it("drives a workflow step through fake Ensen-loop EIP transport and persists the resulting run state", async () => {
     const transport = createFakeEnsenLoopEipExecutorTransport({
       completedAt: "2026-04-30T04:00:03.000Z",


### PR DESCRIPTION
## Summary
- require explicit Track B dataClassification before audit/evidence export writes public-safe evidence refs
- keep confidential and regulated evidence refs out of public-safe export output
- accept Protocol v0.4.0 customer-confidential and regulated values in EIP RunRequest projection

## Verification
- npm ci
- npm run build
- npm test -- test/audit-event-writer.test.ts
- npm test -- test/executor-connector.test.ts
- npm test

Closes #111