### PR TITLE
FLOW-X3B-003: Add artifact storage guards

### DIFF
--- a/src/audit-event-writer.ts
+++ b/src/audit-event-writer.ts
@@ -2,6 +2,10 @@ import { mkdir, open } from "node:fs/promises";
 import { dirname } from "node:path";
 
 import type { WorkflowRunTerminalState } from "./workflow-run-state.js";
+import {
+  findUnsafeWorkflowArtifactValue,
+  formatUnsafeWorkflowArtifactDiagnostic
+} from "./workflow-artifact-hygiene.js";
 
 export type NeutralAuditEventType =
   | "workflow.started"
@@ -194,6 +198,7 @@ const validateNeutralAuditEvent = (event: NeutralAuditEvent): void => {
 
   if (event.retry !== undefined) {
     requireNonEmptyString(event.retry.reason, "audit event retry.reason");
+    rejectUnsafeAuditArtifactValues(event.retry.reason, "audit event retry.reason");
     if (event.retry.nextAttemptAt !== undefined) {
       requireIsoTimestamp(event.retry.nextAttemptAt, "audit event retry.nextAttemptAt");
     }
@@ -207,6 +212,14 @@ const validateNeutralAuditEvent = (event: NeutralAuditEvent): void => {
 
   if (event.outcome?.reason !== undefined) {
     requireNonEmptyString(event.outcome.reason, "audit event outcome.reason");
+    rejectUnsafeAuditArtifactValues(event.outcome.reason, "audit event outcome.reason");
+  }
+};
+
+const rejectUnsafeAuditArtifactValues = (value: unknown, path: string): void => {
+  const finding = findUnsafeWorkflowArtifactValue(value, path);
+  if (finding !== undefined) {
+    throw new Error(formatUnsafeWorkflowArtifactDiagnostic(finding));
   }
 };
 

--- a/src/file-connector.ts
+++ b/src/file-connector.ts
@@ -17,6 +17,10 @@ import type {
   ConnectorResult,
   ConnectorSubmitRequest
 } from "./connector.js";
+import {
+  findUnsafeWorkflowArtifactValue,
+  formatUnsafeWorkflowArtifactDiagnostic
+} from "./workflow-artifact-hygiene.js";
 
 export type LocalFileAction = "read" | "write";
 
@@ -287,6 +291,18 @@ const createLocalFileReceipt = async (input: {
   if (!outcome.ok) {
     throw new LocalFileExecutionError(outcome.message, outcome.retryable);
   }
+  if (outcome.content !== undefined) {
+    const unsafeOutput = findUnsafeWorkflowArtifactValue(
+      outcome.content,
+      "local file output"
+    );
+    if (unsafeOutput !== undefined) {
+      throw new LocalFileExecutionError(
+        formatUnsafeWorkflowArtifactDiagnostic(unsafeOutput),
+        false
+      );
+    }
+  }
 
   const requestId = `${input.connectorId}-${input.request.runId}-${input.request.stepId}`;
   const acceptedAt = input.now();
@@ -398,6 +414,16 @@ const validateSubmitRequest = (request: LocalFileSubmitRequest): string | undefi
 
   if (request.file.action === "read" && request.file.content !== undefined) {
     return "local file read request must not include content";
+  }
+
+  if (request.file.content !== undefined) {
+    const unsafeContent = findUnsafeWorkflowArtifactValue(
+      request.file.content,
+      "local file content"
+    );
+    if (unsafeContent !== undefined) {
+      return formatUnsafeWorkflowArtifactDiagnostic(unsafeContent);
+    }
   }
 
   return undefined;

--- a/src/file-connector.ts
+++ b/src/file-connector.ts
@@ -227,6 +227,10 @@ export const createLocalFileConnector = (
           })
         });
       } catch (error) {
+        if (isLocalFileInvalidRequestError(error)) {
+          return invalidRequest(connectorId, error.message);
+        }
+
         if (!isLocalFileExecutionError(error)) {
           throw error;
         }
@@ -287,6 +291,11 @@ const createLocalFileReceipt = async (input: {
   request: LocalFileSubmitRequest;
   resolved: ResolvedLocalFileRequest;
 }): Promise<LocalFileReceipt> => {
+  const unsafeContent = validateLocalFileContent(input.request);
+  if (unsafeContent !== undefined) {
+    throw new LocalFileInvalidRequestError(unsafeContent);
+  }
+
   const outcome = await executeFileRequest(input.resolved);
   if (!outcome.ok) {
     throw new LocalFileExecutionError(outcome.message, outcome.retryable);
@@ -416,17 +425,21 @@ const validateSubmitRequest = (request: LocalFileSubmitRequest): string | undefi
     return "local file read request must not include content";
   }
 
-  if (request.file.content !== undefined) {
-    const unsafeContent = findUnsafeWorkflowArtifactValue(
-      request.file.content,
-      "local file content"
-    );
-    if (unsafeContent !== undefined) {
-      return formatUnsafeWorkflowArtifactDiagnostic(unsafeContent);
-    }
+  return undefined;
+};
+
+const validateLocalFileContent = (request: LocalFileSubmitRequest): string | undefined => {
+  if (request.file.content === undefined) {
+    return undefined;
   }
 
-  return undefined;
+  const unsafeContent = findUnsafeWorkflowArtifactValue(
+    request.file.content,
+    "local file content"
+  );
+  return unsafeContent === undefined
+    ? undefined
+    : formatUnsafeWorkflowArtifactDiagnostic(unsafeContent);
 };
 
 const resolveLocalFileRequest = async (
@@ -581,6 +594,16 @@ class LocalFileExecutionError extends Error {
 
 const isLocalFileExecutionError = (error: unknown): error is LocalFileExecutionError =>
   error instanceof LocalFileExecutionError;
+
+class LocalFileInvalidRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LocalFileInvalidRequestError";
+  }
+}
+
+const isLocalFileInvalidRequestError = (error: unknown): error is LocalFileInvalidRequestError =>
+  error instanceof LocalFileInvalidRequestError;
 
 const fingerprintFileRequest = (
   request: LocalFileSubmitRequest,

--- a/src/webhook-intake.ts
+++ b/src/webhook-intake.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { join } from "node:path";
 
 import type { WorkflowRunState } from "./workflow-run-state.js";
+import { readWorkflowRunState } from "./workflow-run-state.js";
 import { validateWorkflowDefinition } from "./workflow-definition.js";
 import type { WorkflowDefinition } from "./workflow-definition.js";
 import { runWorkflow } from "./workflow-runner.js";
@@ -91,6 +92,14 @@ export const consumeWebhookInput = async (
   const statePath = join(options.stateRoot, `${runId}.jsonl`);
   const inputFingerprint = createWebhookInputFingerprint(normalizedInput);
 
+  const existingState = await readExistingWebhookRunState(statePath);
+  if (existingState !== undefined) {
+    assertWebhookInputMatchesState(existingState, inputFingerprint);
+  } else {
+    rejectCredentialShapedKeys(normalizedInput.payload, "webhook input payload");
+    rejectUnsafeWebhookArtifactValues(normalizedInput.payload, "webhook input payload");
+  }
+
   return runWorkflow({
     definition,
     statePath,
@@ -106,6 +115,7 @@ export const consumeWebhookInput = async (
         payload: normalizedInput.payload
       }
     },
+    existingRunStateArtifactHygiene: "skip",
     existingRunStateGuard: (existingState) =>
       assertWebhookInputMatchesState(existingState, inputFingerprint),
     now: options.now,
@@ -179,8 +189,6 @@ const normalizeWebhookInput = (value: unknown, expectedPath: string): WebhookInp
     throw new WebhookIntakeRejectedError("webhook input payload must be an object");
   }
   validateBoundedJson(value.payload, "webhook input payload", 0);
-  rejectCredentialShapedKeys(value.payload, "webhook input payload");
-  rejectUnsafeWebhookArtifactValues(value.payload, "webhook input payload");
 
   return {
     schemaVersion: WEBHOOK_INPUT_SCHEMA_VERSION,
@@ -314,6 +322,20 @@ const rejectUnsafeWebhookArtifactValues = (value: unknown, path: string): void =
   }
 };
 
+const readExistingWebhookRunState = async (
+  statePath: string
+): Promise<WorkflowRunState | undefined> => {
+  try {
+    return await readWorkflowRunState(statePath, { artifactHygiene: "skip" });
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+
+    throw error;
+  }
+};
+
 const assertWebhookInputMatchesState = (
   existingState: WorkflowRunState,
   inputFingerprint: string
@@ -439,3 +461,6 @@ const isStrictUtcMillisTimestamp = (value: string): boolean => {
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isNodeError = (error: unknown): error is NodeJS.ErrnoException =>
+  error instanceof Error && "code" in error;

--- a/src/webhook-intake.ts
+++ b/src/webhook-intake.ts
@@ -6,6 +6,10 @@ import { validateWorkflowDefinition } from "./workflow-definition.js";
 import type { WorkflowDefinition } from "./workflow-definition.js";
 import { runWorkflow } from "./workflow-runner.js";
 import type { WorkflowStepHandler } from "./workflow-runner.js";
+import {
+  findUnsafeWorkflowArtifactValue,
+  formatUnsafeWorkflowArtifactDiagnostic
+} from "./workflow-artifact-hygiene.js";
 
 const WEBHOOK_INPUT_SCHEMA_VERSION = "flow.webhook.input.v1";
 const MAX_HEADER_COUNT = 20;
@@ -176,6 +180,7 @@ const normalizeWebhookInput = (value: unknown, expectedPath: string): WebhookInp
   }
   validateBoundedJson(value.payload, "webhook input payload", 0);
   rejectCredentialShapedKeys(value.payload, "webhook input payload");
+  rejectUnsafeWebhookArtifactValues(value.payload, "webhook input payload");
 
   return {
     schemaVersion: WEBHOOK_INPUT_SCHEMA_VERSION,
@@ -300,6 +305,13 @@ const rejectCredentialShapedValue = (value: unknown, path: string): void => {
 
 const rejectCredentialShapedKeys = (value: Record<string, unknown>, path: string): void => {
   rejectCredentialShapedValue(value, path);
+};
+
+const rejectUnsafeWebhookArtifactValues = (value: unknown, path: string): void => {
+  const finding = findUnsafeWorkflowArtifactValue(value, path);
+  if (finding !== undefined) {
+    throw new WebhookIntakeRejectedError(formatUnsafeWorkflowArtifactDiagnostic(finding));
+  }
 };
 
 const assertWebhookInputMatchesState = (

--- a/src/workflow-artifact-hygiene.ts
+++ b/src/workflow-artifact-hygiene.ts
@@ -164,7 +164,17 @@ const isEmptyPublicPlaceholder = (value: unknown): boolean =>
   value === undefined ||
   value === null ||
   value === "" ||
-  (Array.isArray(value) && value.length === 0);
+  (Array.isArray(value) && value.length === 0) ||
+  isEmptyPlainObject(value);
+
+const isEmptyPlainObject = (value: unknown): boolean => {
+  if (!isRecord(value) || Object.keys(value).length !== 0) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+};
 
 export const formatUnsafeWorkflowArtifactDiagnostic = (
   finding: UnsafeWorkflowArtifactFinding

--- a/src/workflow-artifact-hygiene.ts
+++ b/src/workflow-artifact-hygiene.ts
@@ -27,23 +27,11 @@ const CUSTOMER_IDENTIFIER_ASSIGNMENT_PATTERN =
   /(?:^|\b)(?:customer[_ -]?id|customer[_ -]?name|customer[_ -]?email|account[_ -]?number)\s*["']?\s*[:=]/iu;
 const WORKSTATION_LOCAL_PATH_PATTERN =
   /(?:^|["'\s])(?:\/(?:Users|home|var|tmp|opt|etc|srv|mnt|root|Volumes|usr)\/[^/\\\s]+|[A-Za-z]:[\\/][^/\\\s]+|file:\/\/\/(?:[A-Za-z]:\/|(?:Users|home|var|tmp|opt|etc|srv|mnt|root|Volumes|usr)\/)[^/\\\s]+)/u;
-const CREDENTIAL_FIELD_KEYS = new Set([
-  "authorization",
-  "proxyauthorization",
+const SESSION_COOKIE_FIELD_KEYS = new Set([
   "cookie",
   "setcookie",
-  "password",
-  "passwd",
-  "secret",
-  "clientsecret",
-  "apikey",
-  "accesskey",
-  "privatekey",
-  "token",
   "sessioncookie",
-  "sessionid",
-  "credential",
-  "credentials"
+  "sessionid"
 ]);
 const REGULATED_FIELD_KEYS = new Set([
   "ssn",
@@ -166,12 +154,6 @@ const classifyUnsafeWorkflowArtifactKey = (
     return tokenBearingCategory;
   }
 
-  if (CREDENTIAL_FIELD_KEYS.has(normalized)) {
-    return normalized === "cookie" || normalized === "setcookie" || normalized === "sessioncookie"
-      ? "session-cookie"
-      : "credential";
-  }
-
   const credentialBearingCategory = classifyCredentialBearingArtifactKey(normalized);
   if (credentialBearingCategory !== undefined) {
     return credentialBearingCategory;
@@ -206,6 +188,10 @@ const classifyTokenBearingArtifactKey = (
 const classifyCredentialBearingArtifactKey = (
   normalizedKey: string
 ): UnsafeWorkflowArtifactCategory | undefined => {
+  if (SESSION_COOKIE_FIELD_KEYS.has(normalizedKey)) {
+    return "session-cookie";
+  }
+
   if (!CREDENTIAL_BEARING_FIELD_KEY_MARKERS.some((marker) => normalizedKey.includes(marker))) {
     return undefined;
   }

--- a/src/workflow-artifact-hygiene.ts
+++ b/src/workflow-artifact-hygiene.ts
@@ -65,6 +65,14 @@ export const findUnsafeWorkflowArtifactValue = (
   path: string
 ): UnsafeWorkflowArtifactFinding | undefined => {
   if (typeof value === "string") {
+    const parsed = parseJsonFormattedContainer(value);
+    if (parsed !== undefined) {
+      const nested = findUnsafeWorkflowArtifactValue(parsed, path);
+      if (nested !== undefined) {
+        return nested;
+      }
+    }
+
     const category = classifyUnsafeWorkflowArtifactString(value);
     return category === undefined ? undefined : { path, category };
   }
@@ -146,6 +154,12 @@ const classifyUnsafeWorkflowArtifactKey = (
       : "credential";
   }
 
+  if (isCredentialBearingKey(normalized)) {
+    return normalized.includes("cookie") || normalized.includes("session")
+      ? "session-cookie"
+      : "credential";
+  }
+
   if (REGULATED_FIELD_KEYS.has(normalized)) {
     return "regulated-content";
   }
@@ -159,6 +173,35 @@ const classifyUnsafeWorkflowArtifactKey = (
 
 const normalizeArtifactKey = (key: string): string =>
   key.replaceAll(/[^A-Za-z0-9]/gu, "").toLowerCase();
+
+const isCredentialBearingKey = (normalizedKey: string): boolean =>
+  [
+    "authorization",
+    "password",
+    "passwd",
+    "secret",
+    "apikey",
+    "accesskey",
+    "privatekey",
+    "credential",
+    "token",
+    "sessioncookie",
+    "sessionid"
+  ].some((token) => normalizedKey.includes(token));
+
+const parseJsonFormattedContainer = (value: string): unknown[] | Record<string, unknown> | undefined => {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    return Array.isArray(parsed) || isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+};
 
 const isEmptyPublicPlaceholder = (value: unknown): boolean =>
   value === undefined ||

--- a/src/workflow-artifact-hygiene.ts
+++ b/src/workflow-artifact-hygiene.ts
@@ -1,8 +1,11 @@
 export type UnsafeWorkflowArtifactCategory =
   | "secret"
+  | "credential"
   | "token"
   | "private-key"
   | "session-cookie"
+  | "regulated-content"
+  | "customer-identifier"
   | "workstation-local-path";
 
 export interface UnsafeWorkflowArtifactFinding {
@@ -18,8 +21,44 @@ const SECRET_ASSIGNMENT_PATTERN =
 const TOKEN_ASSIGNMENT_PATTERN = /(?:^|\b)token\s*[:=]/iu;
 const SESSION_COOKIE_PATTERN =
   /(?:^|\b)(?:cookie|set-cookie)\s*:\s*[^;\n]*(?:session|sid)=|(?:^|\b)(?:sessionid|session_id|sid)\s*=/iu;
+const REGULATED_CONTENT_ASSIGNMENT_PATTERN =
+  /(?:^|\b)(?:ssn|social[_ -]?security[_ -]?number|patient[_ -]?id|patient[_ -]?name|medical[_ -]?record[_ -]?number|mrn)\s*[:=]/iu;
+const CUSTOMER_IDENTIFIER_ASSIGNMENT_PATTERN =
+  /(?:^|\b)(?:customer[_ -]?id|customer[_ -]?name|customer[_ -]?email|account[_ -]?number)\s*[:=]/iu;
 const WORKSTATION_LOCAL_PATH_PATTERN =
   /(?:^|["'\s])(?:\/(?:Users|home|var|tmp|opt|etc|srv|mnt|root|Volumes|usr)\/[^/\\\s]+|[A-Za-z]:[\\/][^/\\\s]+|file:\/\/\/(?:[A-Za-z]:\/|(?:Users|home|var|tmp|opt|etc|srv|mnt|root|Volumes|usr)\/)[^/\\\s]+)/u;
+const CREDENTIAL_FIELD_KEYS = new Set([
+  "authorization",
+  "proxyauthorization",
+  "cookie",
+  "setcookie",
+  "password",
+  "passwd",
+  "secret",
+  "clientsecret",
+  "apikey",
+  "accesskey",
+  "privatekey",
+  "token",
+  "sessioncookie",
+  "sessionid",
+  "credential",
+  "credentials"
+]);
+const REGULATED_FIELD_KEYS = new Set([
+  "ssn",
+  "socialsecuritynumber",
+  "patientid",
+  "patientname",
+  "medicalrecordnumber",
+  "mrn"
+]);
+const CUSTOMER_IDENTIFIER_FIELD_KEYS = new Set([
+  "customerid",
+  "customername",
+  "customeremail",
+  "accountnumber"
+]);
 
 export const findUnsafeWorkflowArtifactValue = (
   value: unknown,
@@ -42,9 +81,15 @@ export const findUnsafeWorkflowArtifactValue = (
 
   if (isRecord(value)) {
     for (const [key, nestedValue] of Object.entries(value)) {
-      const nested = findUnsafeWorkflowArtifactValue(nestedValue, `${path}.${key}`);
+      const nestedPath = `${path}.${key}`;
+      const nested = findUnsafeWorkflowArtifactValue(nestedValue, nestedPath);
       if (nested !== undefined) {
         return nested;
+      }
+
+      const keyedCategory = classifyUnsafeWorkflowArtifactKey(key, nestedValue);
+      if (keyedCategory !== undefined) {
+        return { path: nestedPath, category: keyedCategory };
       }
     }
   }
@@ -67,6 +112,14 @@ export const classifyUnsafeWorkflowArtifactString = (
     return "session-cookie";
   }
 
+  if (REGULATED_CONTENT_ASSIGNMENT_PATTERN.test(value)) {
+    return "regulated-content";
+  }
+
+  if (CUSTOMER_IDENTIFIER_ASSIGNMENT_PATTERN.test(value)) {
+    return "customer-identifier";
+  }
+
   if (SECRET_ASSIGNMENT_PATTERN.test(value)) {
     return "secret";
   }
@@ -77,6 +130,41 @@ export const classifyUnsafeWorkflowArtifactString = (
 
   return undefined;
 };
+
+const classifyUnsafeWorkflowArtifactKey = (
+  key: string,
+  value: unknown
+): UnsafeWorkflowArtifactCategory | undefined => {
+  if (isEmptyPublicPlaceholder(value)) {
+    return undefined;
+  }
+
+  const normalized = normalizeArtifactKey(key);
+  if (CREDENTIAL_FIELD_KEYS.has(normalized)) {
+    return normalized === "cookie" || normalized === "setcookie" || normalized === "sessioncookie"
+      ? "session-cookie"
+      : "credential";
+  }
+
+  if (REGULATED_FIELD_KEYS.has(normalized)) {
+    return "regulated-content";
+  }
+
+  if (CUSTOMER_IDENTIFIER_FIELD_KEYS.has(normalized)) {
+    return "customer-identifier";
+  }
+
+  return undefined;
+};
+
+const normalizeArtifactKey = (key: string): string =>
+  key.replaceAll(/[^A-Za-z0-9]/gu, "").toLowerCase();
+
+const isEmptyPublicPlaceholder = (value: unknown): boolean =>
+  value === undefined ||
+  value === null ||
+  value === "" ||
+  (Array.isArray(value) && value.length === 0);
 
 export const formatUnsafeWorkflowArtifactDiagnostic = (
   finding: UnsafeWorkflowArtifactFinding

--- a/src/workflow-artifact-hygiene.ts
+++ b/src/workflow-artifact-hygiene.ts
@@ -22,9 +22,9 @@ const TOKEN_ASSIGNMENT_PATTERN = /(?:^|\b)token\s*[:=]/iu;
 const SESSION_COOKIE_PATTERN =
   /(?:^|\b)(?:cookie|set-cookie)\s*:\s*[^;\n]*(?:session|sid)=|(?:^|\b)(?:sessionid|session_id|sid)\s*=/iu;
 const REGULATED_CONTENT_ASSIGNMENT_PATTERN =
-  /(?:^|\b)(?:ssn|social[_ -]?security[_ -]?number|patient[_ -]?id|patient[_ -]?name|medical[_ -]?record[_ -]?number|mrn)\s*[:=]/iu;
+  /(?:^|\b)(?:ssn|social[_ -]?security[_ -]?number|patient[_ -]?id|patient[_ -]?name|medical[_ -]?record[_ -]?number|mrn)\s*["']?\s*[:=]/iu;
 const CUSTOMER_IDENTIFIER_ASSIGNMENT_PATTERN =
-  /(?:^|\b)(?:customer[_ -]?id|customer[_ -]?name|customer[_ -]?email|account[_ -]?number)\s*[:=]/iu;
+  /(?:^|\b)(?:customer[_ -]?id|customer[_ -]?name|customer[_ -]?email|account[_ -]?number)\s*["']?\s*[:=]/iu;
 const WORKSTATION_LOCAL_PATH_PATTERN =
   /(?:^|["'\s])(?:\/(?:Users|home|var|tmp|opt|etc|srv|mnt|root|Volumes|usr)\/[^/\\\s]+|[A-Za-z]:[\\/][^/\\\s]+|file:\/\/\/(?:[A-Za-z]:\/|(?:Users|home|var|tmp|opt|etc|srv|mnt|root|Volumes|usr)\/)[^/\\\s]+)/u;
 const CREDENTIAL_FIELD_KEYS = new Set([
@@ -59,6 +59,19 @@ const CUSTOMER_IDENTIFIER_FIELD_KEYS = new Set([
   "customeremail",
   "accountnumber"
 ]);
+const TOKEN_BEARING_FIELD_KEY_MARKERS = ["token"];
+const CREDENTIAL_BEARING_FIELD_KEY_MARKERS = [
+  "authorization",
+  "password",
+  "passwd",
+  "secret",
+  "apikey",
+  "accesskey",
+  "privatekey",
+  "credential",
+  "sessioncookie",
+  "sessionid"
+];
 
 export const findUnsafeWorkflowArtifactValue = (
   value: unknown,
@@ -148,16 +161,20 @@ const classifyUnsafeWorkflowArtifactKey = (
   }
 
   const normalized = normalizeArtifactKey(key);
+  const tokenBearingCategory = classifyTokenBearingArtifactKey(normalized);
+  if (tokenBearingCategory !== undefined) {
+    return tokenBearingCategory;
+  }
+
   if (CREDENTIAL_FIELD_KEYS.has(normalized)) {
     return normalized === "cookie" || normalized === "setcookie" || normalized === "sessioncookie"
       ? "session-cookie"
       : "credential";
   }
 
-  if (isCredentialBearingKey(normalized)) {
-    return normalized.includes("cookie") || normalized.includes("session")
-      ? "session-cookie"
-      : "credential";
+  const credentialBearingCategory = classifyCredentialBearingArtifactKey(normalized);
+  if (credentialBearingCategory !== undefined) {
+    return credentialBearingCategory;
   }
 
   if (REGULATED_FIELD_KEYS.has(normalized)) {
@@ -174,20 +191,29 @@ const classifyUnsafeWorkflowArtifactKey = (
 const normalizeArtifactKey = (key: string): string =>
   key.replaceAll(/[^A-Za-z0-9]/gu, "").toLowerCase();
 
-const isCredentialBearingKey = (normalizedKey: string): boolean =>
-  [
-    "authorization",
-    "password",
-    "passwd",
-    "secret",
-    "apikey",
-    "accesskey",
-    "privatekey",
-    "credential",
-    "token",
-    "sessioncookie",
-    "sessionid"
-  ].some((token) => normalizedKey.includes(token));
+const classifyTokenBearingArtifactKey = (
+  normalizedKey: string
+): UnsafeWorkflowArtifactCategory | undefined => {
+  if (!TOKEN_BEARING_FIELD_KEY_MARKERS.some((marker) => normalizedKey.includes(marker))) {
+    return undefined;
+  }
+
+  return normalizedKey.includes("cookie") || normalizedKey.includes("session")
+    ? "session-cookie"
+    : "credential";
+};
+
+const classifyCredentialBearingArtifactKey = (
+  normalizedKey: string
+): UnsafeWorkflowArtifactCategory | undefined => {
+  if (!CREDENTIAL_BEARING_FIELD_KEY_MARKERS.some((marker) => normalizedKey.includes(marker))) {
+    return undefined;
+  }
+
+  return normalizedKey.includes("cookie") || normalizedKey.includes("session")
+    ? "session-cookie"
+    : "credential";
+};
 
 const parseJsonFormattedContainer = (value: string): unknown[] | Record<string, unknown> | undefined => {
   const trimmed = value.trim();

--- a/src/workflow-run-state.ts
+++ b/src/workflow-run-state.ts
@@ -221,6 +221,8 @@ export interface ReadWorkflowRunStateOptions {
   artifactHygiene?: "enforce" | "skip";
 }
 
+export type AppendWorkflowRunEventOptions = ReadWorkflowRunStateOptions;
+
 export type WorkflowStepAttemptResultMetadata = Record<string, unknown>;
 
 export type WorkflowRunRecoveryClassification =
@@ -290,19 +292,22 @@ export const createWorkflowRun = async (
 
 export const appendWorkflowRunEvent = async (
   statePath: string,
-  event: AppendableWorkflowRunEvent
+  event: AppendableWorkflowRunEvent,
+  options?: AppendWorkflowRunEventOptions
 ): Promise<void> => {
   validateWorkflowRunEvent(event, 1);
   await mkdir(dirname(statePath), { recursive: true });
 
   await withStatePathAppendLock(statePath, async () => {
-    const currentState = await readWorkflowRunState(statePath).catch((error: unknown) => {
-      if (isNodeError(error) && error.code === "ENOENT") {
-        throw missingWorkflowRunStateError();
-      }
+    const currentState = await readWorkflowRunState(statePath, options).catch(
+      (error: unknown) => {
+        if (isNodeError(error) && error.code === "ENOENT") {
+          throw missingWorkflowRunStateError();
+        }
 
-      throw error;
-    });
+        throw error;
+      }
+    );
 
     if (currentState.run.runId !== event.runId) {
       throw new Error("appendWorkflowRunEvent event.runId must match the existing workflow run");

--- a/src/workflow-run-state.ts
+++ b/src/workflow-run-state.ts
@@ -217,6 +217,10 @@ export interface WorkflowRunState {
   stepAttempts: Record<string, WorkflowStepAttemptState[]>;
 }
 
+export interface ReadWorkflowRunStateOptions {
+  artifactHygiene?: "enforce" | "skip";
+}
+
 export type WorkflowStepAttemptResultMetadata = Record<string, unknown>;
 
 export type WorkflowRunRecoveryClassification =
@@ -330,10 +334,11 @@ export const appendWorkflowRunEvent = async (
 };
 
 export const readWorkflowRunState = async (
-  statePath: string
+  statePath: string,
+  options?: ReadWorkflowRunStateOptions
 ): Promise<WorkflowRunState> => {
   const contents = await readFile(statePath, "utf8");
-  const events = parseWorkflowRunEvents(contents);
+  const events = parseWorkflowRunEvents(contents, options);
 
   return projectWorkflowRunEvents(events);
 };
@@ -531,7 +536,10 @@ const projectWorkflowRunEvents = (events: WorkflowRunEvent[]): WorkflowRunState 
   };
 };
 
-const parseWorkflowRunEvents = (contents: string): WorkflowRunEvent[] => {
+const parseWorkflowRunEvents = (
+  contents: string,
+  options?: ReadWorkflowRunStateOptions
+): WorkflowRunEvent[] => {
   const lines = contents.split("\n");
   if (lines.at(-1) === "") {
     lines.pop();
@@ -551,7 +559,7 @@ const parseWorkflowRunEvents = (contents: string): WorkflowRunEvent[] => {
       throw new Error(`workflow run state line ${lineNumber}: invalid JSON: ${message}`);
     }
 
-    return validateWorkflowRunEvent(parsed, lineNumber);
+    return validateWorkflowRunEvent(parsed, lineNumber, options);
   });
 };
 
@@ -654,7 +662,8 @@ const stepAttemptStatusFromFailedEvent = (
 
 const validateWorkflowRunEvent = (
   value: unknown,
-  lineNumber: number
+  lineNumber: number,
+  options?: ReadWorkflowRunStateOptions
 ): WorkflowRunEvent => {
   if (!isRecord(value)) {
     throw stateError(lineNumber, "record must be an object");
@@ -674,7 +683,7 @@ const validateWorkflowRunEvent = (
     requireNonEmptyString(value, "workflowId", lineNumber);
     requireNonEmptyString(value, "workflowVersion", lineNumber);
     requireTimestamp(value, "occurredAt", lineNumber);
-    validateTrigger(value.trigger, lineNumber);
+    validateTrigger(value.trigger, lineNumber, options);
     return value as unknown as WorkflowRunCreatedEvent;
   }
 
@@ -691,7 +700,7 @@ const validateWorkflowRunEvent = (
     }
 
     if ("recovery" in value) {
-      validateRecoveryDecisionMetadata(value.recovery, lineNumber);
+      validateRecoveryDecisionMetadata(value.recovery, lineNumber, options);
     }
 
     return value as unknown as WorkflowRunCompletedEvent;
@@ -704,24 +713,28 @@ const validateWorkflowRunEvent = (
   requireTimestamp(value, "occurredAt", lineNumber);
 
   if ("retry" in value) {
-    validateRetryMetadata(value.retry, lineNumber);
+    validateRetryMetadata(value.retry, lineNumber, options);
   }
 
   if ("result" in value) {
     if (eventType === "step.attempt.started") {
       throw stateError(lineNumber, "result is only allowed on terminal step attempt events");
     }
-    validateResultMetadata(value.result, lineNumber);
+    validateResultMetadata(value.result, lineNumber, options);
   }
 
   if ("recovery" in value) {
-    validateRecoveryDecisionMetadata(value.recovery, lineNumber);
+    validateRecoveryDecisionMetadata(value.recovery, lineNumber, options);
   }
 
   return value as unknown as WorkflowStepAttemptEvent;
 };
 
-const validateTrigger = (value: unknown, lineNumber: number): void => {
+const validateTrigger = (
+  value: unknown,
+  lineNumber: number,
+  options?: ReadWorkflowRunStateOptions
+): void => {
   if (!isRecord(value)) {
     throw stateError(lineNumber, "trigger must be an object");
   }
@@ -736,15 +749,24 @@ const validateTrigger = (value: unknown, lineNumber: number): void => {
 
   if ("context" in value) {
     validateJsonSerializableValue(value.context, lineNumber, "trigger.context");
-    rejectUnsafeWorkflowArtifactValues(value.context, lineNumber, "trigger.context");
+    rejectUnsafeWorkflowArtifactValues(
+      value.context,
+      lineNumber,
+      "trigger.context",
+      options
+    );
   }
 
   if ("idempotencyKey" in value) {
-    validateIdempotencyMetadata(value.idempotencyKey, lineNumber);
+    validateIdempotencyMetadata(value.idempotencyKey, lineNumber, options);
   }
 };
 
-const validateIdempotencyMetadata = (value: unknown, lineNumber: number): void => {
+const validateIdempotencyMetadata = (
+  value: unknown,
+  lineNumber: number,
+  options?: ReadWorkflowRunStateOptions
+): void => {
   if (!isRecord(value)) {
     throw stateError(lineNumber, "trigger.idempotencyKey must be an object");
   }
@@ -759,10 +781,14 @@ const validateIdempotencyMetadata = (value: unknown, lineNumber: number): void =
   }
 
   requireNonEmptyString(value, "key", lineNumber);
-  rejectUnsafeWorkflowArtifactValues(value.key, lineNumber, "idempotencyKey.key");
+  rejectUnsafeWorkflowArtifactValues(value.key, lineNumber, "idempotencyKey.key", options);
 };
 
-const validateRetryMetadata = (value: unknown, lineNumber: number): void => {
+const validateRetryMetadata = (
+  value: unknown,
+  lineNumber: number,
+  options?: ReadWorkflowRunStateOptions
+): void => {
   if (!isRecord(value)) {
     throw stateError(lineNumber, "retry must be an object");
   }
@@ -782,11 +808,15 @@ const validateRetryMetadata = (value: unknown, lineNumber: number): void => {
   }
 
   if ("reason" in value) {
-    rejectUnsafeWorkflowArtifactValues(value.reason, lineNumber, "retry.reason");
+    rejectUnsafeWorkflowArtifactValues(value.reason, lineNumber, "retry.reason", options);
   }
 };
 
-const validateRecoveryDecisionMetadata = (value: unknown, lineNumber: number): void => {
+const validateRecoveryDecisionMetadata = (
+  value: unknown,
+  lineNumber: number,
+  options?: ReadWorkflowRunStateOptions
+): void => {
   if (!isRecord(value)) {
     throw stateError(lineNumber, "recovery must be an object");
   }
@@ -807,16 +837,20 @@ const validateRecoveryDecisionMetadata = (value: unknown, lineNumber: number): v
   }
 
   requireNonEmptyString(value, "reason", lineNumber);
-  rejectUnsafeWorkflowArtifactValues(value.reason, lineNumber, "recovery.reason");
+  rejectUnsafeWorkflowArtifactValues(value.reason, lineNumber, "recovery.reason", options);
 };
 
-const validateResultMetadata = (value: unknown, lineNumber: number): void => {
+const validateResultMetadata = (
+  value: unknown,
+  lineNumber: number,
+  options?: ReadWorkflowRunStateOptions
+): void => {
   if (!isRecord(value)) {
     throw stateError(lineNumber, "result must be an object");
   }
 
   validateJsonSerializableValue(value, lineNumber, "result");
-  rejectUnsafeWorkflowArtifactValues(value, lineNumber, "result");
+  rejectUnsafeWorkflowArtifactValues(value, lineNumber, "result", options);
 };
 
 const rejectUnknownKeys = (
@@ -992,8 +1026,13 @@ const validateJsonSerializableValue = (
 const rejectUnsafeWorkflowArtifactValues = (
   value: unknown,
   lineNumber: number,
-  path: string
+  path: string,
+  options?: ReadWorkflowRunStateOptions
 ): void => {
+  if (options?.artifactHygiene === "skip") {
+    return;
+  }
+
   const finding = findUnsafeWorkflowArtifactValue(value, path);
   if (finding !== undefined) {
     throw stateError(lineNumber, formatUnsafeWorkflowArtifactDiagnostic(finding));

--- a/src/workflow-runner.ts
+++ b/src/workflow-runner.ts
@@ -13,6 +13,7 @@ import type {
   ExecutorConnectorExecutionStatus
 } from "./executor-connector.js";
 import type {
+  AppendableWorkflowRunEvent,
   WorkflowRunIdempotencyMetadata,
   WorkflowRunRecoveryDecisionMetadata,
   WorkflowStepAttemptResultMetadata,
@@ -94,6 +95,15 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
     input.runId ??
     `${input.definition.id}-${triggerIdempotencyKey?.key ?? "local-run"}`;
   const stepHandler = input.stepHandler ?? defaultWorkflowStepHandler;
+  const existingRunStateArtifactHygiene =
+    input.existingRunStateArtifactHygiene ?? "enforce";
+  const existingRunStateReadOptions = {
+    artifactHygiene: existingRunStateArtifactHygiene
+  };
+  const readCurrentRunState = () =>
+    readWorkflowRunState(input.statePath, existingRunStateReadOptions);
+  const appendRunEvent = (event: AppendableWorkflowRunEvent) =>
+    appendWorkflowRunEvent(input.statePath, event, existingRunStateReadOptions);
   const auditWriter =
     input.auditPath === undefined
       ? undefined
@@ -108,7 +118,7 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
 
   const existingState = await readExistingRunState(
     input.statePath,
-    input.existingRunStateArtifactHygiene
+    existingRunStateArtifactHygiene
   );
   if (existingState !== undefined) {
     assertExistingRunMatches(existingState, input.definition, runId, triggerIdempotencyKey);
@@ -145,7 +155,7 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
 
       const competingState = await readCompetingRunState(
         input.statePath,
-        input.existingRunStateArtifactHygiene
+        existingRunStateArtifactHygiene
       );
       assertExistingRunMatches(competingState, input.definition, runId, triggerIdempotencyKey);
       assertPersistedRunCustomerWorkflowAllowlisted(competingState, input.definition);
@@ -166,9 +176,7 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
 
   for (const step of orderedSteps) {
     const retryPolicy = step.retry ?? { maxAttempts: 1, backoff: { strategy: "none" as const } };
-    const latestAttempt = latestStepAttempt(
-      (await readWorkflowRunState(input.statePath)).stepAttempts[step.id]
-    );
+    const latestAttempt = latestStepAttempt((await readCurrentRunState()).stepAttempts[step.id]);
     if (latestAttempt?.status === "succeeded") {
       continue;
     }
@@ -183,7 +191,7 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
 
     for (let attempt = firstAttempt; attempt <= retryPolicy.maxAttempts; attempt += 1) {
       const startedAt = now();
-      await appendWorkflowRunEvent(input.statePath, {
+      await appendRunEvent({
         type: "step.attempt.started",
         runId,
         stepId: step.id,
@@ -204,7 +212,7 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
             step,
             attempt,
             triggerContext,
-            runState: await readWorkflowRunState(input.statePath)
+            runState: await readCurrentRunState()
           })
         );
 
@@ -219,7 +227,7 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
         }
 
         const completedAt = now();
-        await appendWorkflowRunEvent(input.statePath, {
+        await appendRunEvent({
           type: "step.attempt.completed",
           runId,
           stepId: step.id,
@@ -243,7 +251,7 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
         const nextAttemptAt = retryable
           ? calculateNextAttemptAt(failedAt, retryPolicy, attempt)
           : undefined;
-        await appendWorkflowRunEvent(input.statePath, {
+        await appendRunEvent({
           type: "step.attempt.failed",
           runId,
           stepId: step.id,
@@ -277,12 +285,12 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
           recovery?.state === "approval-required" ||
           recovery?.state === "manual-repair-needed"
         ) {
-          return readWorkflowRunState(input.statePath);
+          return readCurrentRunState();
         }
 
         if (!retryable) {
           const completedAt = now();
-          await appendWorkflowRunEvent(input.statePath, {
+          await appendRunEvent({
             type: "run.completed",
             runId,
             terminalState: "failed",
@@ -297,7 +305,7 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
               reason: errorReason(error)
             }
           });
-          return readWorkflowRunState(input.statePath);
+          return readCurrentRunState();
         }
 
         await writeStepAuditEvent(auditWriter, {
@@ -316,7 +324,7 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
   }
 
   const completedAt = now();
-  await appendWorkflowRunEvent(input.statePath, {
+  await appendRunEvent({
     type: "run.completed",
     runId,
     terminalState: "succeeded",
@@ -328,7 +336,7 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
     outcome: { status: "succeeded" }
   });
 
-  return readWorkflowRunState(input.statePath);
+  return readCurrentRunState();
 };
 
 class WorkflowStepOutcomeError extends Error {

--- a/src/workflow-runner.ts
+++ b/src/workflow-runner.ts
@@ -42,6 +42,7 @@ export interface RunWorkflowInput {
   runId?: string;
   triggerContext?: Record<string, unknown>;
   existingRunStateGuard?: (existingState: WorkflowRunState) => void;
+  existingRunStateArtifactHygiene?: "enforce" | "skip";
   now?: () => string;
   stepHandler?: WorkflowStepHandler;
 }
@@ -105,7 +106,10 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
           run: { id: runId }
         });
 
-  const existingState = await readExistingRunState(input.statePath);
+  const existingState = await readExistingRunState(
+    input.statePath,
+    input.existingRunStateArtifactHygiene
+  );
   if (existingState !== undefined) {
     assertExistingRunMatches(existingState, input.definition, runId, triggerIdempotencyKey);
     assertPersistedRunCustomerWorkflowAllowlisted(existingState, input.definition);
@@ -139,7 +143,10 @@ export const runWorkflow = async (input: RunWorkflowInput): Promise<WorkflowRunS
         throw error;
       }
 
-      const competingState = await readCompetingRunState(input.statePath);
+      const competingState = await readCompetingRunState(
+        input.statePath,
+        input.existingRunStateArtifactHygiene
+      );
       assertExistingRunMatches(competingState, input.definition, runId, triggerIdempotencyKey);
       assertPersistedRunCustomerWorkflowAllowlisted(competingState, input.definition);
       assertRequestedCustomerWorkflowAllowlisted(input.definition, triggerContext);
@@ -479,9 +486,12 @@ const defaultWorkflowStepHandler: WorkflowStepHandler = ({ step }) => {
   }
 };
 
-const readExistingRunState = async (statePath: string): Promise<WorkflowRunState | undefined> => {
+const readExistingRunState = async (
+  statePath: string,
+  artifactHygiene: "enforce" | "skip" = "enforce"
+): Promise<WorkflowRunState | undefined> => {
   try {
-    return await readWorkflowRunState(statePath);
+    return await readWorkflowRunState(statePath, { artifactHygiene });
   } catch (error) {
     if (isNodeError(error) && error.code === "ENOENT") {
       return undefined;
@@ -491,11 +501,14 @@ const readExistingRunState = async (statePath: string): Promise<WorkflowRunState
   }
 };
 
-const readCompetingRunState = async (statePath: string): Promise<WorkflowRunState> => {
+const readCompetingRunState = async (
+  statePath: string,
+  artifactHygiene: "enforce" | "skip" = "enforce"
+): Promise<WorkflowRunState> => {
   const maxAttempts = 5;
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     try {
-      return await readWorkflowRunState(statePath);
+      return await readWorkflowRunState(statePath, { artifactHygiene });
     } catch (error) {
       if (!isTransientRunCreationRead(error) || attempt === maxAttempts) {
         throw error;
@@ -504,7 +517,7 @@ const readCompetingRunState = async (statePath: string): Promise<WorkflowRunStat
     }
   }
 
-  return readWorkflowRunState(statePath);
+  return readWorkflowRunState(statePath, { artifactHygiene });
 };
 
 const isTransientRunCreationRead = (error: unknown): boolean =>

--- a/test/audit-event-writer.test.ts
+++ b/test/audit-event-writer.test.ts
@@ -49,7 +49,7 @@ describe("neutral audit event writer", () => {
         receivedAt: "2026-04-29T00:00:00.000Z",
         context: {
           requestId: "private-request-id",
-          customerName: "private-customer"
+          privateLabel: "private-label"
         },
         idempotencyKey: {
           source: "input",
@@ -177,7 +177,7 @@ describe("neutral audit event writer", () => {
     });
     expect(serialized).not.toContain(statePath);
     expect(serialized).not.toContain(auditPath);
-    expect(serialized).not.toContain("private-customer");
+    expect(serialized).not.toContain("private-label");
     expect(serialized).not.toContain("private-request-id");
     expect(serialized).not.toContain("private-idempotency-key");
   });

--- a/test/file-connector.test.ts
+++ b/test/file-connector.test.ts
@@ -239,6 +239,41 @@ describe("local file connector skeleton", () => {
     expect(JSON.stringify(result)).not.toContain("patient-12345");
   });
 
+  it("rejects JSON-fragment customer fixture writes before persisting content", async () => {
+    const fixtureRoot = await createTempRoot();
+    const connector = createLocalFileConnector({
+      allowedRoots: [{ alias: "fixture-root", path: fixtureRoot }]
+    });
+    const unsafeContent = `fixture export ${JSON.stringify({
+      customerEmail: "private-customer@example.invalid"
+    })}`;
+
+    const result = await connector.submit({
+      workflowId: "file-demo",
+      runId: "file-demo-run",
+      stepId: "write-json-customer-fragment",
+      idempotencyKey: "file-demo-run:write-json-customer-fragment",
+      file: {
+        action: "write",
+        rootAlias: "fixture-root",
+        path: "outputs/customer-fragment.txt",
+        content: unsafeContent
+      }
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid-request",
+        message:
+          "local file content must not contain unsafe workflow artifact values (category: customer-identifier)",
+        retryable: false
+      }
+    });
+    await expect(readFile(join(fixtureRoot, "outputs", "customer-fragment.txt"), "utf8")).rejects.toThrow();
+    expect(JSON.stringify(result)).not.toContain("private-customer@example.invalid");
+  });
+
   it("rejects unsafe fixture reads before returning connector output", async () => {
     const fixtureRoot = await createTempRoot();
     await mkdir(join(fixtureRoot, "inputs"), { recursive: true });

--- a/test/file-connector.test.ts
+++ b/test/file-connector.test.ts
@@ -114,6 +114,72 @@ describe("local file connector skeleton", () => {
     expect(JSON.stringify(first)).not.toContain(fixtureRoot);
   });
 
+  it("rejects regulated-looking fixture writes before persisting content", async () => {
+    const fixtureRoot = await createTempRoot();
+    const connector = createLocalFileConnector({
+      allowedRoots: [{ alias: "fixture-root", path: fixtureRoot }]
+    });
+    const unsafeContent = "patientId: patient-12345";
+
+    const result = await connector.submit({
+      workflowId: "file-demo",
+      runId: "file-demo-run",
+      stepId: "write-regulated-fixture",
+      idempotencyKey: "file-demo-run:write-regulated-fixture",
+      file: {
+        action: "write",
+        rootAlias: "fixture-root",
+        path: "outputs/regulated.txt",
+        content: unsafeContent
+      }
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid-request",
+        message:
+          "local file content must not contain unsafe workflow artifact values (category: regulated-content)",
+        retryable: false
+      }
+    });
+    await expect(readFile(join(fixtureRoot, "outputs", "regulated.txt"), "utf8")).rejects.toThrow();
+    expect(JSON.stringify(result)).not.toContain(unsafeContent);
+  });
+
+  it("rejects unsafe fixture reads before returning connector output", async () => {
+    const fixtureRoot = await createTempRoot();
+    await mkdir(join(fixtureRoot, "inputs"), { recursive: true });
+    const unsafeContent = "customerEmail: private-customer@example.invalid";
+    await writeFile(join(fixtureRoot, "inputs", "customer.txt"), unsafeContent, "utf8");
+    const connector = createLocalFileConnector({
+      allowedRoots: [{ alias: "fixture-root", path: fixtureRoot }]
+    });
+
+    const result = await connector.submit({
+      workflowId: "file-demo",
+      runId: "file-demo-run",
+      stepId: "read-unsafe-fixture",
+      idempotencyKey: "file-demo-run:read-unsafe-fixture",
+      file: {
+        action: "read",
+        rootAlias: "fixture-root",
+        path: "inputs/customer.txt"
+      }
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "execution-failed",
+        message:
+          "local file output must not contain unsafe workflow artifact values (category: customer-identifier)",
+        retryable: false
+      }
+    });
+    expect(JSON.stringify(result)).not.toContain(unsafeContent);
+  });
+
   it("rejects changed replays from a shared idempotency store after connector recreation", async () => {
     const fixtureRoot = await createTempRoot();
     const idempotencyStore = createInMemoryLocalFileIdempotencyStore();

--- a/test/file-connector.test.ts
+++ b/test/file-connector.test.ts
@@ -11,6 +11,7 @@ import {
   runWorkflow
 } from "../src/index.js";
 import type {
+  LocalFileIdempotencyStore,
   LocalFileSubmitRequest,
   WorkflowDefinition
 } from "../src/index.js";
@@ -114,6 +115,64 @@ describe("local file connector skeleton", () => {
     expect(JSON.stringify(first)).not.toContain(fixtureRoot);
   });
 
+  it("replays stored local file writes before applying upgraded content guards", async () => {
+    const fixtureRoot = await createTempRoot();
+    const request: LocalFileSubmitRequest = {
+      workflowId: "file-demo",
+      runId: "file-demo-run",
+      stepId: "write-fixture",
+      idempotencyKey: "file-demo-run:write-fixture",
+      file: {
+        action: "write",
+        rootAlias: "fixture-root",
+        path: "outputs/result.txt",
+        content: "patientId: patient-12345"
+      }
+    };
+    const idempotencyStore: LocalFileIdempotencyStore = {
+      async submitSuccessfulReceipt(input) {
+        return {
+          status: "replayed",
+          record: {
+            fingerprint: input.fingerprint,
+            receipt: {
+              requestId: "local-file-file-demo-run-write-fixture",
+              acceptedAt: "2026-05-02T04:01:00.000Z",
+              file: {
+                action: "write",
+                rootAlias: "fixture-root",
+                path: "outputs/result.txt",
+                bytes: 11,
+                summary: "local fixture file written"
+              },
+              evidence: {
+                kind: "local-file-fixture",
+                rootAlias: "fixture-root",
+                path: "outputs/result.txt",
+                bytes: 11
+              }
+            }
+          }
+        };
+      }
+    };
+    const connector = createLocalFileConnector({
+      allowedRoots: [{ alias: "fixture-root", path: fixtureRoot }],
+      idempotencyStore
+    });
+
+    await expect(connector.submit(request)).resolves.toMatchObject({
+      ok: true,
+      value: {
+        requestId: "local-file-file-demo-run-write-fixture",
+        file: {
+          path: "outputs/result.txt"
+        }
+      }
+    });
+    await expect(readFile(join(fixtureRoot, "outputs", "result.txt"), "utf8")).rejects.toThrow();
+  });
+
   it("rejects regulated-looking fixture writes before persisting content", async () => {
     const fixtureRoot = await createTempRoot();
     const connector = createLocalFileConnector({
@@ -145,6 +204,39 @@ describe("local file connector skeleton", () => {
     });
     await expect(readFile(join(fixtureRoot, "outputs", "regulated.txt"), "utf8")).rejects.toThrow();
     expect(JSON.stringify(result)).not.toContain(unsafeContent);
+  });
+
+  it("rejects JSON-formatted regulated fixture writes before persisting content", async () => {
+    const fixtureRoot = await createTempRoot();
+    const connector = createLocalFileConnector({
+      allowedRoots: [{ alias: "fixture-root", path: fixtureRoot }]
+    });
+    const unsafeContent = JSON.stringify({ patientId: "patient-12345" });
+
+    const result = await connector.submit({
+      workflowId: "file-demo",
+      runId: "file-demo-run",
+      stepId: "write-json-regulated-fixture",
+      idempotencyKey: "file-demo-run:write-json-regulated-fixture",
+      file: {
+        action: "write",
+        rootAlias: "fixture-root",
+        path: "outputs/regulated.json",
+        content: unsafeContent
+      }
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid-request",
+        message:
+          "local file content.patientId must not contain unsafe workflow artifact values (category: regulated-content)",
+        retryable: false
+      }
+    });
+    await expect(readFile(join(fixtureRoot, "outputs", "regulated.json"), "utf8")).rejects.toThrow();
+    expect(JSON.stringify(result)).not.toContain("patient-12345");
   });
 
   it("rejects unsafe fixture reads before returning connector output", async () => {

--- a/test/webhook-intake-boundary.test.ts
+++ b/test/webhook-intake-boundary.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -201,6 +201,73 @@ describe("webhook intake boundary", () => {
 
     expect(await readWorkflowRunState(statePath)).toEqual(legacyState);
     expect(await readAuditEvents(auditPath)).toEqual(auditBeforeReplay);
+  });
+
+  it("replays existing webhook runs before applying upgraded payload artifact guards", async () => {
+    const definition = createWebhookWorkflow();
+    const root = await createTempRoot();
+    const stateRoot = join(root, "runs");
+    const auditPath = join(root, "audit", "webhook.audit.jsonl");
+    const input = createWebhookInput();
+    input.payload = {
+      eventType: "local-demo.created",
+      patientId: "patient-12345"
+    };
+    const expectedRunId = createExpectedWebhookRunId(definition.id, input.requestId);
+    const statePath = join(stateRoot, `${expectedRunId}.jsonl`);
+    await mkdir(stateRoot, { recursive: true });
+    await writeFile(
+      statePath,
+      [
+        JSON.stringify({
+          type: "run.created",
+          runId: expectedRunId,
+          workflowId: definition.id,
+          workflowVersion: "flow.workflow.v1",
+          trigger: {
+            type: "webhook",
+            receivedAt: "2026-05-02T01:00:01.000Z",
+            context: {
+              webhook: {
+                path: input.path,
+                receivedAt: input.receivedAt,
+                headers: input.headers,
+                payload: input.payload
+              },
+              requestId: input.requestId
+            },
+            idempotencyKey: {
+              source: "input",
+              key: input.requestId
+            }
+          },
+          occurredAt: "2026-05-02T01:00:01.000Z"
+        }),
+        JSON.stringify({
+          type: "run.completed",
+          runId: expectedRunId,
+          terminalState: "succeeded",
+          occurredAt: "2026-05-02T01:00:02.000Z"
+        })
+      ].join("\n") + "\n"
+    );
+
+    const replay = await consumeWebhookInput({
+      definition,
+      stateRoot,
+      auditPath,
+      input
+    });
+
+    expect(replay.run.runId).toBe(expectedRunId);
+    expect(replay.run.terminalState).toBe("succeeded");
+    expect(replay.run.trigger.context).toMatchObject({
+      webhook: {
+        payload: input.payload
+      },
+      requestId: input.requestId
+    });
+    await expect(readFile(auditPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("rejects reused requestIds when normalized webhook payload changes without writing audit events", async () => {

--- a/test/workflow-run-state.test.ts
+++ b/test/workflow-run-state.test.ts
@@ -558,6 +558,45 @@ describe("workflow run JSONL state", () => {
     }
   );
 
+  it.each([
+    {
+      context: { connectorConfig: { apiKey: "placeholder-api-key-value" } },
+      message:
+        "trigger.context.connectorConfig.apiKey must not contain unsafe workflow artifact values (category: credential)"
+    },
+    {
+      context: { intake: { patientId: "patient-12345" } },
+      message:
+        "trigger.context.intake.patientId must not contain unsafe workflow artifact values (category: regulated-content)"
+    },
+    {
+      context: { intake: { customerEmail: "private-customer@example.invalid" } },
+      message:
+        "trigger.context.intake.customerEmail must not contain unsafe workflow artifact values (category: customer-identifier)"
+    }
+  ])(
+    "rejects credential and regulated-shaped trigger fields without echoing values %#",
+    async ({ context, message }) => {
+      const statePath = await createTempStatePath();
+
+      await expect(
+        createWorkflowRun(statePath, {
+          runId: "run-unsafe-trigger-field",
+          workflowId: "operator-review",
+          workflowVersion: "flow.workflow.v1",
+          trigger: {
+            type: "manual",
+            receivedAt: "2026-04-29T00:00:00.000Z",
+            context
+          },
+          createdAt: "2026-04-29T00:00:01.000Z"
+        })
+      ).rejects.toThrow(`workflow run state line 1: ${message}`);
+
+      await expect(readFile(statePath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    }
+  );
+
   it.each(["succeeded", "failed", "canceled", "retryable-failed"] as const)(
     "represents %s as a distinct terminal state",
     async (terminalState) => {

--- a/test/workflow-run-state.test.ts
+++ b/test/workflow-run-state.test.ts
@@ -565,6 +565,16 @@ describe("workflow run JSONL state", () => {
         "trigger.context.connectorConfig.apiKey must not contain unsafe workflow artifact values (category: credential)"
     },
     {
+      context: { connectorConfig: { accessToken: "placeholder-token-value" } },
+      message:
+        "trigger.context.connectorConfig.accessToken must not contain unsafe workflow artifact values (category: credential)"
+    },
+    {
+      context: { connectorConfig: { bearerToken: "placeholder-token-value" } },
+      message:
+        "trigger.context.connectorConfig.bearerToken must not contain unsafe workflow artifact values (category: credential)"
+    },
+    {
       context: { intake: { patientId: "patient-12345" } },
       message:
         "trigger.context.intake.patientId must not contain unsafe workflow artifact values (category: regulated-content)"
@@ -573,6 +583,11 @@ describe("workflow run JSONL state", () => {
       context: { intake: { customerEmail: "private-customer@example.invalid" } },
       message:
         "trigger.context.intake.customerEmail must not contain unsafe workflow artifact values (category: customer-identifier)"
+    },
+    {
+      context: { serialized: JSON.stringify({ customerEmail: "private-customer@example.invalid" }) },
+      message:
+        "trigger.context.serialized.customerEmail must not contain unsafe workflow artifact values (category: customer-identifier)"
     }
   ])(
     "rejects credential and regulated-shaped trigger fields without echoing values %#",

--- a/test/workflow-run-state.test.ts
+++ b/test/workflow-run-state.test.ts
@@ -575,6 +575,11 @@ describe("workflow run JSONL state", () => {
         "trigger.context.connectorConfig.bearerToken must not contain unsafe workflow artifact values (category: credential)"
     },
     {
+      context: { connectorConfig: { refreshToken: "placeholder-token-value" } },
+      message:
+        "trigger.context.connectorConfig.refreshToken must not contain unsafe workflow artifact values (category: credential)"
+    },
+    {
       context: { intake: { patientId: "patient-12345" } },
       message:
         "trigger.context.intake.patientId must not contain unsafe workflow artifact values (category: regulated-content)"
@@ -588,6 +593,15 @@ describe("workflow run JSONL state", () => {
       context: { serialized: JSON.stringify({ customerEmail: "private-customer@example.invalid" }) },
       message:
         "trigger.context.serialized.customerEmail must not contain unsafe workflow artifact values (category: customer-identifier)"
+    },
+    {
+      context: {
+        serializedFragment: `public fixture ${JSON.stringify({
+          customerEmail: "private-customer@example.invalid"
+        })}`
+      },
+      message:
+        "trigger.context.serializedFragment must not contain unsafe workflow artifact values (category: customer-identifier)"
     }
   ])(
     "rejects credential and regulated-shaped trigger fields without echoing values %#",

--- a/test/workflow-run-state.test.ts
+++ b/test/workflow-run-state.test.ts
@@ -597,6 +597,31 @@ describe("workflow run JSONL state", () => {
     }
   );
 
+  it.each([
+    { context: { connectorConfig: { apiKey: {} } } },
+    { context: { connectorConfig: { credentials: {} } } },
+    { context: { intake: { patientId: {} } } },
+    { context: { intake: { customerEmail: {} } } }
+  ])("allows empty object placeholders for sensitive trigger fields %#", async ({ context }) => {
+    const statePath = await createTempStatePath();
+
+    await createWorkflowRun(statePath, {
+      runId: "run-empty-sensitive-placeholder",
+      workflowId: "operator-review",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z",
+        context
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+
+    const state = await readWorkflowRunState(statePath);
+
+    expect(state.run.trigger.context).toEqual(context);
+  });
+
   it.each(["succeeded", "failed", "canceled", "retryable-failed"] as const)(
     "represents %s as a distinct terminal state",
     async (terminalState) => {

--- a/test/workflow-runner.test.ts
+++ b/test/workflow-runner.test.ts
@@ -1,6 +1,6 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -148,6 +148,97 @@ describe("sequential workflow runner", () => {
       "step.started",
       "step.completed",
       "workflow.completed"
+    ]);
+  });
+
+  it("propagates skipped artifact hygiene across resumed legacy run execution", async () => {
+    const definition = readWorkflowFixture("simple-manual.valid.json");
+    const statePath = await createTempStatePath();
+    const calls: string[] = [];
+    const legacyUnsafeToken = "test-token-shaped-value";
+    const runId = "local-manual-demo-legacy-resume";
+
+    await mkdir(dirname(statePath), { recursive: true });
+    await writeFile(
+      statePath,
+      [
+        {
+          type: "run.created",
+          runId,
+          workflowId: "local-manual-demo",
+          workflowVersion: "flow.workflow.v1",
+          trigger: {
+            type: "manual",
+            receivedAt: "2026-04-29T00:06:00.000Z",
+            context: {
+              requestId: "legacy-resume",
+              connectorConfig: {
+                accessToken: legacyUnsafeToken
+              }
+            },
+            idempotencyKey: {
+              source: "input",
+              key: "legacy-resume"
+            }
+          },
+          occurredAt: "2026-04-29T00:06:01.000Z"
+        },
+        {
+          type: "step.attempt.started",
+          runId,
+          stepId: "collect-input",
+          attempt: 1,
+          occurredAt: "2026-04-29T00:06:02.000Z"
+        },
+        {
+          type: "step.attempt.completed",
+          runId,
+          stepId: "collect-input",
+          attempt: 1,
+          occurredAt: "2026-04-29T00:06:03.000Z"
+        }
+      ]
+        .map((event) => JSON.stringify(event))
+        .join("\n") + "\n",
+      "utf8"
+    );
+
+    await expect(readWorkflowRunState(statePath)).rejects.toThrow(
+      "trigger.context.connectorConfig.accessToken must not contain unsafe workflow artifact values (category: credential)"
+    );
+
+    const result = await runWorkflow({
+      definition,
+      statePath,
+      triggerContext: {
+        requestId: "legacy-resume"
+      },
+      existingRunStateArtifactHygiene: "skip",
+      now: createClock([
+        "2026-04-29T00:06:04.000Z",
+        "2026-04-29T00:06:05.000Z",
+        "2026-04-29T00:06:06.000Z"
+      ]),
+      stepHandler: ({ step, runState }) => {
+        calls.push(step.id);
+        expect(runState.run.trigger.context).toMatchObject({
+          requestId: "legacy-resume",
+          connectorConfig: {
+            accessToken: legacyUnsafeToken
+          }
+        });
+      }
+    });
+
+    expect(calls).toEqual(["notify-operator"]);
+    expect(result.run.status).toBe("succeeded");
+    expect(result.events.map((event) => event.type)).toEqual([
+      "run.created",
+      "step.attempt.started",
+      "step.attempt.completed",
+      "step.attempt.started",
+      "step.attempt.completed",
+      "run.completed"
     ]);
   });
 


### PR DESCRIPTION
## Summary
- extend workflow artifact hygiene detection for credential-shaped fields, regulated-record fields, and customer identifiers
- reject unsafe values at JSONL state, webhook payload, audit diagnostic, and local file connector boundaries
- keep public-safe export tests synthetic by removing customer-identifier fixture storage

## Verification
- npm ci
- npx vitest run test/workflow-run-state.test.ts test/file-connector.test.ts test/webhook-intake-boundary.test.ts test/audit-event-writer.test.ts
- npm run build
- npm test

Closes #112