### PR TITLE
Fix revocation runbook supervisor config command

### DIFF
--- a/docs/controlled-pilot-rollback-revocation-runbook.md
+++ b/docs/controlled-pilot-rollback-revocation-runbook.md
@@ -55,7 +55,8 @@ From the companion supervisor checkout, validate issue readiness with an
 operator-provided config path:
 
 ```sh
-CODEX_SUPERVISOR_CONFIG=<supervisor-config-path> node dist/index.js issue-lint <this-issue-number> --config "$CODEX_SUPERVISOR_CONFIG"
+export CODEX_SUPERVISOR_CONFIG=<supervisor-config-path>
+node dist/index.js issue-lint <this-issue-number> --config "$CODEX_SUPERVISOR_CONFIG"
 ```
 
 ## Expected Artifacts

--- a/test/controlled-pilot-rollback-revocation-runbook.test.ts
+++ b/test/controlled-pilot-rollback-revocation-runbook.test.ts
@@ -8,6 +8,8 @@ const docsIndexPath = "docs/README.md";
 const posixHomeRootPattern = new RegExp(["", "Users", "[A-Za-z0-9._-]+"].join("\\/"));
 const linuxHomeRootPattern = new RegExp(["", "home", "[A-Za-z0-9._-]+"].join("\\/"));
 const windowsHomeRootPattern = new RegExp(["[A-Za-z]:", "Users", ""].join("\\\\"));
+const sameLineSupervisorConfigExpansionPattern =
+  /CODEX_SUPERVISOR_CONFIG=[^\n]*"\$CODEX_SUPERVISOR_CONFIG"/;
 
 describe("controlled pilot rollback and revocation runbook", () => {
   it("documents commands, artifacts, classifications, retained evidence, and X-Gate 5 blockers", async () => {
@@ -55,6 +57,7 @@ describe("controlled pilot rollback and revocation runbook", () => {
     expect(runbook).not.toMatch(posixHomeRootPattern);
     expect(runbook).not.toMatch(linuxHomeRootPattern);
     expect(runbook).not.toMatch(windowsHomeRootPattern);
+    expect(runbook).not.toMatch(sameLineSupervisorConfigExpansionPattern);
   });
 
   it("links the runbook from public documentation navigation", async () => {


### PR DESCRIPTION
## Summary
- fix the revocation runbook supervisor issue-lint command to export CODEX_SUPERVISOR_CONFIG before using it
- add focused docs coverage that rejects same-line supervisor config assignment plus expansion

## Tests
- npm test -- test/controlled-pilot-rollback-revocation-runbook.test.ts
- npm run build
- npm test

Closes #134