### PR TITLE
Emit default controlled pilot evidence ref

### DIFF
--- a/src/audit-evidence-export.ts
+++ b/src/audit-evidence-export.ts
@@ -212,6 +212,7 @@ export interface AuditEvidenceExportLocalReference {
 const EXPORT_SCHEMA_VERSION = "flow.audit-evidence-export.v1";
 const EVIDENCE_REF_SCHEMA_VERSION = "eip.evidence-bundle-ref.v1";
 const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/;
+const EVIDENCE_CLASSIFICATION_NOT_PROVIDED = Symbol("evidenceClassificationNotProvided");
 const ISO_UTC_MILLIS_TIMESTAMP_PATTERN =
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 const EXPORTABLE_APPROVAL_STATES = new Set<AuditEvidenceExportApprovalState>([
@@ -729,6 +730,16 @@ const collectEvidenceRefsFromValue = (
     return;
   }
 
+  const envelopeEvidenceRef = normalizeEvidenceEnvelopeRef(value);
+  if (envelopeEvidenceRef !== undefined) {
+    if (isPublicSafeEvidenceRef(envelopeEvidenceRef)) {
+      refs.push(envelopeEvidenceRef);
+    } else {
+      diagnostics.push(createUnsafeEvidenceRefDiagnostic(envelopeEvidenceRef));
+    }
+    return;
+  }
+
   const evidenceRef = normalizeEvidenceRef(value);
   if (evidenceRef !== undefined) {
     if (isPublicSafeEvidenceRef(evidenceRef)) {
@@ -744,8 +755,24 @@ const collectEvidenceRefsFromValue = (
   }
 };
 
-const normalizeEvidenceRef = (
+const normalizeEvidenceEnvelopeRef = (
   value: Record<string, unknown>
+): NormalizedEvidenceRef | undefined => {
+  if (!isRecord(value.evidenceBundleRef)) {
+    return undefined;
+  }
+
+  return normalizeEvidenceRef(
+    value.evidenceBundleRef,
+    Object.hasOwn(value, "dataClassification")
+      ? value.dataClassification
+      : EVIDENCE_CLASSIFICATION_NOT_PROVIDED
+  );
+};
+
+const normalizeEvidenceRef = (
+  value: Record<string, unknown>,
+  dataClassificationOverride: unknown = EVIDENCE_CLASSIFICATION_NOT_PROVIDED
 ): NormalizedEvidenceRef | undefined => {
   if (value.schemaVersion !== EVIDENCE_REF_SCHEMA_VERSION) {
     return undefined;
@@ -762,8 +789,12 @@ const normalizeEvidenceRef = (
   }
 
   const checksum = normalizeChecksum(value.checksum);
+  const classificationValue =
+    dataClassificationOverride === EVIDENCE_CLASSIFICATION_NOT_PROVIDED
+      ? value.dataClassification
+      : dataClassificationOverride;
   const dataClassification = normalizeDataClassification(
-    value.dataClassification,
+    classificationValue,
     typeof value.id === "string" ? value.id : "<unknown-evidence-ref>"
   );
   return {

--- a/src/audit-evidence-export.ts
+++ b/src/audit-evidence-export.ts
@@ -737,6 +737,12 @@ const collectEvidenceRefsFromValue = (
     } else {
       diagnostics.push(createUnsafeEvidenceRefDiagnostic(envelopeEvidenceRef));
     }
+
+    for (const [key, nestedValue] of Object.entries(value)) {
+      if (key !== "evidenceBundleRef") {
+        collectEvidenceRefsFromValue(nestedValue, refs, diagnostics);
+      }
+    }
     return;
   }
 
@@ -762,12 +768,45 @@ const normalizeEvidenceEnvelopeRef = (
     return undefined;
   }
 
-  return normalizeEvidenceRef(
-    value.evidenceBundleRef,
-    Object.hasOwn(value, "dataClassification")
-      ? value.dataClassification
-      : EVIDENCE_CLASSIFICATION_NOT_PROVIDED
+  return normalizeEvidenceRef(value.evidenceBundleRef, selectEnvelopeEvidenceClassification(value));
+};
+
+const selectEnvelopeEvidenceClassification = (value: Record<string, unknown>): unknown => {
+  const evidenceBundleRef = value.evidenceBundleRef;
+  if (!isRecord(evidenceBundleRef)) {
+    return EVIDENCE_CLASSIFICATION_NOT_PROVIDED;
+  }
+
+  const envelopeClassification = Object.hasOwn(value, "dataClassification")
+    ? value.dataClassification
+    : EVIDENCE_CLASSIFICATION_NOT_PROVIDED;
+  if (!Object.hasOwn(evidenceBundleRef, "dataClassification")) {
+    return envelopeClassification;
+  }
+
+  const evidenceRefId =
+    typeof evidenceBundleRef.id === "string" ? evidenceBundleRef.id : "<unknown-evidence-ref>";
+  const refClassification = normalizeDataClassification(
+    evidenceBundleRef.dataClassification,
+    evidenceRefId
   );
+  const normalizedEnvelopeClassification =
+    envelopeClassification === EVIDENCE_CLASSIFICATION_NOT_PROVIDED
+      ? undefined
+      : normalizeDataClassification(envelopeClassification, evidenceRefId);
+
+  if (refClassification !== undefined && refClassification !== "public") {
+    return refClassification;
+  }
+
+  if (
+    normalizedEnvelopeClassification !== undefined &&
+    normalizedEnvelopeClassification !== "public"
+  ) {
+    return normalizedEnvelopeClassification;
+  }
+
+  return refClassification ?? normalizedEnvelopeClassification;
 };
 
 const normalizeEvidenceRef = (

--- a/src/controlled-pilot-package.ts
+++ b/src/controlled-pilot-package.ts
@@ -32,14 +32,14 @@ const selectedControlledPilotDefaultNotificationOutcome: HttpNotificationOutcome
   status: "succeeded",
   summary: "local fake notification accepted",
   evidence: {
+    dataClassification: "public",
     evidenceBundleRef: {
       schemaVersion: "eip.evidence-bundle-ref.v1",
       id: "evb_controlled_pilot_default_fake_notification",
       correlationId: "corr_controlled_pilot_default_fake_notification",
       type: "local_path",
       uri: "artifacts/evidence/controlled-pilot/default-fake-notification.json",
-      createdAt: "2026-05-30T00:00:00.000Z",
-      dataClassification: "public"
+      createdAt: "2026-05-30T00:00:00.000Z"
     }
   }
 };

--- a/src/controlled-pilot-package.ts
+++ b/src/controlled-pilot-package.ts
@@ -30,19 +30,19 @@ const selectedControlledPilotTransportBoundaryModes = new Set([
 ]);
 const selectedControlledPilotDefaultNotificationOutcome: HttpNotificationOutcome = {
   status: "succeeded",
-  summary: "local fake notification accepted",
-  evidence: {
-    dataClassification: "public",
-    evidenceBundleRef: {
-      schemaVersion: "eip.evidence-bundle-ref.v1",
-      id: "evb_controlled_pilot_default_fake_notification",
-      correlationId: "corr_controlled_pilot_default_fake_notification",
-      type: "local_path",
-      uri: "artifacts/evidence/controlled-pilot/default-fake-notification.json",
-      createdAt: "2026-05-30T00:00:00.000Z"
-    }
-  }
+  summary: "local fake notification accepted"
 };
+const createSelectedControlledPilotDefaultEvidence = (createdAt: string): Record<string, unknown> => ({
+  dataClassification: "public",
+  evidenceBundleRef: {
+    schemaVersion: "eip.evidence-bundle-ref.v1",
+    id: "evb_controlled_pilot_default_fake_notification",
+    correlationId: "corr_controlled_pilot_default_fake_notification",
+    type: "local_path",
+    uri: "artifacts/evidence/controlled-pilot/default-fake-notification.json",
+    createdAt
+  }
+});
 
 export type ControlledPilotInputPackageMode = "dry-run";
 export type ControlledPilotApprovalState = "approved" | "rejected";
@@ -159,6 +159,7 @@ export const runSelectedControlledPilot = async (
     createFakeHttpNotificationTransport({
       outcomes: [selectedControlledPilotDefaultNotificationOutcome]
     });
+  const usesDefaultNotificationTransport = input.notificationTransport === undefined;
   assertSelectedControlledPilotTransportBoundary(notificationTransport);
   const notificationConnector = createHttpNotificationConnector({
     transport: notificationTransport,
@@ -242,6 +243,13 @@ export const runSelectedControlledPilot = async (
         throw new Error(submitted.error.message);
       }
 
+      const evidence = usesDefaultNotificationTransport
+        ? {
+            ...submitted.value.evidence,
+            transport: createSelectedControlledPilotDefaultEvidence(submitted.value.acceptedAt)
+          }
+        : submitted.value.evidence;
+
       return {
         executor: {
           requestId: submitted.value.requestId,
@@ -250,7 +258,7 @@ export const runSelectedControlledPilot = async (
           result: {
             status: "succeeded",
             summary: submitted.value.notification.summary,
-            evidence: submitted.value.evidence
+            evidence
           }
         }
       };

--- a/src/controlled-pilot-package.ts
+++ b/src/controlled-pilot-package.ts
@@ -11,6 +11,7 @@ import {
   createNormalizedWebhookInputFingerprint
 } from "./webhook-intake.js";
 import type {
+  HttpNotificationOutcome,
   HttpNotificationTarget,
   HttpNotificationTransport
 } from "./http-notification-connector.js";
@@ -27,6 +28,21 @@ const selectedControlledPilotTransportBoundaryModes = new Set([
   "local",
   "dry-run"
 ]);
+const selectedControlledPilotDefaultNotificationOutcome: HttpNotificationOutcome = {
+  status: "succeeded",
+  summary: "local fake notification accepted",
+  evidence: {
+    evidenceBundleRef: {
+      schemaVersion: "eip.evidence-bundle-ref.v1",
+      id: "evb_controlled_pilot_default_fake_notification",
+      correlationId: "corr_controlled_pilot_default_fake_notification",
+      type: "local_path",
+      uri: "artifacts/evidence/controlled-pilot/default-fake-notification.json",
+      createdAt: "2026-05-30T00:00:00.000Z",
+      dataClassification: "public"
+    }
+  }
+};
 
 export type ControlledPilotInputPackageMode = "dry-run";
 export type ControlledPilotApprovalState = "approved" | "rejected";
@@ -139,7 +155,10 @@ export const runSelectedControlledPilot = async (
     inputFingerprint
   });
   const notificationTransport =
-    input.notificationTransport ?? createFakeHttpNotificationTransport();
+    input.notificationTransport ??
+    createFakeHttpNotificationTransport({
+      outcomes: [selectedControlledPilotDefaultNotificationOutcome]
+    });
   assertSelectedControlledPilotTransportBoundary(notificationTransport);
   const notificationConnector = createHttpNotificationConnector({
     transport: notificationTransport,

--- a/src/http-notification-connector.ts
+++ b/src/http-notification-connector.ts
@@ -310,7 +310,23 @@ export const createFakeHttpNotificationTransport = (
   const deliveries: HttpNotificationTransportDelivery[] = [];
   const outcomes =
     input.outcomes === undefined || input.outcomes.length === 0
-      ? [{ status: "succeeded" as const, summary: "local fake notification accepted" }]
+      ? [
+          {
+            status: "succeeded" as const,
+            summary: "local fake notification accepted",
+            evidence: {
+              evidenceBundleRef: {
+                schemaVersion: "eip.evidence-bundle-ref.v1",
+                id: "evb_controlled_pilot_default_fake_notification",
+                correlationId: "corr_controlled_pilot_default_fake_notification",
+                type: "local_path",
+                uri: "artifacts/evidence/controlled-pilot/default-fake-notification.json",
+                createdAt: "2026-05-30T00:00:00.000Z",
+                dataClassification: "public"
+              }
+            }
+          }
+        ]
       : input.outcomes;
 
   return {

--- a/src/http-notification-connector.ts
+++ b/src/http-notification-connector.ts
@@ -313,18 +313,7 @@ export const createFakeHttpNotificationTransport = (
       ? [
           {
             status: "succeeded" as const,
-            summary: "local fake notification accepted",
-            evidence: {
-              evidenceBundleRef: {
-                schemaVersion: "eip.evidence-bundle-ref.v1",
-                id: "evb_controlled_pilot_default_fake_notification",
-                correlationId: "corr_controlled_pilot_default_fake_notification",
-                type: "local_path",
-                uri: "artifacts/evidence/controlled-pilot/default-fake-notification.json",
-                createdAt: "2026-05-30T00:00:00.000Z",
-                dataClassification: "public"
-              }
-            }
+            summary: "local fake notification accepted"
           }
         ]
       : input.outcomes;

--- a/test/audit-event-writer.test.ts
+++ b/test/audit-event-writer.test.ts
@@ -585,6 +585,87 @@ describe("neutral audit event writer", () => {
     expect(JSON.stringify(exported.publicSafe)).not.toContain("evb_regulated_export");
   });
 
+  it("continues scanning envelope siblings and respects stricter nested classifications", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
+    tempRoots.push(stateRoot);
+    const statePath = join(stateRoot, "runs", "manual-run.jsonl");
+
+    await createWorkflowRun(statePath, {
+      runId: "local-manual-demo-export",
+      workflowId: "local-manual-demo",
+      workflowVersion: "flow.workflow.v1",
+      trigger: {
+        type: "manual",
+        receivedAt: "2026-04-29T00:00:00.000Z",
+        context: {}
+      },
+      createdAt: "2026-04-29T00:00:01.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.started",
+      runId: "local-manual-demo-export",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:02.000Z"
+    });
+    await appendWorkflowRunEvent(statePath, {
+      type: "step.attempt.completed",
+      runId: "local-manual-demo-export",
+      stepId: "collect-input",
+      attempt: 1,
+      occurredAt: "2026-04-29T00:00:03.000Z",
+      result: {
+        evidence: {
+          transport: {
+            dataClassification: "public",
+            evidenceBundleRef: {
+              schemaVersion: "eip.evidence-bundle-ref.v1",
+              id: "evb_enveloped_public_export",
+              correlationId: "corr_manual_export",
+              type: "local_path",
+              uri: "artifacts/evidence/public/enveloped-bundle.json",
+              createdAt: "2026-04-29T00:00:03.000Z"
+            },
+            additionalRefs: [
+              {
+                schemaVersion: "eip.evidence-bundle-ref.v1",
+                id: "evb_envelope_sibling_export",
+                correlationId: "corr_manual_export",
+                type: "local_path",
+                uri: "artifacts/evidence/public/sibling-bundle.json",
+                createdAt: "2026-04-29T00:00:03.000Z",
+                dataClassification: "public"
+              }
+            ]
+          },
+          stricterNestedRef: {
+            dataClassification: "public",
+            evidenceBundleRef: {
+              schemaVersion: "eip.evidence-bundle-ref.v1",
+              id: "evb_nested_internal_export",
+              correlationId: "corr_manual_export",
+              type: "local_path",
+              uri: "artifacts/evidence/internal/nested-bundle.json",
+              createdAt: "2026-04-29T00:00:03.000Z",
+              dataClassification: "internal"
+            }
+          }
+        }
+      }
+    });
+
+    const exported = await createAuditEvidenceExport({ statePath });
+
+    expect(exported.publicSafe.evidenceRefs.map((ref) => ref.id)).toEqual([
+      "evb_enveloped_public_export",
+      "evb_envelope_sibling_export"
+    ]);
+    expect(exported.publicSafe.diagnostics).toEqual([
+      "omitted an evidence reference because its data classification is not public-safe"
+    ]);
+    expect(JSON.stringify(exported.publicSafe)).not.toContain("evb_nested_internal_export");
+  });
+
   it("rejects unknown evidence data classifications before writing an export artifact", async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));
     const exportRoot = await mkdtemp(join(tmpdir(), "ensen-flow-audit-export-"));

--- a/test/controlled-pilot-package.test.ts
+++ b/test/controlled-pilot-package.test.ts
@@ -171,6 +171,79 @@ describe("selected controlled pilot dry-run package", () => {
     );
   });
 
+  it("exports a public-safe evidence ref from the default CLI fake transport path", async () => {
+    const root = await createTempRoot();
+    const stateRoot = join(root, "runs");
+    const auditPath = join(root, "audit", "pilot.audit.jsonl");
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (message?: unknown): void => {
+      logs.push(String(message));
+    };
+
+    try {
+      await expect(
+        runCli([
+          "run-controlled-pilot",
+          "fixtures/controlled-pilot/webhook-review-notification.dry-run.json",
+          stateRoot,
+          auditPath
+        ])
+      ).resolves.toBe(0);
+    } finally {
+      console.log = originalLog;
+    }
+
+    const output = JSON.parse(logs.join("\n")) as Record<string, unknown>;
+    const runId = output.runId;
+    if (typeof runId !== "string") {
+      throw new Error("CLI output runId must be a string");
+    }
+
+    logs.length = 0;
+    console.log = (message?: unknown): void => {
+      logs.push(String(message));
+    };
+
+    try {
+      await expect(
+        runCli([
+          "export-audit-evidence",
+          join(stateRoot, `${runId}.jsonl`),
+          auditPath
+        ])
+      ).resolves.toBe(0);
+    } finally {
+      console.log = originalLog;
+    }
+
+    const exported = JSON.parse(logs.join("\n")) as {
+      boundary: { notes: string[] };
+      publicSafe: {
+        evidenceRefs: Array<{
+          schemaVersion: string;
+          id: string;
+          type: string;
+          uri: string;
+          dataClassification: string;
+        }>;
+      };
+    };
+    expect(exported.publicSafe.evidenceRefs).toEqual([
+      expect.objectContaining({
+        schemaVersion: "eip.evidence-bundle-ref.v1",
+        id: "evb_controlled_pilot_default_fake_notification",
+        type: "local_path",
+        uri: "artifacts/evidence/controlled-pilot/default-fake-notification.json",
+        dataClassification: "public"
+      })
+    ]);
+    expect(JSON.stringify(exported.publicSafe.evidenceRefs)).not.toContain(root);
+    expect(exported.boundary.notes.join("\n")).toContain(
+      "It is not a production evidence archive, compliance bundle, or customer data export."
+    );
+  });
+
   it("binds approval to the normalized webhook input fingerprint", async () => {
     const inputPackage = createPilotPackage();
     inputPackage.webhook.headers = {

--- a/test/controlled-pilot-package.test.ts
+++ b/test/controlled-pilot-package.test.ts
@@ -176,7 +176,9 @@ describe("selected controlled pilot dry-run package", () => {
                     correlationId: "corr_controlled_pilot_default_fake_notification",
                     type: "local_path",
                     uri: "artifacts/evidence/controlled-pilot/default-fake-notification.json",
-                    createdAt: "2026-05-30T00:00:00.000Z"
+                    createdAt: expect.stringMatching(
+                      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u
+                    )
                   }
                 }
               }
@@ -207,6 +209,50 @@ describe("selected controlled pilot dry-run package", () => {
         })
       ])
     );
+  });
+
+  it("derives the default pilot evidence timestamp from the run clock", async () => {
+    const root = await createTempRoot();
+    const stateRoot = join(root, "runs");
+    const auditPath = join(root, "audit", "pilot.audit.jsonl");
+
+    const result = await runSelectedControlledPilot({
+      inputPackage: createPilotPackage(),
+      stateRoot,
+      auditPath,
+      now: createClock([
+        "2026-05-31T01:00:00.000Z",
+        "2026-05-31T01:00:01.000Z",
+        "2026-05-31T01:00:02.000Z",
+        "2026-05-31T01:00:03.000Z",
+        "2026-05-31T01:00:04.000Z",
+        "2026-05-31T01:00:05.000Z",
+        "2026-05-31T01:00:06.000Z"
+      ])
+    });
+
+    const notifyAttempt = result.stepAttempts["notify-operator"]?.[0]?.result as {
+      executor?: {
+        observedAt?: string;
+        result?: {
+          evidence?: {
+            transport?: {
+              evidenceBundleRef?: {
+                createdAt?: string;
+              };
+            };
+          };
+        };
+      };
+    };
+
+    expect(notifyAttempt.executor?.result?.evidence?.transport?.evidenceBundleRef).toMatchObject({
+      id: "evb_controlled_pilot_default_fake_notification",
+      createdAt: notifyAttempt.executor?.observedAt
+    });
+    expect(
+      notifyAttempt.executor?.result?.evidence?.transport?.evidenceBundleRef?.createdAt
+    ).not.toBe("2026-05-30T00:00:00.000Z");
   });
 
   it("exports a public-safe evidence ref from the default CLI fake transport path", async () => {

--- a/test/controlled-pilot-package.test.ts
+++ b/test/controlled-pilot-package.test.ts
@@ -161,6 +161,44 @@ describe("selected controlled pilot dry-run package", () => {
     }
     const state = await readWorkflowRunState(join(stateRoot, `${runId}.jsonl`));
     expect(state.run.status).toBe("succeeded");
+    expect(state.stepAttempts["notify-operator"]).toMatchObject([
+      {
+        status: "succeeded",
+        result: {
+          executor: {
+            result: {
+              evidence: {
+                transport: {
+                  dataClassification: "public",
+                  evidenceBundleRef: {
+                    schemaVersion: "eip.evidence-bundle-ref.v1",
+                    id: "evb_controlled_pilot_default_fake_notification",
+                    correlationId: "corr_controlled_pilot_default_fake_notification",
+                    type: "local_path",
+                    uri: "artifacts/evidence/controlled-pilot/default-fake-notification.json",
+                    createdAt: "2026-05-30T00:00:00.000Z"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    ]);
+    const defaultEvidenceRef = (
+      state.stepAttempts["notify-operator"]?.[0]?.result as {
+        executor?: {
+          result?: {
+            evidence?: {
+              transport?: {
+                evidenceBundleRef?: Record<string, unknown>;
+              };
+            };
+          };
+        };
+      }
+    ).executor?.result?.evidence?.transport?.evidenceBundleRef;
+    expect(defaultEvidenceRef).not.toHaveProperty("dataClassification");
     await expect(readAuditEvents(auditPath)).resolves.toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/test/http-notification-connector.test.ts
+++ b/test/http-notification-connector.test.ts
@@ -112,6 +112,30 @@ describe("HTTP notification connector skeleton", () => {
     expect(transport.deliveries).toHaveLength(1);
   });
 
+  it("keeps the exported fake transport default evidence neutral", async () => {
+    const transport = createFakeHttpNotificationTransport();
+    const connector = createHttpNotificationConnector({
+      transport,
+      now: () => "2026-05-02T03:00:00.000Z"
+    });
+
+    const submitted = await connector.submit(notifyRequest);
+
+    expect(submitted).toMatchObject({
+      ok: true,
+      value: {
+        evidence: {
+          kind: "http-notification-local",
+          endpointAlias: "local-operator-notification",
+          attempt: 1,
+          idempotencyKey: "notification-demo-run:notify-operator:attempt-1"
+        }
+      }
+    });
+    expect(JSON.stringify(submitted)).not.toContain("controlled-pilot");
+    expect(JSON.stringify(submitted)).not.toContain("eip.evidence-bundle-ref.v1");
+  });
+
   it("rejects unsafe notification artifact values with sanitized diagnostics", async () => {
     const transport = createFakeHttpNotificationTransport();
     const connector = createHttpNotificationConnector({ transport });


### PR DESCRIPTION
## Summary
- add a default public-safe EvidenceBundleRef to the local fake HTTP notification success path
- cover the shipped run-controlled-pilot plus export-audit-evidence CLI pair

## Verification
- npm run build
- npm test -- test/controlled-pilot-package.test.ts
- npm test
- manual node dist/cli.js run-controlled-pilot ... plus node dist/cli.js export-audit-evidence ...

Closes #132