### PR TITLE
FLOW-063 add pilot audit evidence recovery export

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,22 +175,26 @@ node dist/cli.js export-audit-evidence <state-jsonl-path> [audit-jsonl-path] [--
 
 The export intentionally separates `publicSafe` metadata from
 `localConfidentialReferences`. Public-safe fields summarize run status, trigger
-type, step attempts, neutral audit event summaries, and any public-safe
-`eip.evidence-bundle-ref.v1` references found in step result metadata. Trigger
-context, idempotency key values, raw local state paths, raw audit paths,
-workstation-local evidence paths, secrets, customer data, production evidence
-locations, and local confidential reference values are not exported into the
-public-safe section. The export boundary uses the copied Protocol v0.4.0
-operational evidence and Track B classification vocabulary for public data
-classification, bounded producer metadata, retention hints, checksum presence,
-and confidential reference policy facts without claiming production evidence
-readiness or regulated workflow execution. Track B evidence references must
-carry an explicit `dataClassification` before entering public-safe output;
-missing values are omitted as unclassified references, and unknown values fail
-closed before an export artifact is written. `file_uri` evidence references are
-omitted from public-safe exports until Flow adopts a deliberately public mapping;
-portable relative `local_path` references remain exportable only when they are
-explicitly classified as `public`. Internal, customer-confidential, regulated,
+type, step attempts, neutral audit event summaries, recovery replay status, and
+any public-safe `eip.evidence-bundle-ref.v1` references found in step result
+metadata. The recovery replay summary ties projected run state to neutral audit
+event IDs, retry facts, approval checkpoint states, blocked outcomes, and
+public evidence reference IDs without exporting raw reasons, approver IDs, or
+idempotency key values. Trigger context, idempotency key values, raw local state
+paths, raw audit paths, workstation-local evidence paths, secrets, customer
+data, production evidence locations, and local confidential reference values are
+not exported into the public-safe section. The export boundary uses copied
+Protocol v0.3.0 operational evidence profile and Protocol v0.4.0 Track B
+classification boundary snapshots for public data classification, bounded
+producer metadata, retention hints, checksum presence, and confidential
+reference policy facts without claiming production evidence readiness or
+regulated workflow execution. Track B evidence references must carry an explicit
+`dataClassification` before entering public-safe output; missing values are
+omitted as unclassified references, and unknown values fail closed before an
+export artifact is written. `file_uri` evidence references are omitted from
+public-safe exports until Flow adopts a deliberately public mapping; portable
+relative `local_path` references remain exportable only when they are explicitly
+classified as `public`. Internal, customer-confidential, regulated,
 confidential, and restricted evidence references stay out of the public-safe
 export surface.
 

--- a/src/audit-evidence-export.ts
+++ b/src/audit-evidence-export.ts
@@ -667,6 +667,10 @@ const classifyRecoveryReplay = (
     return "blocked";
   }
 
+  if (hasLatestStepStatus(state, "manual-repair-needed")) {
+    return "manual-repair-needed";
+  }
+
   if (hasLatestStepStatus(state, "failed")) {
     return "manual-repair-needed";
   }

--- a/src/audit-evidence-export.ts
+++ b/src/audit-evidence-export.ts
@@ -28,6 +28,16 @@ export interface AuditEvidenceExportBoundary {
     name: "ensen-protocol";
     version: "0.4.0";
   };
+  protocolEvidenceProfileSnapshot: {
+    name: "ensen-protocol";
+    version: "0.3.0";
+    profile: "operational-evidence-profile.v1";
+  };
+  trackBBoundarySnapshot: {
+    name: "ensen-protocol";
+    version: "0.4.0";
+    boundary: "Track B customer-regulated data classification";
+  };
   protocolEvidenceProfile: "operational-evidence-profile.v1";
   notes: string[];
 }
@@ -55,6 +65,7 @@ export interface AuditEvidenceExportPublicSafe {
   steps: AuditEvidenceExportStepSummary[];
   auditEvents: AuditEvidenceExportAuditEventSummary[];
   evidenceRefs: AuditEvidenceExportEvidenceRef[];
+  recoveryReplay: AuditEvidenceExportRecoveryReplay;
   diagnostics: string[];
 }
 
@@ -116,6 +127,54 @@ export interface AuditEvidenceExportEvidenceRef {
   checksumPresence: "present" | "absent";
 }
 
+export interface AuditEvidenceExportRecoveryReplay {
+  source: "workflow-run-state-and-neutral-audit";
+  run: {
+    status: string;
+    terminalState?: string;
+    recoveryClassification:
+      | "recoverable"
+      | "terminal"
+      | "approval-required"
+      | "blocked"
+      | "manual-repair-needed";
+    replayAction:
+      | "resume-from-projected-state"
+      | "do-not-replay"
+      | "operator-review-required";
+  };
+  trigger: {
+    idempotencyKeyBound: boolean;
+    keyExported: false;
+  };
+  stepHistory: AuditEvidenceExportRecoveryReplayStep[];
+}
+
+export interface AuditEvidenceExportRecoveryReplayStep {
+  stepId: string;
+  attempt: number;
+  status: string;
+  auditEventIds: string[];
+  retry?: {
+    retryable: boolean;
+    nextAttemptAt?: string;
+    reasonExported: false;
+  };
+  recovery?: {
+    state: string;
+    decision: string;
+    reasonExported: false;
+  };
+  approval?: {
+    state: string;
+    inputRef?: string;
+    decidedAt?: string;
+    reasonExported: false;
+    decidedByExported: false;
+  };
+  evidenceRefIds: string[];
+}
+
 type EvidenceDataClassification =
   | "public"
   | "internal"
@@ -166,11 +225,21 @@ export const createAuditEvidenceExport = async (
         name: "ensen-protocol",
         version: "0.4.0"
       },
+      protocolEvidenceProfileSnapshot: {
+        name: "ensen-protocol",
+        version: "0.3.0",
+        profile: "operational-evidence-profile.v1"
+      },
+      trackBBoundarySnapshot: {
+        name: "ensen-protocol",
+        version: "0.4.0",
+        boundary: "Track B customer-regulated data classification"
+      },
       protocolEvidenceProfile: "operational-evidence-profile.v1",
       notes: [
         "This is a deterministic local metadata export skeleton.",
         "It is not a production evidence archive, compliance bundle, or customer data export.",
-        "It uses the copied Protocol v0.4.0 operational evidence and Track B classification vocabulary without claiming protocol conformance, regulated workflow execution, or production evidence readiness."
+        "It uses copied Protocol v0.3.0 operational evidence profile and Protocol v0.4.0 Track B boundary snapshots without runtime protocol imports, protocol conformance claims, regulated workflow execution, or production evidence readiness."
       ]
     },
     publicSafe: {
@@ -219,6 +288,7 @@ export const createAuditEvidenceExport = async (
       steps: summarizeStepAttempts(state),
       auditEvents: auditEvents.map(summarizeAuditEvent),
       evidenceRefs: collectPublicEvidenceRefs(state, diagnostics),
+      recoveryReplay: createRecoveryReplaySummary(state, auditEvents),
       diagnostics
     },
     localConfidentialReferences: {
@@ -348,6 +418,189 @@ const summarizeAuditEvent = (
       }),
   ...(event.outcome === undefined ? {} : { outcomeStatus: event.outcome.status })
 });
+
+const createRecoveryReplaySummary = (
+  state: WorkflowRunState,
+  auditEvents: NeutralAuditEvent[]
+): AuditEvidenceExportRecoveryReplay => {
+  const recoveryClassification = classifyRecoveryReplay(state);
+
+  return {
+    source: "workflow-run-state-and-neutral-audit",
+    run: {
+      status: state.run.status,
+      ...(state.run.terminalState === undefined
+        ? {}
+        : { terminalState: state.run.terminalState }),
+      recoveryClassification,
+      replayAction: recoveryReplayAction(recoveryClassification)
+    },
+    trigger: {
+      idempotencyKeyBound: state.run.trigger.idempotencyKey !== undefined,
+      keyExported: false
+    },
+    stepHistory: Object.entries(state.stepAttempts).flatMap(([stepId, attempts]) =>
+      attempts.map((attempt) => summarizeRecoveryReplayStep(stepId, attempt, auditEvents))
+    )
+  };
+};
+
+const summarizeRecoveryReplayStep = (
+  stepId: string,
+  attempt: WorkflowStepAttemptEventSummary,
+  auditEvents: NeutralAuditEvent[]
+): AuditEvidenceExportRecoveryReplayStep => {
+  const approval = approvalSummaryFromAttempt(attempt);
+  const evidenceRefIds = evidenceRefIdsFromAttempt(attempt);
+
+  return {
+    stepId,
+    attempt: attempt.attempt,
+    status: attempt.status,
+    auditEventIds: auditEvents
+      .filter((event) => event.step?.id === stepId && event.step.attempt === attempt.attempt)
+      .map((event) => event.id),
+    ...(attempt.retry === undefined
+      ? {}
+      : {
+          retry: {
+            retryable: attempt.retry.retryable,
+            ...(attempt.retry.nextAttemptAt === undefined
+              ? {}
+              : { nextAttemptAt: attempt.retry.nextAttemptAt }),
+            reasonExported: false
+          }
+        }),
+    ...(attempt.recovery === undefined
+      ? {}
+      : {
+          recovery: {
+            state: attempt.recovery.state,
+            decision: attempt.recovery.decision,
+            reasonExported: false
+          }
+        }),
+    ...(approval === undefined ? {} : { approval }),
+    evidenceRefIds
+  };
+};
+
+type WorkflowStepAttemptEventSummary = WorkflowRunState["stepAttempts"][string][number];
+
+const approvalSummaryFromAttempt = (
+  attempt: WorkflowStepAttemptEventSummary
+): AuditEvidenceExportRecoveryReplayStep["approval"] | undefined => {
+  const approval = findApprovalCheckpoint(attempt.result);
+  if (approval === undefined) {
+    return undefined;
+  }
+
+  return {
+    state: approval.state,
+    ...(approval.inputRef === undefined ? {} : { inputRef: approval.inputRef }),
+    ...(approval.decidedAt === undefined ? {} : { decidedAt: approval.decidedAt }),
+    reasonExported: false,
+    decidedByExported: false
+  };
+};
+
+const findApprovalCheckpoint = (
+  value: unknown
+): { state: string; inputRef?: string; decidedAt?: string } | undefined => {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const nested = findApprovalCheckpoint(item);
+      if (nested !== undefined) {
+        return nested;
+      }
+    }
+
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  if (value.schemaVersion === "flow.approval-checkpoint.v1" && typeof value.state === "string") {
+    return {
+      state: value.state,
+      ...(typeof value.inputRef === "string" && isPublicSafeRelativeRef(value.inputRef)
+        ? { inputRef: value.inputRef }
+        : {}),
+      ...(typeof value.decidedAt === "string" ? { decidedAt: value.decidedAt } : {})
+    };
+  }
+
+  for (const nestedValue of Object.values(value)) {
+    const nested = findApprovalCheckpoint(nestedValue);
+    if (nested !== undefined) {
+      return nested;
+    }
+  }
+
+  return undefined;
+};
+
+const evidenceRefIdsFromAttempt = (attempt: WorkflowStepAttemptEventSummary): string[] => {
+  if (attempt.result === undefined) {
+    return [];
+  }
+
+  const refs: AuditEvidenceExportEvidenceRef[] = [];
+  collectEvidenceRefsFromValue(attempt.result, refs, []);
+  return refs.map((ref) => ref.id);
+};
+
+const classifyRecoveryReplay = (
+  state: WorkflowRunState
+): AuditEvidenceExportRecoveryReplay["run"]["recoveryClassification"] => {
+  if (state.run.terminalState === "failed" && hasLatestStepStatus(state, "blocked")) {
+    return "blocked";
+  }
+
+  if (state.run.terminalState !== undefined) {
+    return "terminal";
+  }
+
+  if (hasLatestStepStatus(state, "running")) {
+    return "manual-repair-needed";
+  }
+
+  if (hasLatestStepStatus(state, "approval-required")) {
+    return "approval-required";
+  }
+
+  if (hasLatestStepStatus(state, "blocked")) {
+    return "blocked";
+  }
+
+  if (hasLatestStepStatus(state, "failed")) {
+    return "manual-repair-needed";
+  }
+
+  return "recoverable";
+};
+
+const recoveryReplayAction = (
+  classification: AuditEvidenceExportRecoveryReplay["run"]["recoveryClassification"]
+): AuditEvidenceExportRecoveryReplay["run"]["replayAction"] => {
+  if (classification === "terminal") {
+    return "do-not-replay";
+  }
+
+  if (classification === "recoverable") {
+    return "resume-from-projected-state";
+  }
+
+  return "operator-review-required";
+};
+
+const hasLatestStepStatus = (
+  state: WorkflowRunState,
+  status: WorkflowStepAttemptEventSummary["status"]
+): boolean =>
+  Object.values(state.stepAttempts).some((attempts) => attempts.at(-1)?.status === status);
 
 const collectPublicEvidenceRefs = (
   state: WorkflowRunState,
@@ -524,6 +777,9 @@ const isSafeRelativePath = (value: string): boolean => {
     !trimmed.split(/[\\/]+/u).includes("..")
   );
 };
+
+const isPublicSafeRelativeRef = (value: string): boolean =>
+  isSafeRelativePath(value) && classifyUnsafeWorkflowArtifactString(value) === undefined;
 
 const createUnsafeEvidenceRefDiagnostic = (ref: NormalizedEvidenceRef): string => {
   if (ref.dataClassification === undefined) {

--- a/src/audit-evidence-export.ts
+++ b/src/audit-evidence-export.ts
@@ -191,6 +191,11 @@ type NormalizedEvidenceRef = Omit<
   referenceKind: "publicSafeArtifactReference" | "localConfidentialReference";
 };
 
+interface AuditEvidenceExportRunScope {
+  runId: string;
+  workflowId: string;
+}
+
 export interface AuditEvidenceExportLocalConfidentialReferences {
   statePath: AuditEvidenceExportLocalReference;
   auditPath?: AuditEvidenceExportLocalReference;
@@ -434,6 +439,10 @@ const createRecoveryReplaySummary = (
   auditEvents: NeutralAuditEvent[]
 ): AuditEvidenceExportRecoveryReplay => {
   const recoveryClassification = classifyRecoveryReplay(state);
+  const runScope: AuditEvidenceExportRunScope = {
+    runId: state.run.runId,
+    workflowId: state.run.workflowId
+  };
 
   return {
     source: "workflow-run-state-and-neutral-audit",
@@ -450,12 +459,15 @@ const createRecoveryReplaySummary = (
       keyExported: false
     },
     stepHistory: Object.entries(state.stepAttempts).flatMap(([stepId, attempts]) =>
-      attempts.map((attempt) => summarizeRecoveryReplayStep(stepId, attempt, auditEvents))
+      attempts.map((attempt) =>
+        summarizeRecoveryReplayStep(runScope, stepId, attempt, auditEvents)
+      )
     )
   };
 };
 
 const summarizeRecoveryReplayStep = (
+  runScope: AuditEvidenceExportRunScope,
   stepId: string,
   attempt: WorkflowStepAttemptEventSummary,
   auditEvents: NeutralAuditEvent[]
@@ -468,7 +480,13 @@ const summarizeRecoveryReplayStep = (
     attempt: attempt.attempt,
     status: attempt.status,
     auditEventIds: auditEvents
-      .filter((event) => event.step?.id === stepId && event.step.attempt === attempt.attempt)
+      .filter(
+        (event) =>
+          event.run.id === runScope.runId &&
+          event.workflow.id === runScope.workflowId &&
+          event.step?.id === stepId &&
+          event.step.attempt === attempt.attempt
+      )
       .map((event) => event.id),
     ...(attempt.retry === undefined
       ? {}

--- a/src/audit-evidence-export.ts
+++ b/src/audit-evidence-export.ts
@@ -573,9 +573,7 @@ const findApprovalCheckpoint = (
 
     return {
       state: value.state,
-      ...(typeof value.inputRef === "string" && isPublicSafeRelativeRef(value.inputRef)
-        ? { inputRef: value.inputRef }
-        : {}),
+      ...approvalInputRefExport(value),
       ...(typeof value.decidedAt === "string" && isStrictUtcMillisTimestamp(value.decidedAt)
         ? { decidedAt: value.decidedAt }
         : {})
@@ -590,6 +588,20 @@ const findApprovalCheckpoint = (
   }
 
   return undefined;
+};
+
+const approvalInputRefExport = (
+  value: Record<string, unknown>
+): { inputRef: string } | Record<string, never> => {
+  if (
+    typeof value.inputRef !== "string" ||
+    value.inputRefDataClassification !== "public" ||
+    !isPublicSafeRelativeRef(value.inputRef)
+  ) {
+    return {};
+  }
+
+  return { inputRef: value.inputRef };
 };
 
 const isExportableApprovalState = (

--- a/src/audit-evidence-export.ts
+++ b/src/audit-evidence-export.ts
@@ -166,7 +166,7 @@ export interface AuditEvidenceExportRecoveryReplayStep {
     reasonExported: false;
   };
   approval?: {
-    state: string;
+    state: AuditEvidenceExportApprovalState;
     inputRef?: string;
     decidedAt?: string;
     reasonExported: false;
@@ -182,6 +182,7 @@ type EvidenceDataClassification =
   | "customer-confidential"
   | "regulated"
   | "restricted";
+export type AuditEvidenceExportApprovalState = "approval-required" | "approved" | "rejected";
 
 type NormalizedEvidenceRef = Omit<
   AuditEvidenceExportEvidenceRef,
@@ -194,6 +195,7 @@ type NormalizedEvidenceRef = Omit<
 interface AuditEvidenceExportRunScope {
   runId: string;
   workflowId: string;
+  workflowVersion: string;
 }
 
 export interface AuditEvidenceExportLocalConfidentialReferences {
@@ -210,6 +212,11 @@ export interface AuditEvidenceExportLocalReference {
 const EXPORT_SCHEMA_VERSION = "flow.audit-evidence-export.v1";
 const EVIDENCE_REF_SCHEMA_VERSION = "eip.evidence-bundle-ref.v1";
 const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/;
+const EXPORTABLE_APPROVAL_STATES = new Set<AuditEvidenceExportApprovalState>([
+  "approval-required",
+  "approved",
+  "rejected"
+]);
 
 export const createAuditEvidenceExport = async (
   input: CreateAuditEvidenceExportInput
@@ -335,7 +342,9 @@ const filterAuditEventsForRun = (
 ): NeutralAuditEvent[] =>
   auditEvents.filter(
     (event) =>
-      event.run.id === state.run.runId && event.workflow.id === state.run.workflowId
+      event.run.id === state.run.runId &&
+      event.workflow.id === state.run.workflowId &&
+      event.workflow.version === state.run.workflowVersion
   );
 
 const summarizeStepAttempts = (
@@ -392,6 +401,7 @@ const validateNeutralAuditEventForExport = (
     typeof value.occurredAt !== "string" ||
     !isRecord(value.workflow) ||
     typeof value.workflow.id !== "string" ||
+    typeof value.workflow.version !== "string" ||
     !isRecord(value.run) ||
     typeof value.run.id !== "string"
   ) {
@@ -441,7 +451,8 @@ const createRecoveryReplaySummary = (
   const recoveryClassification = classifyRecoveryReplay(state);
   const runScope: AuditEvidenceExportRunScope = {
     runId: state.run.runId,
-    workflowId: state.run.workflowId
+    workflowId: state.run.workflowId,
+    workflowVersion: state.run.workflowVersion
   };
 
   return {
@@ -484,6 +495,7 @@ const summarizeRecoveryReplayStep = (
         (event) =>
           event.run.id === runScope.runId &&
           event.workflow.id === runScope.workflowId &&
+          event.workflow.version === runScope.workflowVersion &&
           event.step?.id === stepId &&
           event.step.attempt === attempt.attempt
       )
@@ -534,7 +546,9 @@ const approvalSummaryFromAttempt = (
 
 const findApprovalCheckpoint = (
   value: unknown
-): { state: string; inputRef?: string; decidedAt?: string } | undefined => {
+):
+  | { state: AuditEvidenceExportApprovalState; inputRef?: string; decidedAt?: string }
+  | undefined => {
   if (Array.isArray(value)) {
     for (const item of value) {
       const nested = findApprovalCheckpoint(item);
@@ -550,7 +564,11 @@ const findApprovalCheckpoint = (
     return undefined;
   }
 
-  if (value.schemaVersion === "flow.approval-checkpoint.v1" && typeof value.state === "string") {
+  if (value.schemaVersion === "flow.approval-checkpoint.v1") {
+    if (!isExportableApprovalState(value.state)) {
+      return undefined;
+    }
+
     return {
       state: value.state,
       ...(typeof value.inputRef === "string" && isPublicSafeRelativeRef(value.inputRef)
@@ -569,6 +587,12 @@ const findApprovalCheckpoint = (
 
   return undefined;
 };
+
+const isExportableApprovalState = (
+  value: unknown
+): value is AuditEvidenceExportApprovalState =>
+  typeof value === "string" &&
+  EXPORTABLE_APPROVAL_STATES.has(value as AuditEvidenceExportApprovalState);
 
 const evidenceRefIdsFromAttempt = (attempt: WorkflowStepAttemptEventSummary): string[] => {
   if (attempt.result === undefined) {

--- a/src/audit-evidence-export.ts
+++ b/src/audit-evidence-export.ts
@@ -217,6 +217,7 @@ export const createAuditEvidenceExport = async (
       : await readNeutralAuditEvents(input.auditPath).catch((error: unknown) => {
           throw new Error(`audit event export failed: ${safeErrorMessage(error)}`);
         });
+  const runAuditEvents = filterAuditEventsForRun(state, auditEvents);
   const exportArtifact: AuditEvidenceExport = {
     schemaVersion: EXPORT_SCHEMA_VERSION,
     boundary: {
@@ -286,9 +287,9 @@ export const createAuditEvidenceExport = async (
             })
       },
       steps: summarizeStepAttempts(state),
-      auditEvents: auditEvents.map(summarizeAuditEvent),
+      auditEvents: runAuditEvents.map(summarizeAuditEvent),
       evidenceRefs: collectPublicEvidenceRefs(state, diagnostics),
-      recoveryReplay: createRecoveryReplaySummary(state, auditEvents),
+      recoveryReplay: createRecoveryReplaySummary(state, runAuditEvents),
       diagnostics
     },
     localConfidentialReferences: {
@@ -322,6 +323,15 @@ export const createAuditEvidenceExport = async (
 
   return exportArtifact;
 };
+
+const filterAuditEventsForRun = (
+  state: WorkflowRunState,
+  auditEvents: NeutralAuditEvent[]
+): NeutralAuditEvent[] =>
+  auditEvents.filter(
+    (event) =>
+      event.run.id === state.run.runId && event.workflow.id === state.run.workflowId
+  );
 
 const summarizeStepAttempts = (
   state: WorkflowRunState

--- a/src/audit-evidence-export.ts
+++ b/src/audit-evidence-export.ts
@@ -342,11 +342,12 @@ const filterAuditEventsForRun = (
   state: WorkflowRunState,
   auditEvents: NeutralAuditEvent[]
 ): NeutralAuditEvent[] =>
-  auditEvents.filter(
-    (event) =>
-      event.run.id === state.run.runId &&
-      event.workflow.id === state.run.workflowId &&
-      event.workflow.version === state.run.workflowVersion
+  auditEvents.filter((event) =>
+    auditEventMatchesRunScope(event, {
+      runId: state.run.runId,
+      workflowId: state.run.workflowId,
+      workflowVersion: state.run.workflowVersion
+    })
   );
 
 const summarizeStepAttempts = (
@@ -495,9 +496,7 @@ const summarizeRecoveryReplayStep = (
     auditEventIds: auditEvents
       .filter(
         (event) =>
-          event.run.id === runScope.runId &&
-          event.workflow.id === runScope.workflowId &&
-          event.workflow.version === runScope.workflowVersion &&
+          auditEventMatchesRunScope(event, runScope) &&
           event.step?.id === stepId &&
           event.step.attempt === attempt.attempt
       )
@@ -567,12 +566,13 @@ const findApprovalCheckpoint = (
   }
 
   if (value.schemaVersion === "flow.approval-checkpoint.v1") {
-    if (!isExportableApprovalState(value.state)) {
+    const state = normalizeApprovalState(value.state);
+    if (state === undefined) {
       return undefined;
     }
 
     return {
-      state: value.state,
+      state,
       ...approvalInputRefExport(value),
       ...(typeof value.decidedAt === "string" && isStrictUtcMillisTimestamp(value.decidedAt)
         ? { decidedAt: value.decidedAt }
@@ -604,11 +604,26 @@ const approvalInputRefExport = (
   return { inputRef: value.inputRef };
 };
 
-const isExportableApprovalState = (
+const auditEventMatchesRunScope = (
+  event: NeutralAuditEvent,
+  runScope: AuditEvidenceExportRunScope
+): boolean =>
+  event.run.id === runScope.runId &&
+  event.workflow.id === runScope.workflowId &&
+  event.workflow.version === runScope.workflowVersion;
+
+const normalizeApprovalState = (
   value: unknown
-): value is AuditEvidenceExportApprovalState =>
-  typeof value === "string" &&
-  EXPORTABLE_APPROVAL_STATES.has(value as AuditEvidenceExportApprovalState);
+): AuditEvidenceExportApprovalState | undefined => {
+  if (
+    typeof value === "string" &&
+    EXPORTABLE_APPROVAL_STATES.has(value as AuditEvidenceExportApprovalState)
+  ) {
+    return value as AuditEvidenceExportApprovalState;
+  }
+
+  return undefined;
+};
 
 const isStrictUtcMillisTimestamp = (value: string): boolean => {
   if (!ISO_UTC_MILLIS_TIMESTAMP_PATTERN.test(value)) {

--- a/src/audit-evidence-export.ts
+++ b/src/audit-evidence-export.ts
@@ -212,6 +212,8 @@ export interface AuditEvidenceExportLocalReference {
 const EXPORT_SCHEMA_VERSION = "flow.audit-evidence-export.v1";
 const EVIDENCE_REF_SCHEMA_VERSION = "eip.evidence-bundle-ref.v1";
 const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/;
+const ISO_UTC_MILLIS_TIMESTAMP_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 const EXPORTABLE_APPROVAL_STATES = new Set<AuditEvidenceExportApprovalState>([
   "approval-required",
   "approved",
@@ -574,7 +576,9 @@ const findApprovalCheckpoint = (
       ...(typeof value.inputRef === "string" && isPublicSafeRelativeRef(value.inputRef)
         ? { inputRef: value.inputRef }
         : {}),
-      ...(typeof value.decidedAt === "string" ? { decidedAt: value.decidedAt } : {})
+      ...(typeof value.decidedAt === "string" && isStrictUtcMillisTimestamp(value.decidedAt)
+        ? { decidedAt: value.decidedAt }
+        : {})
     };
   }
 
@@ -593,6 +597,15 @@ const isExportableApprovalState = (
 ): value is AuditEvidenceExportApprovalState =>
   typeof value === "string" &&
   EXPORTABLE_APPROVAL_STATES.has(value as AuditEvidenceExportApprovalState);
+
+const isStrictUtcMillisTimestamp = (value: string): boolean => {
+  if (!ISO_UTC_MILLIS_TIMESTAMP_PATTERN.test(value)) {
+    return false;
+  }
+
+  const parsed = new Date(value);
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString() === value;
+};
 
 const evidenceRefIdsFromAttempt = (attempt: WorkflowStepAttemptEventSummary): string[] => {
   if (attempt.result === undefined) {

--- a/src/controlled-pilot-package.ts
+++ b/src/controlled-pilot-package.ts
@@ -335,6 +335,7 @@ const createPendingApprovalCheckpoint = (input: {
   state: "approval-required" as const,
   reason: "human approval checkpoint is required before notification",
   inputRef: input.inputRef,
+  inputRefDataClassification: "public",
   inputFingerprint: input.inputFingerprint
 });
 
@@ -348,6 +349,7 @@ const createRecordedApprovalCheckpoint = (
   decidedAt: approval.decidedAt,
   reason: approval.reason,
   inputRef: approval.inputRef,
+  inputRefDataClassification: "public",
   inputFingerprint: approval.inputFingerprint
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,6 +199,8 @@ export type {
   AuditEvidenceExportLocalConfidentialReferences,
   AuditEvidenceExportLocalReference,
   AuditEvidenceExportPublicSafe,
+  AuditEvidenceExportRecoveryReplay,
+  AuditEvidenceExportRecoveryReplayStep,
   AuditEvidenceExportStepSummary,
   CreateAuditEvidenceExportInput
 } from "./audit-evidence-export.js";

--- a/test/audit-event-writer.test.ts
+++ b/test/audit-event-writer.test.ts
@@ -598,6 +598,67 @@ describe("neutral audit event writer", () => {
     expect(JSON.stringify(exported.publicSafe)).not.toContain("raw-customer-approval-note");
   });
 
+  it("does not export malformed approval decision timestamps from generic step results", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
+    tempRoots.push(stateRoot);
+    const statePath = join(stateRoot, "runs", "malformed-approval-decided-at.jsonl");
+
+    await createWorkflowRun(statePath, {
+      runId: "malformed-approval-decided-at",
+      workflowId: "local-manual-demo",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z"
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "malformed-approval-decided-at",
+      stepId: "generic-step",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:02.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.completed",
+      runId: "malformed-approval-decided-at",
+      stepId: "generic-step",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:03.000Z",
+      result: {
+        metadata: {
+          approvalCheckpoint: {
+            schemaVersion: "flow.approval-checkpoint.v1",
+            state: "approved",
+            inputRef: "fixtures/manual-review/input.json",
+            decidedAt: "not-a-timestamp"
+          }
+        }
+      }
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "run.completed",
+      runId: "malformed-approval-decided-at",
+      terminalState: "succeeded",
+      occurredAt: "2026-04-29T00:00:04.000Z"
+    });
+
+    const exported = await createAuditEvidenceExport({ statePath });
+
+    expect(exported.publicSafe.recoveryReplay.stepHistory).toEqual([
+      expect.objectContaining({
+        approval: {
+          state: "approved",
+          inputRef: "fixtures/manual-review/input.json",
+          reasonExported: false,
+          decidedByExported: false
+        }
+      })
+    ]);
+    expect(JSON.stringify(exported.publicSafe)).not.toContain("not-a-timestamp");
+  });
+
   it("rejects extra export-audit-evidence CLI arguments", async () => {
     const originalError = console.error;
     const errors: string[] = [];

--- a/test/audit-event-writer.test.ts
+++ b/test/audit-event-writer.test.ts
@@ -542,6 +542,62 @@ describe("neutral audit event writer", () => {
     );
   });
 
+  it("does not export unknown approval checkpoint states from generic step results", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
+    tempRoots.push(stateRoot);
+    const statePath = join(stateRoot, "runs", "unknown-approval-state.jsonl");
+
+    await createWorkflowRun(statePath, {
+      runId: "unknown-approval-state",
+      workflowId: "local-manual-demo",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z"
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "unknown-approval-state",
+      stepId: "generic-step",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:02.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.completed",
+      runId: "unknown-approval-state",
+      stepId: "generic-step",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:03.000Z",
+      result: {
+        metadata: {
+          approvalCheckpoint: {
+            schemaVersion: "flow.approval-checkpoint.v1",
+            state: "raw-customer-approval-note",
+            inputRef: "fixtures/manual-review/input.json",
+            decidedAt: "2026-04-29T00:00:03.000Z"
+          }
+        }
+      }
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "run.completed",
+      runId: "unknown-approval-state",
+      terminalState: "succeeded",
+      occurredAt: "2026-04-29T00:00:04.000Z"
+    });
+
+    const exported = await createAuditEvidenceExport({ statePath });
+
+    expect(exported.publicSafe.recoveryReplay.stepHistory).toEqual([
+      expect.not.objectContaining({
+        approval: expect.anything()
+      })
+    ]);
+    expect(JSON.stringify(exported.publicSafe)).not.toContain("raw-customer-approval-note");
+  });
+
   it("rejects extra export-audit-evidence CLI arguments", async () => {
     const originalError = console.error;
     const errors: string[] = [];

--- a/test/audit-event-writer.test.ts
+++ b/test/audit-event-writer.test.ts
@@ -598,6 +598,67 @@ describe("neutral audit event writer", () => {
     expect(JSON.stringify(exported.publicSafe)).not.toContain("raw-customer-approval-note");
   });
 
+  it("does not export unclassified approval input refs from generic step results", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
+    tempRoots.push(stateRoot);
+    const statePath = join(stateRoot, "runs", "unclassified-approval-input-ref.jsonl");
+
+    await createWorkflowRun(statePath, {
+      runId: "unclassified-approval-input-ref",
+      workflowId: "local-manual-demo",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z"
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "unclassified-approval-input-ref",
+      stepId: "generic-step",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:02.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.completed",
+      runId: "unclassified-approval-input-ref",
+      stepId: "generic-step",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:03.000Z",
+      result: {
+        metadata: {
+          approvalCheckpoint: {
+            schemaVersion: "flow.approval-checkpoint.v1",
+            state: "approved",
+            inputRef: "approvals/acme-contract.json",
+            decidedAt: "2026-04-29T00:00:03.000Z"
+          }
+        }
+      }
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "run.completed",
+      runId: "unclassified-approval-input-ref",
+      terminalState: "succeeded",
+      occurredAt: "2026-04-29T00:00:04.000Z"
+    });
+
+    const exported = await createAuditEvidenceExport({ statePath });
+
+    expect(exported.publicSafe.recoveryReplay.stepHistory).toEqual([
+      expect.objectContaining({
+        approval: {
+          state: "approved",
+          decidedAt: "2026-04-29T00:00:03.000Z",
+          reasonExported: false,
+          decidedByExported: false
+        }
+      })
+    ]);
+    expect(JSON.stringify(exported.publicSafe)).not.toContain("approvals/acme-contract.json");
+  });
+
   it("does not export malformed approval decision timestamps from generic step results", async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
     tempRoots.push(stateRoot);
@@ -632,6 +693,7 @@ describe("neutral audit event writer", () => {
             schemaVersion: "flow.approval-checkpoint.v1",
             state: "approved",
             inputRef: "fixtures/manual-review/input.json",
+            inputRefDataClassification: "public",
             decidedAt: "not-a-timestamp"
           }
         }

--- a/test/audit-event-writer.test.ts
+++ b/test/audit-event-writer.test.ts
@@ -270,6 +270,98 @@ describe("neutral audit event writer", () => {
     );
   });
 
+  it("filters audit summaries and replay IDs by run, workflow, and version", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
+    const auditRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
+    tempRoots.push(stateRoot, auditRoot);
+    const statePath = join(stateRoot, "runs", "scoped-audit-replay.jsonl");
+    const auditPath = join(auditRoot, "audit", "scoped-audit-replay.audit.jsonl");
+
+    await createWorkflowRun(statePath, {
+      runId: "deterministic-run",
+      workflowId: "local-manual-demo",
+      workflowVersion: "flow.workflow.v2",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z",
+        context: {}
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "deterministic-run",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:02.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.completed",
+      runId: "deterministic-run",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:03.000Z",
+      result: { ok: true }
+    });
+
+    const scopedAuditEvent = (
+      id: string,
+      scope: { runId: string; workflowId: string; workflowVersion: string }
+    ) => ({
+      id,
+      type: "step.completed",
+      occurredAt: "2026-04-29T00:00:03.000Z",
+      actor: { type: "system", id: "ensen-flow.local-runner" },
+      source: { type: "runner", id: "ensen-flow.local-runner" },
+      workflow: { id: scope.workflowId, version: scope.workflowVersion },
+      run: { id: scope.runId },
+      step: { id: "collect-input", attempt: 1 },
+      outcome: { status: "succeeded" }
+    });
+    await mkdir(dirname(auditPath), { recursive: true });
+    await writeFile(
+      auditPath,
+      [
+        scopedAuditEvent("audit.deterministic-run.000001", {
+          runId: "deterministic-run",
+          workflowId: "local-manual-demo",
+          workflowVersion: "flow.workflow.v2"
+        }),
+        scopedAuditEvent("audit.other-run.000001", {
+          runId: "other-run",
+          workflowId: "local-manual-demo",
+          workflowVersion: "flow.workflow.v2"
+        }),
+        scopedAuditEvent("audit.deterministic-run.000002", {
+          runId: "deterministic-run",
+          workflowId: "other-workflow",
+          workflowVersion: "flow.workflow.v2"
+        }),
+        scopedAuditEvent("audit.deterministic-run.000003", {
+          runId: "deterministic-run",
+          workflowId: "local-manual-demo",
+          workflowVersion: "flow.workflow.v1"
+        })
+      ]
+        .map((event) => JSON.stringify(event))
+        .join("\n") + "\n",
+      "utf8"
+    );
+
+    const exported = await createAuditEvidenceExport({ statePath, auditPath });
+
+    expect(exported.publicSafe.auditEvents.map((event) => event.id)).toEqual([
+      "audit.deterministic-run.000001"
+    ]);
+    expect(exported.publicSafe.recoveryReplay.stepHistory).toEqual([
+      expect.objectContaining({
+        stepId: "collect-input",
+        attempt: 1,
+        auditEventIds: ["audit.deterministic-run.000001"]
+      })
+    ]);
+  });
+
   it("omits non-public evidence paths from public-safe exports", async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
     tempRoots.push(stateRoot);

--- a/test/audit-event-writer.test.ts
+++ b/test/audit-event-writer.test.ts
@@ -362,6 +362,64 @@ describe("neutral audit event writer", () => {
     ]);
   });
 
+  it("treats manual-repair-needed step attempts as non-recoverable in replay export", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
+    tempRoots.push(stateRoot);
+    const statePath = join(stateRoot, "runs", "manual-repair-needed.jsonl");
+
+    await createWorkflowRun(statePath, {
+      runId: "manual-repair-needed",
+      workflowId: "local-manual-demo",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z",
+        context: {}
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "manual-repair-needed",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:02.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.failed",
+      runId: "manual-repair-needed",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:03.000Z",
+      retry: {
+        retryable: false,
+        reason: "Operator must repair external state before replay."
+      },
+      recovery: {
+        state: "manual-repair-needed",
+        decision: "manual-repair-needed",
+        reason: "Operator must repair external state before replay."
+      }
+    });
+
+    const exported = await createAuditEvidenceExport({ statePath });
+
+    expect(exported.publicSafe.recoveryReplay).toMatchObject({
+      run: {
+        status: "running",
+        recoveryClassification: "manual-repair-needed",
+        replayAction: "operator-review-required"
+      },
+      stepHistory: [
+        expect.objectContaining({
+          stepId: "collect-input",
+          attempt: 1,
+          status: "manual-repair-needed"
+        })
+      ]
+    });
+  });
+
   it("omits non-public evidence paths from public-safe exports", async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
     tempRoots.push(stateRoot);

--- a/test/controlled-pilot-package.test.ts
+++ b/test/controlled-pilot-package.test.ts
@@ -801,9 +801,23 @@ describe("selected controlled pilot dry-run package", () => {
         outcome: { status: "succeeded" }
       },
       {
-        id: `audit.${approved.run.runId}.999999`,
+        id: `audit.${approved.run.runId}.999998`,
         type: "step.completed",
         occurredAt: "2026-05-30T00:00:11.000Z",
+        actor: { type: "system", id: "ensen-flow.local-runner" },
+        source: { type: "runner", id: "ensen-flow.local-runner" },
+        workflow: {
+          id: approved.run.workflowId,
+          version: "flow.workflow.other-version"
+        },
+        run: { id: approved.run.runId },
+        step: { id: "human-approval", attempt: 1 },
+        outcome: { status: "succeeded" }
+      },
+      {
+        id: `audit.${approved.run.runId}.999999`,
+        type: "step.completed",
+        occurredAt: "2026-05-30T00:00:12.000Z",
         actor: { type: "system", id: "ensen-flow.local-runner" },
         source: { type: "runner", id: "ensen-flow.local-runner" },
         workflow: {
@@ -906,6 +920,7 @@ describe("selected controlled pilot dry-run package", () => {
     expect(approvedExport.publicSafe.auditEvents.map((event) => event.id)).not.toEqual(
       expect.arrayContaining([
         "audit.other-controlled-pilot-run.000001",
+        `audit.${approved.run.runId}.999998`,
         `audit.${approved.run.runId}.999999`
       ])
     );

--- a/test/controlled-pilot-package.test.ts
+++ b/test/controlled-pilot-package.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -785,6 +785,43 @@ describe("selected controlled pilot dry-run package", () => {
       ])
     });
     const approvedStatePath = join(approvedStateRoot, `${approved.run.runId}.jsonl`);
+    const aggregateAuditEvents = [
+      {
+        id: "audit.other-controlled-pilot-run.000001",
+        type: "step.completed",
+        occurredAt: "2026-05-30T00:00:10.000Z",
+        actor: { type: "system", id: "ensen-flow.local-runner" },
+        source: { type: "runner", id: "ensen-flow.local-runner" },
+        workflow: {
+          id: approved.run.workflowId,
+          version: approved.run.workflowVersion
+        },
+        run: { id: "other-controlled-pilot-run" },
+        step: { id: "human-approval", attempt: 1 },
+        outcome: { status: "succeeded" }
+      },
+      {
+        id: `audit.${approved.run.runId}.999999`,
+        type: "step.completed",
+        occurredAt: "2026-05-30T00:00:11.000Z",
+        actor: { type: "system", id: "ensen-flow.local-runner" },
+        source: { type: "runner", id: "ensen-flow.local-runner" },
+        workflow: {
+          id: "other-controlled-pilot-workflow",
+          version: approved.run.workflowVersion
+        },
+        run: { id: approved.run.runId },
+        step: { id: "human-approval", attempt: 1 },
+        outcome: { status: "succeeded" }
+      }
+    ];
+    await writeFile(
+      approvedAuditPath,
+      `${await readFile(approvedAuditPath, "utf8")}${aggregateAuditEvents
+        .map((event) => JSON.stringify(event))
+        .join("\n")}\n`,
+      "utf8"
+    );
 
     const approvedExport = await createAuditEvidenceExport({
       statePath: approvedStatePath,
@@ -866,6 +903,12 @@ describe("selected controlled pilot dry-run package", () => {
         `audit.${approved.run.runId}.000008`
       ]
     ]);
+    expect(approvedExport.publicSafe.auditEvents.map((event) => event.id)).not.toEqual(
+      expect.arrayContaining([
+        "audit.other-controlled-pilot-run.000001",
+        `audit.${approved.run.runId}.999999`
+      ])
+    );
     expect(JSON.stringify(approvedExport.publicSafe)).not.toContain(
       "local fake endpoint temporarily unavailable"
     );

--- a/test/controlled-pilot-package.test.ts
+++ b/test/controlled-pilot-package.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { runCli } from "../src/cli.js";
 import {
+  createAuditEvidenceExport,
   createControlledPilotInputFingerprint,
   createFakeHttpNotificationTransport,
   readWorkflowRunState,
@@ -733,6 +734,194 @@ describe("selected controlled pilot dry-run package", () => {
     await expect(readFile(auditPath, "utf8")).resolves.toBe(auditBeforeReplay);
     expect(await readWorkflowRunState(statePath)).toEqual(first);
     expect((transport as FakeHttpNotificationTransport).deliveries).toHaveLength(1);
+  });
+
+  it("exports public-safe pilot recovery replay evidence for retry and approval rejection history", async () => {
+    const approvedPackage = createPilotPackage();
+    const approvedRoot = await createTempRoot();
+    const approvedStateRoot = join(approvedRoot, "runs");
+    const approvedAuditPath = join(approvedRoot, "audit", "pilot.audit.jsonl");
+    const approvedTransport = createFakeHttpNotificationTransport({
+      outcomes: [
+        {
+          status: "failed",
+          summary: "local fake endpoint temporarily unavailable",
+          retryable: true
+        },
+        {
+          status: "succeeded",
+          summary: "local fake notification accepted after retry",
+          evidence: {
+            evidenceBundleRef: {
+              schemaVersion: "eip.evidence-bundle-ref.v1",
+              id: "evb_controlled_pilot_retry",
+              correlationId: "corr_controlled_pilot_retry",
+              type: "local_path",
+              uri: "artifacts/evidence/controlled-pilot/retry-bundle.json",
+              createdAt: "2026-05-30T00:00:09.000Z",
+              dataClassification: "public"
+            }
+          }
+        }
+      ]
+    });
+
+    const approved = await runSelectedControlledPilot({
+      inputPackage: approvedPackage,
+      stateRoot: approvedStateRoot,
+      auditPath: approvedAuditPath,
+      notificationTransport: approvedTransport,
+      now: createClock([
+        "2026-05-30T00:00:00.000Z",
+        "2026-05-30T00:00:01.000Z",
+        "2026-05-30T00:00:02.000Z",
+        "2026-05-30T00:00:03.000Z",
+        "2026-05-30T00:00:04.000Z",
+        "2026-05-30T00:00:05.000Z",
+        "2026-05-30T00:00:06.000Z",
+        "2026-05-30T00:00:07.000Z",
+        "2026-05-30T00:00:08.000Z",
+        "2026-05-30T00:00:09.000Z"
+      ])
+    });
+    const approvedStatePath = join(approvedStateRoot, `${approved.run.runId}.jsonl`);
+
+    const approvedExport = await createAuditEvidenceExport({
+      statePath: approvedStatePath,
+      auditPath: approvedAuditPath
+    });
+    expect(approvedExport.boundary).toMatchObject({
+      protocolEvidenceProfileSnapshot: {
+        name: "ensen-protocol",
+        version: "0.3.0",
+        profile: "operational-evidence-profile.v1"
+      },
+      trackBBoundarySnapshot: {
+        name: "ensen-protocol",
+        version: "0.4.0",
+        boundary: "Track B customer-regulated data classification"
+      },
+      productionEvidenceReady: false
+    });
+    expect(approvedExport.publicSafe.recoveryReplay).toMatchObject({
+      source: "workflow-run-state-and-neutral-audit",
+      run: {
+        status: "succeeded",
+        terminalState: "succeeded",
+        replayAction: "do-not-replay"
+      },
+      trigger: {
+        idempotencyKeyBound: true,
+        keyExported: false
+      },
+      stepHistory: [
+        {
+          stepId: "human-approval",
+          attempt: 1,
+          status: "succeeded",
+          approval: {
+            state: "approved",
+            inputRef: "fixtures/controlled-pilot/webhook-review-notification.dry-run.json"
+          }
+        },
+        {
+          stepId: "notify-operator",
+          attempt: 1,
+          status: "retryable-failed",
+          retry: {
+            retryable: true,
+            nextAttemptAt: "2026-05-30T00:00:06.000Z",
+            reasonExported: false
+          }
+        },
+        {
+          stepId: "notify-operator",
+          attempt: 2,
+          status: "succeeded",
+          evidenceRefIds: ["evb_controlled_pilot_retry"]
+        }
+      ]
+    });
+    expect(approvedExport.publicSafe.evidenceRefs).toEqual([
+      expect.objectContaining({
+        id: "evb_controlled_pilot_retry",
+        uri: "artifacts/evidence/controlled-pilot/retry-bundle.json",
+        dataClassification: "public"
+      })
+    ]);
+    expect(
+      approvedExport.publicSafe.recoveryReplay.stepHistory.map((step) => step.auditEventIds)
+    ).toEqual([
+      [
+        `audit.${approved.run.runId}.000002`,
+        `audit.${approved.run.runId}.000003`
+      ],
+      [
+        `audit.${approved.run.runId}.000004`,
+        `audit.${approved.run.runId}.000005`,
+        `audit.${approved.run.runId}.000006`
+      ],
+      [
+        `audit.${approved.run.runId}.000007`,
+        `audit.${approved.run.runId}.000008`
+      ]
+    ]);
+    expect(JSON.stringify(approvedExport.publicSafe)).not.toContain(
+      "local fake endpoint temporarily unavailable"
+    );
+
+    const rejectedPackage = createPilotPackage();
+    rejectedPackage.approval = {
+      ...rejectedPackage.approval!,
+      state: "rejected",
+      reason: "Reject the synthetic notification dry-run for operator review."
+    };
+    const rejectedRoot = await createTempRoot();
+    const rejectedStateRoot = join(rejectedRoot, "runs");
+    const rejectedAuditPath = join(rejectedRoot, "audit", "pilot.audit.jsonl");
+
+    const rejected = await runSelectedControlledPilot({
+      inputPackage: rejectedPackage,
+      stateRoot: rejectedStateRoot,
+      auditPath: rejectedAuditPath,
+      notificationTransport: createFakeHttpNotificationTransport()
+    });
+    const rejectedExport = await createAuditEvidenceExport({
+      statePath: join(rejectedStateRoot, `${rejected.run.runId}.jsonl`),
+      auditPath: rejectedAuditPath
+    });
+
+    expect(rejectedExport.publicSafe.recoveryReplay).toMatchObject({
+      run: {
+        status: "failed",
+        terminalState: "failed",
+        recoveryClassification: "blocked",
+        replayAction: "operator-review-required"
+      },
+      stepHistory: [
+        {
+          stepId: "human-approval",
+          attempt: 1,
+          status: "blocked",
+          recovery: {
+            state: "blocked",
+            decision: "block-run",
+            reasonExported: false
+          },
+          approval: {
+            state: "rejected",
+            decidedAt: rejectedPackage.approval.decidedAt,
+            inputRef: "fixtures/controlled-pilot/webhook-review-notification.dry-run.json",
+            reasonExported: false,
+            decidedByExported: false
+          }
+        }
+      ]
+    });
+    expect(JSON.stringify(rejectedExport.publicSafe)).not.toContain(
+      "Reject the synthetic notification dry-run for operator review."
+    );
+    expect(JSON.stringify(rejectedExport.publicSafe)).not.toContain("pilot-owner");
   });
 });
 


### PR DESCRIPTION
## Summary
- add public-safe recovery replay details to audit/evidence exports
- reference copied Protocol v0.3.0 operational evidence profile and v0.4.0 Track B boundary snapshots
- cover selected pilot retry-to-success evidence and rejected approval blocked history

## Verification
- npm run build
- npm test -- --run test/controlled-pilot-package.test.ts -t "exports public-safe pilot recovery replay evidence"
- npm test -- --run test/audit-event-writer.test.ts test/controlled-pilot-package.test.ts test/docs-navigation.test.ts
- npm test
- git diff --check

Draft for #125.